### PR TITLE
Warn that HttpsHandler Send() method do nothing

### DIFF
--- a/micro/https_handler.go
+++ b/micro/https_handler.go
@@ -16,6 +16,8 @@ import (
 	boshsys "github.com/cloudfoundry/bosh-agent/system"
 )
 
+const httpsHandlerLogTag = "Https Handler"
+
 type HTTPSHandler struct {
 	parsedURL   *url.URL
 	logger      boshlog.Logger
@@ -62,6 +64,7 @@ func (h HTTPSHandler) RegisterAdditionalFunc(handlerFunc boshhandler.Func) {
 }
 
 func (h HTTPSHandler) Send(target boshhandler.Target, topic boshhandler.Topic, message interface{}) error {
+	h.logger.Warn(httpsHandlerLogTag, "HTTPSHandler does not support send")
 	return nil
 }
 


### PR DESCRIPTION
Hi

We had a mistake in our deployment manifest: instead of nats:// schema there was https://, but we wasted a lot of time debugging and reading source until we figured out what actually was the problem. I believe it's useful to warn user if he's trying to send using https handler, that basically do nothing. Probably it's even better to panic, as in RegisterAdditionalFunc function, but I'm not sure about it.
