### PR TITLE
User can cancel while drain agent action is running

### DIFF
--- a/agent/action/concrete_factory_test.go
+++ b/agent/action/concrete_factory_test.go
@@ -37,6 +37,7 @@ var _ = Describe("concreteFactory", func() {
 		jobScriptProvider boshscript.JobScriptProvider
 		factory           Factory
 		logger            boshlog.Logger
+		cancelCh          chan struct{}
 	)
 
 	BeforeEach(func() {
@@ -51,6 +52,7 @@ var _ = Describe("concreteFactory", func() {
 		specService = fakeas.NewFakeV1Service()
 		jobScriptProvider = &fakescript.FakeJobScriptProvider{}
 		logger = boshlog.NewLogger(boshlog.LevelNone)
+		cancelCh = make(chan struct{}, 1)
 
 		factory = NewFactory(
 			settingsService,
@@ -82,7 +84,8 @@ var _ = Describe("concreteFactory", func() {
 	It("drain", func() {
 		action, err := factory.Create("drain")
 		Expect(err).ToNot(HaveOccurred())
-		Expect(action).To(Equal(NewDrain(notifier, specService, jobScriptProvider, jobSupervisor, logger)))
+		// Cannot do equality check since channel is used in initializer
+		Expect(action).To(BeAssignableToTypeOf(DrainAction{}))
 	})
 
 	It("fetch_logs", func() {

--- a/agent/action/concrete_factory_test.go
+++ b/agent/action/concrete_factory_test.go
@@ -37,7 +37,6 @@ var _ = Describe("concreteFactory", func() {
 		jobScriptProvider boshscript.JobScriptProvider
 		factory           Factory
 		logger            boshlog.Logger
-		cancelCh          chan struct{}
 	)
 
 	BeforeEach(func() {
@@ -52,7 +51,6 @@ var _ = Describe("concreteFactory", func() {
 		specService = fakeas.NewFakeV1Service()
 		jobScriptProvider = &fakescript.FakeJobScriptProvider{}
 		logger = boshlog.NewLogger(boshlog.LevelNone)
-		cancelCh = make(chan struct{}, 1)
 
 		factory = NewFactory(
 			settingsService,

--- a/agent/action/drain.go
+++ b/agent/action/drain.go
@@ -85,10 +85,10 @@ func (a DrainAction) Run(drainType DrainType, newSpecs ...boshas.V1ApplySpec) (i
 
 	script := a.jobScriptProvider.NewParallelScript("drain", scripts)
 
-	resultsChan := make(chan error)
-	go func() { resultsChan <- script.Run() }()
+	resultsCh := make(chan error, 1)
+	go func() { resultsCh <- script.Run() }()
 	select {
-	case result := <-resultsChan:
+	case result := <-resultsCh:
 		a.logger.Debug(a.logTag, "Got a result")
 		return 0, result
 	case <-a.cancelCh:

--- a/agent/action/drain.go
+++ b/agent/action/drain.go
@@ -18,8 +18,9 @@ type DrainAction struct {
 	specService       boshas.V1Service
 	jobSupervisor     boshjobsuper.JobSupervisor
 
-	logTag string
-	logger boshlog.Logger
+	logTag   string
+	logger   boshlog.Logger
+	cancelCh chan struct{}
 }
 
 type DrainType string
@@ -43,8 +44,9 @@ func NewDrain(
 		jobScriptProvider: jobScriptProvider,
 		jobSupervisor:     jobSupervisor,
 
-		logTag: "Drain Action",
-		logger: logger,
+		logTag:   "Drain Action",
+		logger:   logger,
+		cancelCh: make(chan struct{}, 1),
 	}
 }
 
@@ -81,9 +83,18 @@ func (a DrainAction) Run(drainType DrainType, newSpecs ...boshas.V1ApplySpec) (i
 		scripts = append(scripts, script)
 	}
 
-	parallelScript := a.jobScriptProvider.NewParallelScript("drain", scripts)
+	script := a.jobScriptProvider.NewParallelScript("drain", scripts)
 
-	return 0, parallelScript.Run()
+	resultsChan := make(chan error)
+	go func() { resultsChan <- script.Run() }()
+	select {
+	case result := <-resultsChan:
+		a.logger.Debug(a.logTag, "Got a result")
+		return 0, result
+	case <-a.cancelCh:
+		a.logger.Debug(a.logTag, "Got a cancel request")
+		return 0, script.Cancel()
+	}
 }
 
 func (a DrainAction) determineParams(drainType DrainType, currentSpec boshas.V1ApplySpec, newSpecs []boshas.V1ApplySpec) (boshdrain.ScriptParams, error) {
@@ -124,5 +135,10 @@ func (a DrainAction) Resume() (interface{}, error) {
 }
 
 func (a DrainAction) Cancel() error {
-	return errors.New("not supported")
+	a.logger.Debug(a.logTag, "Cancelling drain action")
+	select {
+	case a.cancelCh <- struct{}{}:
+	default:
+	}
+	return nil
 }

--- a/agent/action/drain_test.go
+++ b/agent/action/drain_test.go
@@ -342,7 +342,6 @@ var _ = Describe("DrainAction", func() {
 		)
 
 		BeforeEach(func() {
-
 			parallelScript = &fakescript.FakeCancellableScript{}
 			jobScriptProvider.NewDrainScriptStub = func(jobName string, params boshdrain.ScriptParams) boshscript.CancellableScript {
 				return fakedrain.NewFakeScript("fake-tag")
@@ -350,12 +349,10 @@ var _ = Describe("DrainAction", func() {
 			jobScriptProvider.NewParallelScriptReturns(parallelScript)
 			currentSpec := boshas.V1ApplySpec{}
 			specService.Spec = currentSpec
-
 		})
 
 		Context("when action was not canceled yet", func() {
 			It("cancel action", func() {
-
 				_, err := action.Run(DrainTypeShutdown, newSpec)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -363,7 +360,5 @@ var _ = Describe("DrainAction", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 		})
-
 	})
-
 })

--- a/agent/action/drain_test.go
+++ b/agent/action/drain_test.go
@@ -41,7 +41,7 @@ var _ = Describe("DrainAction", func() {
 	})
 
 	BeforeEach(func() {
-		jobScriptProvider.NewDrainScriptStub = func(jobName string, params boshdrain.ScriptParams) boshscript.Script {
+		jobScriptProvider.NewDrainScriptStub = func(jobName string, params boshdrain.ScriptParams) boshscript.CancellableScript {
 			_, exists := fakeScripts[jobName]
 			if !exists {
 				fakeScript := fakedrain.NewFakeScript(jobName)
@@ -62,11 +62,11 @@ var _ = Describe("DrainAction", func() {
 
 	Describe("Run", func() {
 		var (
-			parallelScript *fakescript.FakeScript
+			parallelScript *fakescript.FakeCancellableScript
 		)
 
 		BeforeEach(func() {
-			parallelScript = &fakescript.FakeScript{}
+			parallelScript = &fakescript.FakeCancellableScript{}
 			jobScriptProvider.NewParallelScriptReturns(parallelScript)
 		})
 
@@ -116,13 +116,13 @@ var _ = Describe("DrainAction", func() {
 
 					Context("when new apply spec is provided", func() {
 						It("runs drain script with update params in parallel", func() {
-							fooScript := &fakescript.FakeScript{}
+							fooScript := &fakescript.FakeCancellableScript{}
 							fooScript.TagReturns("foo")
 
-							barScript := &fakescript.FakeScript{}
+							barScript := &fakescript.FakeCancellableScript{}
 							barScript.TagReturns("bar")
 
-							jobScriptProvider.NewDrainScriptStub = func(jobName string, params boshdrain.ScriptParams) boshscript.Script {
+							jobScriptProvider.NewDrainScriptStub = func(jobName string, params boshdrain.ScriptParams) boshscript.CancellableScript {
 								Expect(params).To(Equal(boshdrain.NewUpdateParams(currentSpec, newSpec)))
 
 								if jobName == "foo" {
@@ -227,13 +227,13 @@ var _ = Describe("DrainAction", func() {
 
 					Context("when job shutdown notification succeeds", func() {
 						It("runs drain script with shutdown params in parallel", func() {
-							fooScript := &fakescript.FakeScript{}
+							fooScript := &fakescript.FakeCancellableScript{}
 							fooScript.TagReturns("foo")
 
-							barScript := &fakescript.FakeScript{}
+							barScript := &fakescript.FakeCancellableScript{}
 							barScript.TagReturns("bar")
 
-							jobScriptProvider.NewDrainScriptStub = func(jobName string, params boshdrain.ScriptParams) boshscript.Script {
+							jobScriptProvider.NewDrainScriptStub = func(jobName string, params boshdrain.ScriptParams) boshscript.CancellableScript {
 								Expect(params).To(Equal(boshdrain.NewShutdownParams(currentSpec, nil)))
 
 								if jobName == "foo" {
@@ -327,4 +327,43 @@ var _ = Describe("DrainAction", func() {
 			})
 		})
 	})
+
+	Describe("Cancel", func() {
+		var (
+			parallelScript *fakescript.FakeCancellableScript
+			newSpec        = boshas.V1ApplySpec{
+				PackageSpecs: map[string]boshas.PackageSpec{
+					"foo": boshas.PackageSpec{
+						Name: "foo",
+						Sha1: "foo-sha1-new",
+					},
+				},
+			}
+		)
+
+		BeforeEach(func() {
+
+			parallelScript = &fakescript.FakeCancellableScript{}
+			jobScriptProvider.NewDrainScriptStub = func(jobName string, params boshdrain.ScriptParams) boshscript.CancellableScript {
+				return fakedrain.NewFakeScript("fake-tag")
+			}
+			jobScriptProvider.NewParallelScriptReturns(parallelScript)
+			currentSpec := boshas.V1ApplySpec{}
+			specService.Spec = currentSpec
+
+		})
+
+		Context("when action was not canceled yet", func() {
+			It("cancel action", func() {
+
+				_, err := action.Run(DrainTypeShutdown, newSpec)
+				Expect(err).ToNot(HaveOccurred())
+
+				err = action.Cancel()
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+	})
+
 })

--- a/agent/action/run_script_test.go
+++ b/agent/action/run_script_test.go
@@ -40,10 +40,10 @@ var _ = Describe("RunScript", func() {
 		act := func() (map[string]string, error) { return action.Run("run-me", map[string]interface{}{}) }
 
 		Context("when current spec can be retrieved", func() {
-			var parallelScript *fakescript.FakeScript
+			var parallelScript *fakescript.FakeCancellableScript
 
 			BeforeEach(func() {
-				parallelScript = &fakescript.FakeScript{}
+				parallelScript = &fakescript.FakeCancellableScript{}
 				fakeJobScriptProvider.NewParallelScriptReturns(parallelScript)
 			})
 

--- a/agent/script/concrete_job_script_provider.go
+++ b/agent/script/concrete_job_script_provider.go
@@ -48,12 +48,12 @@ func (p ConcreteJobScriptProvider) NewScript(jobName string, scriptName string) 
 	return NewScript(p.fs, p.cmdRunner, jobName, path, stdoutLogPath, stderrLogPath)
 }
 
-func (p ConcreteJobScriptProvider) NewDrainScript(jobName string, params boshdrain.ScriptParams) Script {
+func (p ConcreteJobScriptProvider) NewDrainScript(jobName string, params boshdrain.ScriptParams) CancellableScript {
 	path := filepath.Join(p.dirProvider.JobsDir(), jobName, "bin", "drain")
 
 	return boshdrain.NewConcreteScript(p.fs, p.cmdRunner, jobName, path, params, p.timeService)
 }
 
-func (p ConcreteJobScriptProvider) NewParallelScript(scriptName string, scripts []Script) Script {
+func (p ConcreteJobScriptProvider) NewParallelScript(scriptName string, scripts []Script) CancellableScript {
 	return NewParallelScript(scriptName, scripts, p.logger)
 }

--- a/agent/script/concrete_job_script_provider.go
+++ b/agent/script/concrete_job_script_provider.go
@@ -51,7 +51,7 @@ func (p ConcreteJobScriptProvider) NewScript(jobName string, scriptName string) 
 func (p ConcreteJobScriptProvider) NewDrainScript(jobName string, params boshdrain.ScriptParams) CancellableScript {
 	path := filepath.Join(p.dirProvider.JobsDir(), jobName, "bin", "drain")
 
-	return boshdrain.NewConcreteScript(p.fs, p.cmdRunner, jobName, path, params, p.timeService)
+	return boshdrain.NewConcreteScript(p.fs, p.cmdRunner, jobName, path, params, p.timeService, p.logger)
 }
 
 func (p ConcreteJobScriptProvider) NewParallelScript(scriptName string, scripts []Script) CancellableScript {

--- a/agent/script/drain/concrete_script_test.go
+++ b/agent/script/drain/concrete_script_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cloudfoundry/bosh-agent/agent/applier/applyspec"
 	. "github.com/cloudfoundry/bosh-agent/agent/script/drain"
 	"github.com/cloudfoundry/bosh-agent/agent/script/drain/fakes"
+	boshlog "github.com/cloudfoundry/bosh-utils/logger"
 	boshsys "github.com/cloudfoundry/bosh-utils/system"
 	fakesys "github.com/cloudfoundry/bosh-utils/system/fakes"
 )
@@ -33,7 +34,8 @@ var _ = Describe("ConcreteScript", func() {
 	})
 
 	JustBeforeEach(func() {
-		script = NewConcreteScript(fs, runner, "my-tag", "/fake/script", params, fakeClock)
+		logger := boshlog.NewLogger(boshlog.LevelNone)
+		script = NewConcreteScript(fs, runner, "my-tag", "/fake/script", params, fakeClock, logger)
 	})
 
 	Describe("Tag", func() {

--- a/agent/script/drain/fakes/fake_script.go
+++ b/agent/script/drain/fakes/fake_script.go
@@ -13,6 +13,7 @@ type FakeScript struct {
 	DidRun       bool
 	RunError     error
 	RunStub      func() error
+	WasCanceled  bool
 }
 
 func NewFakeScript(tag string) *FakeScript {
@@ -22,6 +23,11 @@ func NewFakeScript(tag string) *FakeScript {
 func (s *FakeScript) Tag() string  { return s.tag }
 func (s *FakeScript) Path() string { return "/fake/path" }
 func (s *FakeScript) Exists() bool { return s.ExistsBool }
+
+func (s *FakeScript) Cancel() error {
+	s.WasCanceled = true
+	return nil
+}
 
 func (s *FakeScript) Run() error {
 	s.DidRun = true

--- a/agent/script/fakes/fake_job_script_provider.go
+++ b/agent/script/fakes/fake_job_script_provider.go
@@ -18,23 +18,23 @@ type FakeJobScriptProvider struct {
 	newScriptReturns struct {
 		result1 script.Script
 	}
-	NewDrainScriptStub        func(jobName string, params boshdrain.ScriptParams) script.Script
+	NewDrainScriptStub        func(jobName string, params boshdrain.ScriptParams) script.CancellableScript
 	newDrainScriptMutex       sync.RWMutex
 	newDrainScriptArgsForCall []struct {
 		jobName string
 		params  boshdrain.ScriptParams
 	}
 	newDrainScriptReturns struct {
-		result1 script.Script
+		result1 script.CancellableScript
 	}
-	NewParallelScriptStub        func(scriptName string, scripts []script.Script) script.Script
+	NewParallelScriptStub        func(scriptName string, scripts []script.Script) script.CancellableScript
 	newParallelScriptMutex       sync.RWMutex
 	newParallelScriptArgsForCall []struct {
 		scriptName string
 		scripts    []script.Script
 	}
 	newParallelScriptReturns struct {
-		result1 script.Script
+		result1 script.CancellableScript
 	}
 }
 
@@ -71,7 +71,7 @@ func (fake *FakeJobScriptProvider) NewScriptReturns(result1 script.Script) {
 	}{result1}
 }
 
-func (fake *FakeJobScriptProvider) NewDrainScript(jobName string, params boshdrain.ScriptParams) script.Script {
+func (fake *FakeJobScriptProvider) NewDrainScript(jobName string, params boshdrain.ScriptParams) script.CancellableScript {
 	fake.newDrainScriptMutex.Lock()
 	fake.newDrainScriptArgsForCall = append(fake.newDrainScriptArgsForCall, struct {
 		jobName string
@@ -97,14 +97,14 @@ func (fake *FakeJobScriptProvider) NewDrainScriptArgsForCall(i int) (string, bos
 	return fake.newDrainScriptArgsForCall[i].jobName, fake.newDrainScriptArgsForCall[i].params
 }
 
-func (fake *FakeJobScriptProvider) NewDrainScriptReturns(result1 script.Script) {
+func (fake *FakeJobScriptProvider) NewDrainScriptReturns(result1 script.CancellableScript) {
 	fake.NewDrainScriptStub = nil
 	fake.newDrainScriptReturns = struct {
-		result1 script.Script
+		result1 script.CancellableScript
 	}{result1}
 }
 
-func (fake *FakeJobScriptProvider) NewParallelScript(scriptName string, scripts []script.Script) script.Script {
+func (fake *FakeJobScriptProvider) NewParallelScript(scriptName string, scripts []script.Script) script.CancellableScript {
 	fake.newParallelScriptMutex.Lock()
 	fake.newParallelScriptArgsForCall = append(fake.newParallelScriptArgsForCall, struct {
 		scriptName string
@@ -130,10 +130,10 @@ func (fake *FakeJobScriptProvider) NewParallelScriptArgsForCall(i int) (string, 
 	return fake.newParallelScriptArgsForCall[i].scriptName, fake.newParallelScriptArgsForCall[i].scripts
 }
 
-func (fake *FakeJobScriptProvider) NewParallelScriptReturns(result1 script.Script) {
+func (fake *FakeJobScriptProvider) NewParallelScriptReturns(result1 script.CancellableScript) {
 	fake.NewParallelScriptStub = nil
 	fake.newParallelScriptReturns = struct {
-		result1 script.Script
+		result1 script.CancellableScript
 	}{result1}
 }
 

--- a/agent/script/fakes/fake_script.go
+++ b/agent/script/fakes/fake_script.go
@@ -130,4 +130,39 @@ func (fake *FakeScript) RunReturns(result1 error) {
 	}{result1}
 }
 
+type FakeCancellableScript struct {
+	FakeScript
+	CancelStub        func() error
+	cancelMutex       sync.RWMutex
+	cancelArgsForCall []struct{}
+	cancelReturns     struct {
+		result1 error
+	}
+}
+
+func (fake *FakeCancellableScript) Cancel() error {
+	fake.cancelMutex.Lock()
+	fake.cancelArgsForCall = append(fake.cancelArgsForCall, struct{}{})
+	fake.cancelMutex.Unlock()
+	if fake.CancelStub != nil {
+		return fake.CancelStub()
+	} else {
+		return fake.cancelReturns.result1
+	}
+}
+
+func (fake *FakeCancellableScript) CancelCallCount() int {
+	fake.cancelMutex.RLock()
+	defer fake.cancelMutex.RUnlock()
+	return len(fake.cancelArgsForCall)
+}
+
+func (fake *FakeCancellableScript) CancelReturns(result1 error) {
+	fake.CancelStub = nil
+	fake.cancelReturns = struct {
+		result1 error
+	}{result1}
+}
+
 var _ script.Script = new(FakeScript)
+var _ script.CancellableScript = new(FakeCancellableScript)

--- a/agent/script/parallel_script.go
+++ b/agent/script/parallel_script.go
@@ -71,10 +71,9 @@ func (s ParallelScript) Cancel() error {
 	existingScripts := s.findExistingScripts(s.allScripts)
 	for _, script := range existingScripts {
 		if script, ok := script.(CancellableScript); ok {
-			s.logger.Debug(s.logTag, "Canceling a script")
 			err := script.Cancel()
 			if err != nil {
-				return bosherr.Errorf("Failed to cancel %s: %s", s.name, err)
+				bosherr.WrapErrorf(err, "'%s' script did not cancel", s.name)
 			}
 		} else {
 			return bosherr.Errorf("Script %s is not cancellable", s.name)

--- a/agent/script/parallel_script.go
+++ b/agent/script/parallel_script.go
@@ -66,6 +66,23 @@ func (s ParallelScript) Run() error {
 	return s.summarizeErrs(passedScripts, failedScripts)
 }
 
+func (s ParallelScript) Cancel() error {
+	s.logger.Debug(s.logTag, "Canceling a parallel script")
+	existingScripts := s.findExistingScripts(s.allScripts)
+	for _, script := range existingScripts {
+		if script, ok := script.(CancellableScript); ok {
+			s.logger.Debug(s.logTag, "Canceling a script")
+			err := script.Cancel()
+			if err != nil {
+				return bosherr.Errorf("Failed to cancel %s: %s", s.name, err)
+			}
+		} else {
+			return bosherr.Errorf("Script %s is not cancellable", s.name)
+		}
+	}
+	return nil
+}
+
 func (s ParallelScript) findExistingScripts(all []Script) []Script {
 	var existing []Script
 

--- a/agent/script/parallel_script_test.go
+++ b/agent/script/parallel_script_test.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	boshscript "github.com/cloudfoundry/bosh-agent/agent/script"
+	fakedrainscript "github.com/cloudfoundry/bosh-agent/agent/script/drain/fakes"
 	fakescript "github.com/cloudfoundry/bosh-agent/agent/script/fakes"
 	boshlog "github.com/cloudfoundry/bosh-utils/logger"
 )
@@ -202,5 +203,74 @@ var _ = Describe("ParallelScript", func() {
 				close(done)
 			})
 		})
+	})
+
+	Describe("Cancel", func() {
+		Context("when there are no scripts", func() {
+			BeforeEach(func() {
+				scripts = []boshscript.Script{}
+			})
+
+			It("succeeds", func() {
+				err := parallelScript.Cancel()
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when script exists and is not cancelable", func() {
+			var existingScript *fakescript.FakeScript
+
+			BeforeEach(func() {
+				existingScript = &fakescript.FakeScript{}
+				existingScript.TagReturns("fake-job-1")
+				existingScript.PathReturns("path/to/script1")
+				existingScript.ExistsReturns(true)
+				scripts = append(scripts, existingScript)
+			})
+
+			It("returns error", func() {
+				existingScript.RunReturns(nil)
+				err := parallelScript.Cancel()
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		Context("when script exists and is cancelable", func() {
+			var existingScript *fakedrainscript.FakeScript
+
+			BeforeEach(func() {
+				existingScript = fakedrainscript.NewFakeScript("fake-tag")
+				scripts = append(scripts, existingScript)
+			})
+
+			It("succeeds", func() {
+				err := parallelScript.Cancel()
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when run cancelable scripts in parallel", func() {
+			var existingScript1 *fakedrainscript.FakeScript
+			var existingScript2 *fakedrainscript.FakeScript
+
+			BeforeEach(func() {
+				existingScript1 = fakedrainscript.NewFakeScript("fake-job1")
+				scripts = append(scripts, existingScript1)
+				existingScript2 = fakedrainscript.NewFakeScript("fake-job2")
+				scripts = append(scripts, existingScript2)
+			})
+
+			It("succeeds", func() {
+				err := parallelScript.Run()
+				Expect(err).ToNot(HaveOccurred())
+				err = parallelScript.Cancel()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(existingScript1.WasCanceled).To(BeTrue())
+				Expect(existingScript2.WasCanceled).To(BeTrue())
+
+			})
+
+		})
+
 	})
 })

--- a/agent/script/parallel_script_test.go
+++ b/agent/script/parallel_script_test.go
@@ -27,6 +27,7 @@ var _ = Describe("ParallelScript", func() {
 	JustBeforeEach(func() {
 		logger := boshlog.NewLogger(boshlog.LevelNone)
 		parallelScript = boshscript.NewParallelScript("run-me", scripts, logger)
+
 	})
 
 	Describe("Tag", func() {

--- a/agent/script/script_interface.go
+++ b/agent/script/script_interface.go
@@ -8,8 +8,8 @@ import (
 
 type JobScriptProvider interface {
 	NewScript(jobName string, scriptName string) Script
-	NewDrainScript(jobName string, params boshdrain.ScriptParams) Script
-	NewParallelScript(scriptName string, scripts []Script) Script
+	NewDrainScript(jobName string, params boshdrain.ScriptParams) CancellableScript
+	NewParallelScript(scriptName string, scripts []Script) CancellableScript
 }
 
 //go:generate counterfeiter . Script
@@ -20,4 +20,9 @@ type Script interface {
 
 	Exists() bool
 	Run() error
+}
+
+type CancellableScript interface {
+	Script
+	Cancel() error
 }

--- a/vendor/github.com/cloudfoundry/bosh-utils/system/fakes/fake_cmd_runner.go
+++ b/vendor/github.com/cloudfoundry/bosh-utils/system/fakes/fake_cmd_runner.go
@@ -109,7 +109,12 @@ func (r *FakeCmdRunner) RunComplexCommandAsync(cmd boshsys.Command) (boshsys.Pro
 		panic(fmt.Sprintf("Failed to find process for %s", fullCmd))
 	}
 
-	return results[0], nil
+	for _, proc := range results {
+		if !proc.Waited {
+			return proc, nil
+		}
+	}
+	panic(fmt.Sprintf("Failed to find available process for %s", fullCmd))
 }
 
 func (r *FakeCmdRunner) RunCommand(cmdName string, args ...string) (string, string, int, error) {


### PR DESCRIPTION
This fix makes drain action cancellable. It also introduces
CancellableScript interface and its implementation for drain and
parallel scripts.

Small change in fake_cmd_runner was made to propely test parallel async
execution of scripts.

[#106642152] (https://www.pivotaltracker.com/story/show/106642152)

Signed-off-by: Yulia Gaponenko <yulia.gaponenko@ru.ibm.com>