### PR TITLE
Allow build with 'develop' Go version

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -6,10 +6,14 @@ bin=$(dirname $0)
 
 goversion=`$bin/go version | awk '{print $3}'`
 
-MINOR=`echo $goversion | cut -f2 -d.`
-if [ $MINOR -lt 5 ]; then
-  echo "Currently using go version $goversion, must be using go1.5.1 or greater"
-  exit 1
+if [ "$goversion" ==  "devel" ]; then
+  echo "Using 'devel' version, make sure it's go1.5.1 or greater"
+else
+  MINOR=`echo $goversion | cut -f2 -d.`
+  if [ $MINOR -lt 5 ]; then
+    echo "Currently using go version $goversion, must be using go1.5.1 or greater"
+    exit 1
+  fi
 fi
 
 $bin/go build -o $bin/../out/bosh-agent github.com/cloudfoundry/bosh-agent/main


### PR DESCRIPTION
On ppc64le platform sometimes we have to run 'develop' version of Go, may be
applicable  to x64 in some cases. We should
not to restrict a user in this case, a warning is enough.

Signed-off-by: Yulia Gaponenko <yulia.gaponenko@ru.ibm.com>