### PR TITLE
Support specifying a list of unmanaged network interfaces

### DIFF
--- a/agent/bootstrap_test.go
+++ b/agent/bootstrap_test.go
@@ -360,7 +360,7 @@ func init() {
 				arping := bosharp.NewArping(runner, fs, logger, boshplatform.ArpIterations, boshplatform.ArpIterationDelay, boshplatform.ArpInterfaceCheckDelay)
 				interfaceConfigurationCreator := boshnet.NewInterfaceConfigurationCreator(logger)
 
-				ubuntuNetManager := boshnet.NewUbuntuNetManager(fs, runner, ipResolver, interfaceConfigurationCreator, arping, logger)
+				ubuntuNetManager := boshnet.NewUbuntuNetManager(fs, runner, ipResolver, interfaceConfigurationCreator, arping, []string{}, logger)
 
 				ubuntuCertManager := boshcert.NewUbuntuCertManager(fs, runner, logger)
 

--- a/app/config_test.go
+++ b/app/config_test.go
@@ -25,7 +25,11 @@ var _ = Describe("LoadConfigFromPath", func() {
 					"UseDefaultTmpDir": true,
 					"UsePreformattedPersistentDisk": true,
 					"BindMountPersistentDisk": true,
-					"DevicePathResolutionType": "virtio"
+					"DevicePathResolutionType": "virtio",
+					"UnmanagedPhysInterfaces": [
+						"eth1",
+						"eth2"
+					]
 				}
 			},
 			"Infrastructure": {
@@ -70,6 +74,7 @@ var _ = Describe("LoadConfigFromPath", func() {
 					UsePreformattedPersistentDisk: true,
 					BindMountPersistentDisk:       true,
 					DevicePathResolutionType:      "virtio",
+					UnmanagedPhysInterfaces:       []string{"eth1", "eth2"},
 				},
 			},
 			Infrastructure: boshinf.Options{

--- a/platform/linux_platform.go
+++ b/platform/linux_platform.go
@@ -63,6 +63,9 @@ type LinuxOptions struct {
 	// Strategy for resolving device paths;
 	// possible values: virtio, scsi, ''
 	DevicePathResolutionType string
+
+	// List of physical interfaces that shouldn't be managed by the Agent
+	UnmanagedPhysInterfaces []string
 }
 
 type linux struct {

--- a/platform/net/interface_configuration_creator_test.go
+++ b/platform/net/interface_configuration_creator_test.go
@@ -218,7 +218,7 @@ func describeInterfaceConfigurationCreator() {
 			})
 		})
 
-		Context("when the number of networks does not match the number of devices", func() {
+		Context("when the number of networks is greater than the number of devices", func() {
 			BeforeEach(func() {
 				networks["foo"] = staticNetwork
 				networks["bar"] = dhcpNetwork

--- a/platform/net/interface_configuration_creator_test.go
+++ b/platform/net/interface_configuration_creator_test.go
@@ -218,6 +218,23 @@ func describeInterfaceConfigurationCreator() {
 			})
 		})
 
+		Context("when the number of devices is greater than the number of networks", func() {
+			BeforeEach(func() {
+				interfacesByMAC["some-other-mac"] = "dhcp-interface-name"
+			})
+
+			It("additional devices are configured to dhcp", func() {
+				staticInterfaceConfigurations, dhcpInterfaceConfigurations, err := interfaceConfigurationCreator.CreateInterfaceConfigurations(networks, interfacesByMAC)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(staticInterfaceConfigurations).To(BeEmpty())
+				Expect(dhcpInterfaceConfigurations).To(ConsistOf(
+					DHCPInterfaceConfiguration{
+						Name: "dhcp-interface-name",
+					},
+				))
+			})
+		})
+
 		Context("when the number of networks is greater than the number of devices", func() {
 			BeforeEach(func() {
 				networks["foo"] = staticNetwork
@@ -233,6 +250,7 @@ func describeInterfaceConfigurationCreator() {
 				Expect(err).To(HaveOccurred())
 			})
 		})
+
 	})
 
 	It("wraps errors calculating Network and Broadcast addresses", func() {

--- a/platform/net/ubuntu_net_manager_test.go
+++ b/platform/net/ubuntu_net_manager_test.go
@@ -71,6 +71,7 @@ func describeUbuntuNetManager() {
 			ipResolver,
 			interfaceConfigurationCreator,
 			addressBroadcaster,
+			[]string{"fake-eth3"},
 			logger,
 		).(UbuntuNetManager)
 	})
@@ -185,7 +186,7 @@ iface ethstatic inet static
 dns-nameservers 8.8.8.8 9.9.9.9`
 		})
 
-		It("writes interfaces in /etc/network/interfaces in alphabetic order", func() {
+		It("writes managed interfaces in /etc/network/interfaces in alphabetic order", func() {
 			anotherDHCPNetwork := boshsettings.Network{
 				Type:    "dynamic",
 				Default: []string{"dns"},
@@ -197,6 +198,7 @@ dns-nameservers 8.8.8.8 9.9.9.9`
 				"ethstatic": staticNetwork,
 				"ethdhcp1":  dhcpNetwork,
 				"ethdhcp0":  anotherDHCPNetwork,
+				"fake-eth3": {Mac: "gg:hh"},
 			})
 
 			err := netManager.SetupNetworking(boshsettings.Networks{
@@ -595,10 +597,11 @@ iface ethstatic inet static
 				interfacePaths = append(interfacePaths, writeNetworkDevice("fake-eth0", "aa:bb", true))
 				interfacePaths = append(interfacePaths, writeNetworkDevice("fake-eth1", "cc:dd", true))
 				interfacePaths = append(interfacePaths, writeNetworkDevice("fake-eth2", "ee:ff", true))
+				interfacePaths = append(interfacePaths, writeNetworkDevice("fake-eth3", "gg:hh", true))
 				fs.SetGlob("/sys/class/net/*", interfacePaths)
 			})
 
-			It("returns networks that are defined in /etc/network/interfaces", func() {
+			It("returns managed networks that are defined in /etc/network/interfaces", func() {
 				cmdRunner.AddCmdResult("ifup --no-act fake-eth0", fakesys.FakeCmdResult{
 					Stdout:     "",
 					Stderr:     "ifup: interface fake-eth0 already configured",

--- a/platform/provider.go
+++ b/platform/provider.go
@@ -66,8 +66,8 @@ func NewProvider(logger boshlog.Logger, dirProvider boshdirs.Provider, statsColl
 	arping := bosharp.NewArping(runner, fs, logger, ArpIterations, ArpIterationDelay, ArpInterfaceCheckDelay)
 	interfaceConfigurationCreator := boshnet.NewInterfaceConfigurationCreator(logger)
 
-	centosNetManager := boshnet.NewCentosNetManager(fs, runner, ipResolver, interfaceConfigurationCreator, arping, logger)
-	ubuntuNetManager := boshnet.NewUbuntuNetManager(fs, runner, ipResolver, interfaceConfigurationCreator, arping, logger)
+	centosNetManager := boshnet.NewCentosNetManager(fs, runner, ipResolver, interfaceConfigurationCreator, arping, options.Linux.UnmanagedPhysInterfaces, logger)
+	ubuntuNetManager := boshnet.NewUbuntuNetManager(fs, runner, ipResolver, interfaceConfigurationCreator, arping, options.Linux.UnmanagedPhysInterfaces, logger)
 
 	centosCertManager := boshcert.NewCentOSCertManager(fs, runner, logger)
 	ubuntuCertManager := boshcert.NewUbuntuCertManager(fs, runner, logger)


### PR DESCRIPTION
These patches add support for specifying unmanaged NICs (network interfaces that should be ignored by the Agent) and improve some unit tests.
