### PR TITLE
[Power Support] Make a separate script to build bosh-agent on Power platform.

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -13,6 +13,6 @@ then
   exit 1
 fi
 
-$bin/go build $buld_options -o $bin/../out/bosh-agent github.com/cloudfoundry/bosh-agent/main
+$bin/go build -o $bin/../out/bosh-agent github.com/cloudfoundry/bosh-agent/main
 # $bin/go build -o $bin/../out/dav-cli    github.com/cloudfoundry/bosh-utils/davcli/main
 # $bin/go build -o $bin/../out/bosh-bootstrapper github.com/cloudfoundry/bosh-agent/bootstrapper/main

--- a/bin/build
+++ b/bin/build
@@ -13,6 +13,6 @@ then
   exit 1
 fi
 
-$bin/go build -o $bin/../out/bosh-agent github.com/cloudfoundry/bosh-agent/main
+$bin/go build $buld_options -o $bin/../out/bosh-agent github.com/cloudfoundry/bosh-agent/main
 # $bin/go build -o $bin/../out/dav-cli    github.com/cloudfoundry/bosh-utils/davcli/main
 # $bin/go build -o $bin/../out/bosh-bootstrapper github.com/cloudfoundry/bosh-agent/bootstrapper/main

--- a/bin/build-linux-ppc64le
+++ b/bin/build-linux-ppc64le
@@ -7,9 +7,9 @@ bin=$(dirname $0)
 export GOROOT=/usr/local/gccgo
 export PATH=$GOROOT/bin:$PATH
 export LD_LIBRARY_PATH=$GOROOT/lib64
-export buld_options="-compiler gccgo -gccgoflags '-static-libgo'"
+export build_options="-compiler gccgo -gccgoflags '-static-libgo'"
 
 # we need following steps to make gccgo work
 cp -f $GOROOT/lib64/libgo.so.7 /lib/powerpc64le-linux-gnu
 
-$bin/go build -o $bin/../out/bosh-agent github.com/cloudfoundry/bosh-agent/main
+$bin/go build $build_options -o $bin/../out/bosh-agent github.com/cloudfoundry/bosh-agent/main

--- a/bin/build-linux-ppc64le
+++ b/bin/build-linux-ppc64le
@@ -1,0 +1,15 @@
+#!/bin/bash 
+
+set -e
+
+bin=$(dirname $0)
+
+export GOROOT=/usr/local/gccgo
+export PATH=$GOROOT/bin:$PATH
+export LD_LIBRARY_PATH=$GOROOT/lib64
+export buld_options="-compiler gccgo -gccgoflags '-static-libgo'"
+
+# we need following steps to make gccgo work
+cp -f $GOROOT/lib64/libgo.so.7 /lib/powerpc64le-linux-gnu
+
+$bin/go build -o $bin/../out/bosh-agent github.com/cloudfoundry/bosh-agent/main

--- a/bin/env
+++ b/bin/env
@@ -8,11 +8,6 @@ base_gopath=$( cd $base/../../../.. && pwd )
 export GOPATH=$base_gopath GOBIN=$base_gopath/gobin
 export PATH=$PATH:$GOBIN
 
-if [ "`uname -m`" == "ppc64le" ]; then
-  export PATH=/usr/local/gccgo/bin:$PATH
-  export LD_LIBRARY_PATH=/usr/local/gccgo/lib64
-fi
-
 #Travis only has 2 'boosted' cores, recommends 4-6 threads max
 if [ "$TRAVIS" == "true" ]; then
   export GOMAXPROCS=4


### PR DESCRIPTION
Hey, all.

Currently I run bosh-agent on a Power platform and it needs several changes to `bin/build` script. Building bosh-agent with gccgo requires specific environment setup and I am sure that this process should be moved to a separate file. 

Another goal of this PR is to build bosh-agent binary statically, which will allow to use it without having gccgo inside every stemcell.