### PR TITLE
added SoftLayer's config drive disk path

### DIFF
--- a/infrastructure/openstack_metadata_service_provider.go
+++ b/infrastructure/openstack_metadata_service_provider.go
@@ -38,6 +38,7 @@ func (inf openstackServiceProvider) Get() MetadataService {
 		configDriveDiskPaths := []string{
 			"/dev/disk/by-label/CONFIG-2",
 			"/dev/disk/by-label/config-2",
+			"/dev/disk/by-label/METADATA",
 		}
 
 		confDriveMetadataService := NewConfigDriveMetadataService(

--- a/infrastructure/openstack_metadata_service_provider_test.go
+++ b/infrastructure/openstack_metadata_service_provider_test.go
@@ -48,6 +48,7 @@ var _ = Describe("OpenstackMetadataServiceProvider", func() {
 					configDriveDiskPaths := []string{
 						"/dev/disk/by-label/CONFIG-2",
 						"/dev/disk/by-label/config-2",
+						"/dev/disk/by-label/METADATA",
 					}
 
 					configDriveMetadataService := NewConfigDriveMetadataService(


### PR DESCRIPTION
This adds a new path to the `configDriveDiskPaths` which corresponds to SoftLayer's default config drive metadata path.
