### PR TITLE
Eliminate “root partition must be the first one”

### DIFF
--- a/platform/disk/root_device_partitioner.go
+++ b/platform/disk/root_device_partitioner.go
@@ -152,6 +152,10 @@ func (p rootDevicePartitioner) getPartitions(devicePath string) (
 	partitionLines := allLines[2 : len(allLines)-1]
 
 	for _, partitionLine := range partitionLines {
+		// ignore PReP partition on ppc64le
+		if strings.Contains(partitionLine, "prep") {
+			continue
+		}
 		partitionInfo := strings.Split(partitionLine, ":")
 		partitionIndex, err := strconv.Atoi(partitionInfo[0])
 		if err != nil {

--- a/platform/disk/root_device_partitioner_test.go
+++ b/platform/disk/root_device_partitioner_test.go
@@ -115,6 +115,98 @@ var _ = Describe("rootDevicePartitioner", func() {
 			})
 		})
 
+		Context("when the desired partitions do not exist and there are 2 existing partitions", func() {
+			BeforeEach(func() {
+				// 20GiB device, ~3GiB partition 0, 18403868671B remaining
+				fakeCmdRunner.AddCmdResult(
+					"parted -m /dev/sda unit B print",
+					fakesys.FakeCmdResult{
+						Stdout: `BYT;
+/dev/sda:21474836480B:virtblk:512:512:msdos:Virtio Block Device;
+1:0:0B:0B:::boot, prep;
+2:32256B:3071000063B:3070967808B:ext4::;
+`,
+					},
+				)
+			})
+
+			It("creates partitions (aligned to 1MiB) using parted", func() {
+				partitions := []Partition{
+					{SizeInBytes: 8589934592}, // swap (8GiB)
+					{SizeInBytes: 8589934592}, // ephemeral (8GiB)
+				}
+
+				// Calculating "aligned" partition start/end/size
+				// (3071000063 + 1) % 1048576 = 769536
+				// (3071000063 + 1) + 1048576 - 769536 = 3071279104 (aligned start)
+				// 3071279104 + 8589934592 - 1 = 11661213695 (desired end)
+				// swap start=3071279104, end=11661213695, size=8589934592
+				// (11661213695 + 1) % 1048576 = 0
+				// (11661213695 + 1) = 11661213696 (aligned start)
+				// 11661213696 + 8589934592 - 1 = 20251148287 (desired end)
+				// 20251148287 > 21474836480 = false (smaller than disk)
+				// swap start=11661213696, end=20251148287, size=8589934592
+
+				err := partitioner.Partition("/dev/sda", partitions)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(len(fakeCmdRunner.RunCommands)).To(Equal(3))
+				Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"parted", "-m", "/dev/sda", "unit", "B", "print"}))
+				Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"parted", "-s", "/dev/sda", "unit", "B", "mkpart", "primary", "3071279104", "11661213695"}))
+				Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"parted", "-s", "/dev/sda", "unit", "B", "mkpart", "primary", "11661213696", "20251148287"}))
+			})
+
+			It("truncates the last partition if it is larger than remaining disk space", func() {
+				partitions := []Partition{
+					{SizeInBytes: 8589934592}, // swap (8GiB)
+					{SizeInBytes: 9813934079}, // ephemeral ("remaining" that exceeds disk size when aligned)
+				}
+
+				// Calculating "aligned" partition start/end/size
+				// (3071000063 + 1) % 1048576 = 769536
+				// (3071000063 + 1) + 1048576 - 769536 = 3071279104 (aligned start)
+				// 3071279104 + 8589934592 - 1 = 11661213695 (desired end)
+				// 11661213695 - 3071279104 + 1 = 8589934592 (final size)
+				// swap start=3071279104, end=11661213695, size=8589934592
+				// (11661213695 + 1) % 1048576 = 0
+				// (11661213695 + 1) = 11661213696 (aligned start)
+				// 11661213696 + 9813934079 - 1 = 21475147774 (desired end)
+				// 21475147774 > 21474836480 = true (bigger than disk)
+				// 21474836480 - 1 = 21474836479 (end of disk)
+				// 21474836479 - 11661213696 + 1 = 9813622784 (final size from aligned start to end of disk)
+				// swap start=11661213696, end=21474836479, size=9813622784
+
+				err := partitioner.Partition("/dev/sda", partitions)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(len(fakeCmdRunner.RunCommands)).To(Equal(3))
+				Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"parted", "-m", "/dev/sda", "unit", "B", "print"}))
+				Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"parted", "-s", "/dev/sda", "unit", "B", "mkpart", "primary", "3071279104", "11661213695"}))
+				Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"parted", "-s", "/dev/sda", "unit", "B", "mkpart", "primary", "11661213696", "21474836479"}))
+			})
+
+			Context("when partitioning fails", func() {
+				BeforeEach(func() {
+					fakeCmdRunner.AddCmdResult(
+						"parted -s /dev/sda unit B mkpart primary 3071279104 11661213695",
+						fakesys.FakeCmdResult{Error: errors.New("fake-parted-error")},
+					)
+				})
+
+				It("returns error", func() {
+					partitions := []Partition{
+						{SizeInBytes: 8589934592}, // swap (8GiB)
+						{SizeInBytes: 9813934079}, // ephemeral (remaining)
+					}
+
+					err := partitioner.Partition("/dev/sda", partitions)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("Partitioning disk `/dev/sda'"))
+					Expect(err.Error()).To(ContainSubstring("fake-parted-error"))
+				})
+			})
+		})
+
 		Context("when getting existing partitions fails", func() {
 			BeforeEach(func() {
 				fakeCmdRunner.AddCmdResult(

--- a/platform/linux_platform.go
+++ b/platform/linux_platform.go
@@ -8,6 +8,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"text/template"
 	"time"
@@ -285,7 +286,7 @@ func (p linux) SetupRootDisk(ephemeralDiskPath string) error {
 		return nil
 	}
 
-	rootDevice, err := p.findRootDevicePath()
+	rootDevice, _, err := p.findRootDevicePath()
 	if err != nil {
 		return bosherr.WrapError(err, "findRootDevicePath")
 	}
@@ -928,11 +929,10 @@ func (p linux) calculateEphemeralDiskPartitionSizes(diskSizeInBytes uint64) (uin
 	return swapSizeInBytes, linuxSizeInBytes, nil
 }
 
-func (p linux) findRootDevicePath() (string, error) {
+func (p linux) findRootDevicePath() (string, uint8, error) {
 	mounts, err := p.diskManager.GetMountsSearcher().SearchMounts()
-
 	if err != nil {
-		return "", bosherr.WrapError(err, "Searching mounts")
+		return "", 0, bosherr.WrapError(err, "Searching mounts")
 	}
 
 	for _, mount := range mounts {
@@ -941,28 +941,29 @@ func (p linux) findRootDevicePath() (string, error) {
 
 			stdout, _, _, err := p.cmdRunner.RunCommand("readlink", "-f", mount.PartitionPath)
 			if err != nil {
-				return "", bosherr.WrapError(err, "Shelling out to readlink")
+				return "", 0, bosherr.WrapError(err, "Shelling out to readlink")
 			}
 			rootPartition := strings.Trim(stdout, "\n")
 			p.logger.Debug(logTag, "Symlink is: `%s'", rootPartition)
 
-			validRootPartition := regexp.MustCompile(`^/dev/[a-z]+1$`)
+			validRootPartition := regexp.MustCompile(`^/dev/[a-z]+\d$`)
 			if !validRootPartition.MatchString(rootPartition) {
-				return "", bosherr.Error("Root partition is not the first partition")
+				return "", 0, bosherr.Error("Root partition has an invalid name" + rootPartition)
 			}
 
-			return strings.Trim(rootPartition, "1"), nil
+			devNum := rootPartition[len(rootPartition)-1] - 48
+			devPath := rootPartition[:len(rootPartition)-1]
+			return devPath, devNum, nil
 		}
 	}
-
-	return "", bosherr.Error("Getting root partition device")
+	return "", 0, bosherr.Error("Getting root partition device")
 }
 
 func (p linux) createEphemeralPartitionsOnRootDevice() (string, string, error) {
 	p.logger.Info(logTag, "Creating swap & ephemeral partitions on root disk...")
 	p.logger.Debug(logTag, "Determining root device")
 
-	rootDevicePath, err := p.findRootDevicePath()
+	rootDevicePath, rootDeviceNum, err := p.findRootDevicePath()
 	if err != nil {
 		return "", "", bosherr.WrapError(err, "Finding root partition device")
 	}
@@ -998,8 +999,8 @@ func (p linux) createEphemeralPartitionsOnRootDevice() (string, string, error) {
 		return "", "", bosherr.WrapErrorf(err, "Partitioning root device `%s'", rootDevicePath)
 	}
 
-	swapPartitionPath := rootDevicePath + "2"
-	dataPartitionPath := rootDevicePath + "3"
+	swapPartitionPath := rootDevicePath + strconv.Itoa(int(rootDeviceNum+1))
+	dataPartitionPath := rootDevicePath + strconv.Itoa(int(rootDeviceNum+2))
 	return swapPartitionPath, dataPartitionPath, nil
 }
 


### PR DESCRIPTION
Function findRootDevicePath in platform/linux_platform.go requires
that root partition must be the first one. It can't be satisfied on
some platforms, for example on POWER (ppc64le).

This fix eliminates this requirement by detecting next available
partition id for /swap and /data instead hardcoded 2 and 3
respectively.

Signed-off-by: Alexander Lomov <alexander.lomov@altoros.com>