### PR TITLE
Add SkipDiskSetup option to allow disk partitioning to be skipped on linux

### DIFF
--- a/app/config_test.go
+++ b/app/config_test.go
@@ -25,6 +25,7 @@ var _ = Describe("LoadConfigFromPath", func() {
 					"UseDefaultTmpDir": true,
 					"UsePreformattedPersistentDisk": true,
 					"BindMountPersistentDisk": true,
+					"SkipDiskSetup": true,
 					"DevicePathResolutionType": "virtio"
 				}
 			},
@@ -67,6 +68,7 @@ var _ = Describe("LoadConfigFromPath", func() {
 					UseDefaultTmpDir:              true,
 					UsePreformattedPersistentDisk: true,
 					BindMountPersistentDisk:       true,
+					SkipDiskSetup:                 true,
 					DevicePathResolutionType:      "virtio",
 				},
 			},

--- a/platform/linux_platform.go
+++ b/platform/linux_platform.go
@@ -60,6 +60,9 @@ type LinuxOptions struct {
 	// ephemeral disk
 	CreatePartitionIfNoEphemeralDisk bool
 
+	// When set to true the agent will skip both root and ephemeral disk partitioning
+	SkipDiskSetup bool
+
 	// Strategy for resolving device paths;
 	// possible values: virtio, scsi, ''
 	DevicePathResolutionType string
@@ -274,6 +277,10 @@ func (p linux) findEphemeralUsersMatching(reg *regexp.Regexp) (matchingUsers []s
 }
 
 func (p linux) SetupRootDisk(ephemeralDiskPath string) error {
+	if p.options.SkipDiskSetup {
+		return nil
+	}
+
 	//if there is ephemeral disk we can safely autogrow, if not we should not.
 	if (ephemeralDiskPath == "") && (p.options.CreatePartitionIfNoEphemeralDisk == true) {
 		p.logger.Info(logTag, "No Ephemeral Disk provided, Skipping growing of the Root Filesystem")
@@ -461,6 +468,10 @@ func (p linux) SetTimeWithNtpServers(servers []string) (err error) {
 }
 
 func (p linux) SetupEphemeralDiskWithPath(realPath string) error {
+	if p.options.SkipDiskSetup {
+		return nil
+	}
+
 	p.logger.Info(logTag, "Setting up ephemeral disk...")
 	mountPoint := p.dirProvider.DataDir()
 
@@ -535,6 +546,10 @@ func (p linux) SetupEphemeralDiskWithPath(realPath string) error {
 }
 
 func (p linux) SetupRawEphemeralDisks(devices []boshsettings.DiskSettings) (err error) {
+	if p.options.SkipDiskSetup {
+		return nil
+	}
+
 	p.logger.Info(logTag, "Setting up raw ephemeral disks")
 
 	for i, device := range devices {

--- a/platform/linux_platform_test.go
+++ b/platform/linux_platform_test.go
@@ -317,6 +317,19 @@ bosh_foobar:...`
 			})
 		})
 
+		Context("when SkipDiskSetup is true", func() {
+			BeforeEach(func() {
+				options.SkipDiskSetup = true
+				cmdRunner.CommandExistsValue = true
+			})
+
+			It("does nothing", func() {
+				err := platform.SetupRootDisk("/dev/sdb")
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(len(cmdRunner.RunCommands)).To(Equal(0))
+			})
+		})
 	})
 
 	Describe("SetupSSH", func() {
@@ -972,6 +985,21 @@ fake-base-path/data/sys/log/*.log fake-base-path/data/sys/log/*/*.log fake-base-
 				})
 			})
 		})
+
+		Context("when SkipDiskSetup is true", func() {
+			BeforeEach(func() {
+				options.SkipDiskSetup = true
+			})
+
+			It("does nothing", func() {
+				err := platform.SetupEphemeralDiskWithPath("/dev/xvda")
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(partitioner.PartitionCalled).To(BeFalse())
+				Expect(formatter.FormatCalled).To(BeFalse())
+				Expect(mounter.MountCalled).To(BeFalse())
+			})
+		})
 	})
 
 	Describe("SetupRawEphemeralDisks", func() {
@@ -1120,6 +1148,19 @@ Number  Start   End     Size    File system  Name             Flags
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(cmdRunner.RunCommands)).To(Equal(1))
 			Expect(cmdRunner.RunCommands[0]).To(Equal([]string{"parted", "-s", "/dev/xvda", "p"}))
+		})
+
+		Context("when SkipDiskSetup is true", func() {
+			BeforeEach(func() {
+				options.SkipDiskSetup = true
+			})
+
+			It("does nothing", func() {
+				err := platform.SetupRawEphemeralDisks([]boshsettings.DiskSettings{{Path: "/dev/xvdb"}, {Path: "/dev/xvdc"}})
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(len(cmdRunner.RunCommands)).To(Equal(0))
+			})
 		})
 	})
 


### PR DESCRIPTION

+ The Micropcf team needs this option in order to use the an updated bosh-agent with bosh-provisioner and packer-bosh