### PR TITLE
Re-order CipherSuites to avoid http2 error message

### DIFF
--- a/httpsdispatcher/https_dispatcher.go
+++ b/httpsdispatcher/https_dispatcher.go
@@ -27,14 +27,14 @@ func NewHTTPSDispatcher(baseURL *url.URL, logger boshlog.Logger) *HTTPSDispatche
 		// Both 3DES & RC4 ciphers can be exploited
 		// Using Mozilla's "Modern" recommended settings (where they overlap with golang support)
 		CipherSuites: []uint16{
-			tls.TLS_RSA_WITH_AES_128_CBC_SHA,
-			tls.TLS_RSA_WITH_AES_256_CBC_SHA,
-			tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
-			tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
-			tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
-			tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
 			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
 			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+			tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+			tls.TLS_RSA_WITH_AES_256_CBC_SHA,
 		},
 		PreferServerCipherSuites: true,
 	}

--- a/httpsdispatcher/https_dispatcher_test.go
+++ b/httpsdispatcher/https_dispatcher_test.go
@@ -23,8 +23,18 @@ var _ = Describe("HTTPSDispatcher", func() {
 		serverURL, err := url.Parse("https://127.0.0.1:7788")
 		Expect(err).ToNot(HaveOccurred())
 		dispatcher = boshdispatcher.NewHTTPSDispatcher(serverURL, logger)
-		go dispatcher.Start()
-		time.Sleep(1 * time.Second)
+
+		errChan := make(chan error)
+		go func() {
+			errChan <- dispatcher.Start()
+		}()
+
+		select {
+		case err := <-errChan:
+			Expect(err).ToNot(HaveOccurred())
+		case <-time.After(1 * time.Second):
+			// server should now be running, continue
+		}
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
- We received the following error message when running unit tests on OSX
  using Golang 1.6:
  http2: TLSConfig.CipherSuites index 2 contains an HTTP/2-approved
  cipher suite (0xc02f), but it comes after unapproved cipher suites.
  With this configuration, clients that don't support previous, approved
  cipher suites may be given an unapproved one and reject the
  connection.
- Re-ordered the CipherSuites to match the list in Golang source:
  https://github.com/golang/go/blob/dc5a7682f0ec9cc344fcdb61d67b9d37c6ad3cc6/src/crypto/tls/cipher_suites.go#L75-L95

[#116463189](https://www.pivotaltracker.com/story/show/116463189)
Signed-off-by: Lyle Franklin <lfranklin@pivotal.io>