### PR TITLE
fix unit tests from ./bin/test-unit script

### DIFF
--- a/agent/bootstrap_test.go
+++ b/agent/bootstrap_test.go
@@ -31,11 +31,11 @@ import (
 	boshnet "github.com/cloudfoundry/bosh-agent/platform/net"
 	bosharp "github.com/cloudfoundry/bosh-agent/platform/net/arp"
 	boship "github.com/cloudfoundry/bosh-agent/platform/net/ip"
-	boshstats "github.com/cloudfoundry/bosh-agent/platform/stats"
 	boshudev "github.com/cloudfoundry/bosh-agent/platform/udevdevice"
 	boshvitals "github.com/cloudfoundry/bosh-agent/platform/vitals"
 	boshretry "github.com/cloudfoundry/bosh-agent/retrystrategy"
 	boshdirs "github.com/cloudfoundry/bosh-agent/settings/directories"
+	boshsigar "github.com/cloudfoundry/bosh-agent/sigar"
 )
 
 func init() {
@@ -350,7 +350,7 @@ func init() {
 				compressor := boshcmd.NewTarballCompressor(runner, fs)
 				copier := boshcmd.NewCpCopier(runner, fs, logger)
 
-				sigarCollector := boshstats.NewSigarStatsCollector(&sigar.ConcreteSigar{})
+				sigarCollector := boshsigar.NewSigarStatsCollector(&sigar.ConcreteSigar{})
 
 				vitalsService := boshvitals.NewService(sigarCollector, dirProvider)
 

--- a/sigar/sigar_stats_collector_test.go
+++ b/sigar/sigar_stats_collector_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	. "github.com/cloudfoundry/bosh-agent/platform/stats"
+	. "github.com/cloudfoundry/bosh-agent/sigar"
 	sigar "github.com/cloudfoundry/gosigar"
 	fakesigar "github.com/cloudfoundry/gosigar/fakes"
 )


### PR DESCRIPTION
Hey, all.

This PR is copy of https://github.com/cloudfoundry/bosh-agent/pull/17 without test stuff in Godeps folder.

> This is a PR to fix unit tests. I guess that the problem was extracting bosh sigar into a separate package. This changes make all unit tests from ./bin/test-unit script to be green.

Thank you, 
Alex L.