### PR TITLE
Start monit after bootstrapping

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -63,12 +63,6 @@ func New(
 }
 
 func (a Agent) Run() error {
-	a.logger.Debug(agentLogTag, "Starting monit")
-	err := a.platform.StartMonit()
-	if err != nil {
-		return bosherr.WrapError(err, "Starting Monit")
-	}
-
 	errCh := make(chan error, 1)
 
 	a.actionDispatcher.ResumePreviouslyDispatchedTasks()
@@ -82,7 +76,7 @@ func (a Agent) Run() error {
 	go a.syslogServer.Start(a.handleSyslogMsg(errCh))
 
 	select {
-	case err = <-errCh:
+	case err := <-errCh:
 		return err
 	}
 }

--- a/platform/linux_platform.go
+++ b/platform/linux_platform.go
@@ -681,7 +681,12 @@ func (p linux) IsPersistentDiskMounted(path string) (bool, error) {
 }
 
 func (p linux) StartMonit() error {
-	_, _, _, err := p.cmdRunner.RunCommand("sv", "up", "monit")
+	err := p.fs.Symlink(filepath.Join("/etc", "sv", "monit"), filepath.Join("/etc", "service", "monit"))
+	if err != nil {
+		return bosherr.WrapError(err, "Symlinking /etc/service/monit to /etc/sv/monit")
+	}
+
+	_, _, _, err = p.cmdRunner.RunCommand("sv", "start", "monit")
 	if err != nil {
 		return bosherr.WrapError(err, "Shelling out to sv")
 	}

--- a/platform/linux_platform_test.go
+++ b/platform/linux_platform_test.go
@@ -1237,11 +1237,18 @@ fake-base-path/data/sys/log/*.log fake-base-path/data/sys/log/*/*.log fake-base-
 	})
 
 	Describe("StartMonit", func() {
-		It("start monit", func() {
+		It("creates a symlink between /etc/service/monit and /etc/sv/monit", func() {
+			err := platform.StartMonit()
+			Expect(err).NotTo(HaveOccurred())
+			target, _ := fs.ReadLink(filepath.Join("/etc", "service", "monit"))
+			Expect(target).To(Equal(filepath.Join("/etc", "sv", "monit")))
+		})
+
+		It("starts monit", func() {
 			err := platform.StartMonit()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(cmdRunner.RunCommands)).To(Equal(1))
-			Expect(cmdRunner.RunCommands[0]).To(Equal([]string{"sv", "up", "monit"}))
+			Expect(cmdRunner.RunCommands[0]).To(Equal([]string{"sv", "start", "monit"}))
 		})
 	})
 


### PR DESCRIPTION
- Create symlink to start monitoring with runit if necessary

See complementary pull request: https://github.com/cloudfoundry/bosh/pull/706
