### PR TITLE
Replace hardcoded device number to value returned by root device finder

### DIFF
--- a/platform/linux_platform.go
+++ b/platform/linux_platform.go
@@ -295,7 +295,7 @@ func (p linux) SetupRootDisk(ephemeralDiskPath string) error {
 		return nil
 	}
 
-	rootDevicePath, _, err := p.findRootDevicePathAndNumber()
+	rootDevicePath, rootDeviceNumber, err := p.findRootDevicePathAndNumber()
 	if err != nil {
 		return bosherr.WrapError(err, "findRootDevicePath")
 	}
@@ -303,7 +303,7 @@ func (p linux) SetupRootDisk(ephemeralDiskPath string) error {
 	stdout, _, _, err := p.cmdRunner.RunCommand(
 		"growpart",
 		rootDevicePath,
-		"1",
+		strconv.Itoa(rootDeviceNumber),
 	)
 
 	if err != nil {
@@ -315,7 +315,7 @@ func (p linux) SetupRootDisk(ephemeralDiskPath string) error {
 	_, _, _, err = p.cmdRunner.RunCommand(
 		"resize2fs",
 		"-f",
-		fmt.Sprintf("%s1", rootDevicePath),
+		fmt.Sprintf("%s%d", rootDevicePath, rootDeviceNumber),
 	)
 
 	if err != nil {


### PR DESCRIPTION
Since for `ppc64le` architecture device number is not `1` by default the code use value returned from root device finder

Signed-off-by: Yulia Gaponenko <yulia.gaponenko@ru.ibm.com>