### PR TITLE
Allow HTTP Metadata URLs and virtio device prefixes to be configurable

### DIFF
--- a/infrastructure/devicepathresolver/id_device_path_resolver_test.go
+++ b/infrastructure/devicepathresolver/id_device_path_resolver_test.go
@@ -19,6 +19,7 @@ var _ = Describe("IDDevicePathResolver", func() {
 	var (
 		fs           *fakesys.FakeFileSystem
 		udev         *fakeudev.FakeUdevDevice
+		devicePrefix string
 		diskSettings boshsettings.DiskSettings
 		pathResolver DevicePathResolver
 	)
@@ -26,10 +27,13 @@ var _ = Describe("IDDevicePathResolver", func() {
 	BeforeEach(func() {
 		udev = fakeudev.NewFakeUdevDevice()
 		fs = fakesys.NewFakeFileSystem()
-		pathResolver = NewIDDevicePathResolver(500*time.Millisecond, udev, fs)
 		diskSettings = boshsettings.DiskSettings{
 			ID: "fake-disk-id-include-truncate",
 		}
+	})
+
+	JustBeforeEach(func() {
+		pathResolver = NewIDDevicePathResolver(500*time.Millisecond, devicePrefix, udev, fs)
 	})
 
 	Describe("GetRealDevicePath", func() {
@@ -43,17 +47,37 @@ var _ = Describe("IDDevicePathResolver", func() {
 			BeforeEach(func() {
 				err := fs.MkdirAll("fake-device-path", os.FileMode(0750))
 				Expect(err).ToNot(HaveOccurred())
-
-				err = fs.Symlink("fake-device-path", "/dev/disk/by-id/virtio-fake-disk-id-include")
-				Expect(err).ToNot(HaveOccurred())
 			})
 
-			It("returns the path ", func() {
-				path, timeout, err := pathResolver.GetRealDevicePath(diskSettings)
-				Expect(err).ToNot(HaveOccurred())
+			Context("when using the default device prefix", func() {
+				BeforeEach(func() {
+					err := fs.Symlink("fake-device-path", "/dev/disk/by-id/virtio-fake-disk-id-include")
+					Expect(err).ToNot(HaveOccurred())
+				})
 
-				Expect(path).To(Equal("fake-device-path"))
-				Expect(timeout).To(BeFalse())
+				It("returns the path", func() {
+					path, timeout, err := pathResolver.GetRealDevicePath(diskSettings)
+					Expect(err).ToNot(HaveOccurred())
+
+					Expect(path).To(Equal("fake-device-path"))
+					Expect(timeout).To(BeFalse())
+				})
+			})
+
+			Context("when using a custom device prefix", func() {
+				BeforeEach(func() {
+					devicePrefix = "prefix"
+					err := fs.Symlink("fake-device-path", "/dev/disk/by-id/prefix-fake-disk-id-include")
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				It("returns the path", func() {
+					path, timeout, err := pathResolver.GetRealDevicePath(diskSettings)
+					Expect(err).ToNot(HaveOccurred())
+
+					Expect(path).To(Equal("fake-device-path"))
+					Expect(timeout).To(BeFalse())
+				})
 			})
 		})
 

--- a/infrastructure/settings_source_factory.go
+++ b/infrastructure/settings_source_factory.go
@@ -29,7 +29,11 @@ type SourceOptions interface {
 }
 
 type HTTPSourceOptions struct {
-	URI string
+	URI            string
+	Headers        map[string]string
+	UserDataPath   string
+	InstanceIDPath string
+	SSHKeysPath    string
 }
 
 func (o HTTPSourceOptions) sourceOptionsInterface() {}
@@ -97,7 +101,16 @@ func (f SettingsSourceFactory) buildWithRegistry() (boshsettings.Source, error) 
 
 		switch typedOpts := opts.(type) {
 		case HTTPSourceOptions:
-			metadataService = NewHTTPMetadataService(typedOpts.URI, resolver, f.platform, f.logger)
+			metadataService = NewHTTPMetadataService(
+				typedOpts.URI,
+				typedOpts.Headers,
+				typedOpts.UserDataPath,
+				typedOpts.InstanceIDPath,
+				typedOpts.SSHKeysPath,
+				resolver,
+				f.platform,
+				f.logger,
+			)
 
 		case ConfigDriveSourceOptions:
 			metadataService = NewConfigDriveMetadataService(

--- a/infrastructure/settings_source_factory_test.go
+++ b/infrastructure/settings_source_factory_test.go
@@ -43,7 +43,7 @@ var _ = Describe("SettingsSourceFactory", func() {
 
 					It("returns a settings source that uses HTTP to fetch settings", func() {
 						resolver := NewRegistryEndpointResolver(NewDigDNSResolver(platform.GetRunner(), logger))
-						httpMetadataService := NewHTTPMetadataService("http://fake-url", resolver, platform, logger)
+						httpMetadataService := NewHTTPMetadataService("http://fake-url", nil, "", "", "", resolver, platform, logger)
 						multiSourceMetadataService := NewMultiSourceMetadataService(httpMetadataService)
 						registryProvider := NewRegistryProvider(multiSourceMetadataService, platform, useServerName, platform.GetFs(), logger)
 						httpSettingsSource := NewComplexSettingsSource(multiSourceMetadataService, registryProvider, logger)

--- a/platform/linux_platform.go
+++ b/platform/linux_platform.go
@@ -67,6 +67,9 @@ type LinuxOptions struct {
 	// Strategy for resolving device paths;
 	// possible values: virtio, scsi, ''
 	DevicePathResolutionType string
+
+	// Device prexix when using virtio (defaults to 'virtio')
+	VirtioDevicePrefix string
 }
 
 type linux struct {

--- a/platform/provider.go
+++ b/platform/provider.go
@@ -85,7 +85,7 @@ func NewProvider(logger boshlog.Logger, dirProvider boshdirs.Provider, statsColl
 	switch options.Linux.DevicePathResolutionType {
 	case "virtio":
 		udev := boshudev.NewConcreteUdevDevice(runner, logger)
-		idDevicePathResolver := devicepathresolver.NewIDDevicePathResolver(500*time.Millisecond, udev, fs)
+		idDevicePathResolver := devicepathresolver.NewIDDevicePathResolver(500*time.Millisecond, options.Linux.VirtioDevicePrefix, udev, fs)
 		mappedDevicePathResolver := devicepathresolver.NewMappedDevicePathResolver(500*time.Millisecond, fs)
 		devicePathResolver = devicepathresolver.NewVirtioDevicePathResolver(idDevicePathResolver, mappedDevicePathResolver, logger)
 	case "scsi":


### PR DESCRIPTION
**Warning:** this should be merged at the same time as https://github.com/cloudfoundry/bosh/pull/1189 to avoid breaking AWS and OpenStack stemcell building.

Since the metadata service in Google Compute Engine has different paths than AWS or OpenStack for the instance user data, we need to allow the agent to take in the instance user data path, the instance ID path, and the SSH keys path in agent env HTTP sources.

Also, GCE uses "google" as the virtio device prefix, so we must allow this to be configurable as well.