### PR TITLE
More descriptive error when /etc/resolv.conf content doesn't match

### DIFF
--- a/platform/net/dns_validator.go
+++ b/platform/net/dns_validator.go
@@ -37,5 +37,5 @@ func (d *dnsValidator) Validate(dnsServers []string) error {
 		}
 	}
 
-	return bosherr.WrapError(err, "No specified dns servers found in /etc/resolv.conf")
+	return bosherr.WrapError(err, "None of the DNS servers that were specified in the manifest were found in /etc/resolv.conf.")
 }

--- a/platform/net/dns_validator_test.go
+++ b/platform/net/dns_validator_test.go
@@ -41,15 +41,15 @@ var _ = Describe("DNSValidator", func() {
 		})
 	})
 
-	Context("when /etc/resolv.conf does not contain specififed dns servers", func() {
+	Context("when /etc/resolv.conf does not contain any of the dns servers specified in the manifest", func() {
 		BeforeEach(func() {
-			fs.WriteFileString("/etc/resolv.conf", ``)
+			fs.WriteFileString("/etc/resolv.conf", `nameserver 6.6.6.6`)
 		})
 
 		It("returns error", func() {
 			err := dnsValidator.Validate([]string{"8.8.8.8", "9.9.9.9"})
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("No specified dns servers found in /etc/resolv.conf"))
+			Expect(err.Error()).To(ContainSubstring("None of the DNS servers that were specified in the manifest were found in /etc/resolv.conf."))
 		})
 	})
 })


### PR DESCRIPTION
This might happen when the DNS servers in the manifest for some reason didn't make it to `/etc/resolv.conf`