### PR TITLE
New Settings Source: Instance metadata

### DIFF
--- a/app/config_test.go
+++ b/app/config_test.go
@@ -52,6 +52,12 @@ var _ = Describe("LoadConfigFromPath", func() {
 					  {
 					  	"Type": "CDROM",
 					  	"FileName": "/fake-file-name"
+					  },
+					  {
+						"Type": "InstanceMetadata",
+						"URI": "/fake-uri",
+						"Headers": {"fake": "headers"},
+						"SettingsPath": "/fake-settings-path"
 					  }
 				  ],
 				  "UseServerName": true,
@@ -91,6 +97,11 @@ var _ = Describe("LoadConfigFromPath", func() {
 						},
 						boshinf.CDROMSourceOptions{
 							FileName: "/fake-file-name",
+						},
+						boshinf.InstanceMetadataSourceOptions{
+							URI:          "/fake-uri",
+							Headers:      map[string]string{"fake": "headers"},
+							SettingsPath: "/fake-settings-path",
 						},
 					},
 					UseServerName: true,

--- a/app/config_test.go
+++ b/app/config_test.go
@@ -195,6 +195,23 @@ var _ = Describe("LoadConfigFromPath", func() {
 		Expect(err.Error()).To(ContainSubstring("Unmarshalling source type 'HTTP'"))
 	})
 
+	It("returns errors if failed to decode InstanceMetadata source options", func() {
+		fs.WriteFileString("/fake-config.conf", `{
+			"Infrastructure": {
+			  "Settings": {
+				  "Sources": [{
+				  	"Type": "InstanceMetadata",
+					"URI": 1
+					}]
+				}
+			}
+		}`)
+
+		_, err := LoadConfigFromPath(fs, "/fake-config.conf")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("Unmarshalling source type 'InstanceMetadata'"))
+	})
+
 	It("returns errors if failed to decode ConfigDrive source options", func() {
 		fs.WriteFileString("/fake-config.conf", `{
 			"Infrastructure": {

--- a/infrastructure/instance_metadata_settings_source.go
+++ b/infrastructure/instance_metadata_settings_source.go
@@ -1,0 +1,55 @@
+package infrastructure
+
+import (
+	"encoding/json"
+
+	boshplatform "github.com/cloudfoundry/bosh-agent/platform"
+	boshsettings "github.com/cloudfoundry/bosh-agent/settings"
+	bosherr "github.com/cloudfoundry/bosh-utils/errors"
+	boshlog "github.com/cloudfoundry/bosh-utils/logger"
+)
+
+type InstanceMetadataSettingsSource struct {
+	settingsKey string
+
+	platform boshplatform.Platform
+
+	logTag string
+	logger boshlog.Logger
+}
+
+func NewInstanceMetadataSettingsSource(
+	settingsKey string,
+	platform boshplatform.Platform,
+	logger boshlog.Logger,
+) *InstanceMetadataSettingsSource {
+	return &InstanceMetadataSettingsSource{
+		settingsKey: settingsKey,
+
+		platform: platform,
+
+		logTag: "CDROMSettingsSource",
+		logger: logger,
+	}
+}
+
+func (s InstanceMetadataSettingsSource) PublicSSHKeyForUsername(string) (string, error) {
+	return "", nil
+}
+
+func (s *InstanceMetadataSettingsSource) Settings() (boshsettings.Settings, error) {
+	var settings boshsettings.Settings
+
+	contents, err := s.platform.GetFileContentsFromCDROM(s.settingsFileName)
+	if err != nil {
+		return settings, bosherr.WrapError(err, "Reading files from CDROM")
+	}
+
+	err = json.Unmarshal(contents, &settings)
+	if err != nil {
+		return settings, bosherr.WrapErrorf(
+			err, "Parsing CDROM settings from '%s'", s.settingsFileName)
+	}
+
+	return settings, nil
+}

--- a/infrastructure/instance_metadata_settings_source_test.go
+++ b/infrastructure/instance_metadata_settings_source_test.go
@@ -1,0 +1,86 @@
+package infrastructure_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	fakeplat "github.com/cloudfoundry/bosh-agent/platform/fakes"
+	boshlog "github.com/cloudfoundry/bosh-utils/logger"
+
+	. "github.com/cloudfoundry/bosh-agent/infrastructure"
+)
+
+var _ = Describe("InstanceMetadataSettingsSource", describeInstanceMetadataSettingsSource)
+
+func describeInstanceMetadataSettingsSource() {
+	var (
+		metadataHeaders map[string]string
+		settingsPath    string
+		platform        *fakeplat.FakePlatform
+		logger          boshlog.Logger
+		metadataSource  *InstanceMetadataSettingsSource
+	)
+
+	BeforeEach(func() {
+		metadataHeaders = make(map[string]string)
+		metadataHeaders["key"] = "value"
+		settingsPath = "/computeMetadata/v1/instance/attributes/bosh_settings"
+		platform = fakeplat.NewFakePlatform()
+		logger = boshlog.NewLogger(boshlog.LevelNone)
+		metadataSource = NewInstanceMetadataSettingsSource("http://fake-metadata-host", metadataHeaders, settingsPath, platform, logger)
+	})
+
+	Describe("PublicSSHKeyForUsername", func() {
+		It("returns an empty string", func() {
+			publicKey, err := metadataSource.PublicSSHKeyForUsername("fake-username")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(publicKey).To(Equal(""))
+		})
+	})
+
+	Describe("Settings", func() {
+		var (
+			ts *httptest.Server
+		)
+
+		handlerFunc := func(w http.ResponseWriter, r *http.Request) {
+			defer GinkgoRecover()
+
+			Expect(r.Method).To(Equal("GET"))
+			Expect(r.URL.Path).To(Equal(settingsPath))
+			Expect(r.Header.Get("key")).To(Equal("value"))
+
+			var jsonStr string
+
+			jsonStr = `{"agent_id": "123"}`
+
+			w.Write([]byte(jsonStr))
+		}
+
+		BeforeEach(func() {
+			handler := http.HandlerFunc(handlerFunc)
+			ts = httptest.NewServer(handler)
+			metadataSource = NewInstanceMetadataSettingsSource(ts.URL, metadataHeaders, settingsPath, platform, logger)
+		})
+
+		AfterEach(func() {
+			ts.Close()
+		})
+
+		It("returns settings read from the instance metadata endpoint", func() {
+			settings, err := metadataSource.Settings()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(settings.AgentID).To(Equal("123"))
+		})
+
+		It("returns an error if reading from the instance metadata endpoint fails", func() {
+			metadataSource = NewInstanceMetadataSettingsSource("bad-registry-endpoint", metadataHeaders, settingsPath, platform, logger)
+			_, err := metadataSource.Settings()
+			Expect(err).To(HaveOccurred())
+		})
+
+	})
+}

--- a/infrastructure/metadata_service_interface.go
+++ b/infrastructure/metadata_service_interface.go
@@ -33,3 +33,8 @@ type UserDataContentsType struct {
 	}
 	Networks boshsettings.Networks
 }
+
+type DynamicMetadataService interface {
+	MetadataService
+	GetValueAtPath(string) (string, error)
+}

--- a/infrastructure/settings_source_factory.go
+++ b/infrastructure/settings_source_factory.go
@@ -141,7 +141,6 @@ func (f SettingsSourceFactory) buildWithRegistry() (boshsettings.Source, error) 
 
 		case CDROMSourceOptions:
 			return nil, bosherr.Error("CDROM source is not supported when registry is used")
-		}
 
 		case InstanceMetadataSourceOptions:
 			return nil, bosherr.Error("Instance Metadata source is not supported when registry is used")
@@ -181,6 +180,14 @@ func (f SettingsSourceFactory) buildWithoutRegistry() (boshsettings.Source, erro
 		case CDROMSourceOptions:
 			settingsSource = NewCDROMSettingsSource(
 				typedOpts.FileName,
+				f.platform,
+				f.logger,
+			)
+		case InstanceMetadataSourceOptions:
+			settingsSource = NewInstanceMetadataSettingsSource(
+				typedOpts.URI,
+				typedOpts.Headers,
+				typedOpts.SettingsPath,
 				f.platform,
 				f.logger,
 			)

--- a/infrastructure/settings_source_factory.go
+++ b/infrastructure/settings_source_factory.go
@@ -64,6 +64,14 @@ type CDROMSourceOptions struct {
 
 func (o CDROMSourceOptions) sourceOptionsInterface() {}
 
+type InstanceMetadataSourceOptions struct {
+	URI          string
+	Headers      map[string]string
+	SettingsPath string
+}
+
+func (o InstanceMetadataSourceOptions) sourceOptionsInterface() {}
+
 type SettingsSourceFactory struct {
 	options  SettingsOptions
 	platform boshplat.Platform
@@ -135,6 +143,9 @@ func (f SettingsSourceFactory) buildWithRegistry() (boshsettings.Source, error) 
 			return nil, bosherr.Error("CDROM source is not supported when registry is used")
 		}
 
+		case InstanceMetadataSourceOptions:
+			return nil, bosherr.Error("Instance Metadata source is not supported when registry is used")
+		}
 		metadataServices = append(metadataServices, metadataService)
 	}
 

--- a/infrastructure/settings_source_factory.go
+++ b/infrastructure/settings_source_factory.go
@@ -183,6 +183,7 @@ func (f SettingsSourceFactory) buildWithoutRegistry() (boshsettings.Source, erro
 				f.platform,
 				f.logger,
 			)
+
 		case InstanceMetadataSourceOptions:
 			settingsSource = NewInstanceMetadataSettingsSource(
 				typedOpts.URI,
@@ -215,6 +216,10 @@ func (s *SourceOptionsSlice) UnmarshalJSON(data []byte) error {
 			switch {
 			case optType == "HTTP":
 				var o HTTPSourceOptions
+				err, opts = mapstruc.Decode(m, &o), o
+
+			case optType == "InstanceMetadata":
+				var o InstanceMetadataSourceOptions
 				err, opts = mapstruc.Decode(m, &o), o
 
 			case optType == "ConfigDrive":


### PR DESCRIPTION
This change creates a settings source named `InstanceMetadata` that retrieves and unmarshals BOSH settings from a URI on the instance's metadata store. Google Compute Engine supports mutable instance metadata and this will be used in conjunction with the [Google CPI](https://github.com/cloudfoundry-incubator/bosh-google-cpi-release/tree/metadata-registry) to eliminate the registry when using Google Cloud Platform.