### PR TITLE
Add scsi lun device path resolver

### DIFF
--- a/agent/action/unmount_disk_test.go
+++ b/agent/action/unmount_disk_test.go
@@ -28,8 +28,10 @@ var _ = Describe("UnmountDiskAction", func() {
 				Disks: boshsettings.Disks{
 					Persistent: map[string]interface{}{
 						"vol-123": map[string]interface{}{
-							"volume_id": "2",
-							"path":      "/dev/sdf",
+							"volume_id":      "2",
+							"path":           "/dev/sdf",
+							"lun":            "0",
+							"host_device_id": "fake-host-device-id",
 						},
 					},
 				},
@@ -45,6 +47,8 @@ var _ = Describe("UnmountDiskAction", func() {
 			VolumeID:       "2",
 			Path:           "/dev/sdf",
 			FileSystemType: "ext4",
+			Lun:            "0",
+			HostDeviceID:   "fake-host-device-id",
 		}
 	})
 
@@ -61,7 +65,7 @@ var _ = Describe("UnmountDiskAction", func() {
 
 		result, err := action.Run("vol-123")
 		Expect(err).ToNot(HaveOccurred())
-		boshassert.MatchesJSONString(GinkgoT(), result, `{"message":"Unmounted partition of {ID:vol-123 DeviceID: VolumeID:2 Path:/dev/sdf FileSystemType:ext4}"}`)
+		boshassert.MatchesJSONString(GinkgoT(), result, `{"message":"Unmounted partition of {ID:vol-123 DeviceID: VolumeID:2 Lun:0 HostDeviceID:fake-host-device-id Path:/dev/sdf FileSystemType:ext4}"}`)
 
 		Expect(platform.UnmountPersistentDiskSettings).To(Equal(expectedDiskSettings))
 	})
@@ -71,7 +75,7 @@ var _ = Describe("UnmountDiskAction", func() {
 
 		result, err := action.Run("vol-123")
 		Expect(err).ToNot(HaveOccurred())
-		boshassert.MatchesJSONString(GinkgoT(), result, `{"message":"Partition of {ID:vol-123 DeviceID: VolumeID:2 Path:/dev/sdf FileSystemType:ext4} is not mounted"}`)
+		boshassert.MatchesJSONString(GinkgoT(), result, `{"message":"Partition of {ID:vol-123 DeviceID: VolumeID:2 Lun:0 HostDeviceID:fake-host-device-id Path:/dev/sdf FileSystemType:ext4} is not mounted"}`)
 
 		Expect(platform.UnmountPersistentDiskSettings).To(Equal(expectedDiskSettings))
 	})

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -153,7 +153,7 @@ func init() {
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(app.GetPlatform().GetDevicePathResolver()).To(
-					BeAssignableToTypeOf(devicepathresolver.NewScsiDevicePathResolver(nil, nil)))
+					BeAssignableToTypeOf(devicepathresolver.NewScsiDevicePathResolver(nil, nil, nil)))
 			})
 		})
 

--- a/infrastructure/devicepathresolver/scsi_device_path_resolver.go
+++ b/infrastructure/devicepathresolver/scsi_device_path_resolver.go
@@ -8,15 +8,18 @@ import (
 type scsiDevicePathResolver struct {
 	scsiVolumeIDPathResolver DevicePathResolver
 	scsiIDPathResolver       DevicePathResolver
+	scsiLunPathResolver      DevicePathResolver
 }
 
 func NewScsiDevicePathResolver(
 	scsiVolumeIDPathResolver DevicePathResolver,
 	scsiIDPathResolver DevicePathResolver,
+	scsiLunPathResolver DevicePathResolver,
 ) DevicePathResolver {
 	return scsiDevicePathResolver{
 		scsiVolumeIDPathResolver: scsiVolumeIDPathResolver,
 		scsiIDPathResolver:       scsiIDPathResolver,
+		scsiLunPathResolver:      scsiLunPathResolver,
 	}
 }
 
@@ -29,5 +32,9 @@ func (sr scsiDevicePathResolver) GetRealDevicePath(diskSettings boshsettings.Dis
 		return sr.scsiVolumeIDPathResolver.GetRealDevicePath(diskSettings)
 	}
 
-	return "", false, bosherr.Error("Neither ID nor VolumeID provided in disk settings")
+	if len(diskSettings.Lun) > 0 && len(diskSettings.HostDeviceID) > 0 {
+		return sr.scsiLunPathResolver.GetRealDevicePath(diskSettings)
+	}
+
+	return "", false, bosherr.Error("Neither ID, VolumeID nor (Lun, HostDeviceID) provided in disk settings")
 }

--- a/infrastructure/devicepathresolver/scsi_device_path_resolver_test.go
+++ b/infrastructure/devicepathresolver/scsi_device_path_resolver_test.go
@@ -15,6 +15,7 @@ var _ = Describe("scsiDevicePathResolver", func() {
 		scsiDevicePathResolver         DevicePathResolver
 		scsiIDDevicePathResolver       *fakedpresolv.FakeDevicePathResolver
 		scsiVolumeIDDevicePathResolver *fakedpresolv.FakeDevicePathResolver
+		scsiLunDevicePathResolver      *fakedpresolv.FakeDevicePathResolver
 
 		diskSettings boshsettings.DiskSettings
 	)
@@ -22,7 +23,8 @@ var _ = Describe("scsiDevicePathResolver", func() {
 	BeforeEach(func() {
 		scsiIDDevicePathResolver = fakedpresolv.NewFakeDevicePathResolver()
 		scsiVolumeIDDevicePathResolver = fakedpresolv.NewFakeDevicePathResolver()
-		scsiDevicePathResolver = NewScsiDevicePathResolver(scsiVolumeIDDevicePathResolver, scsiIDDevicePathResolver)
+		scsiLunDevicePathResolver = fakedpresolv.NewFakeDevicePathResolver()
+		scsiDevicePathResolver = NewScsiDevicePathResolver(scsiVolumeIDDevicePathResolver, scsiIDDevicePathResolver, scsiLunDevicePathResolver)
 	})
 
 	Describe("GetRealDevicePath", func() {
@@ -62,7 +64,43 @@ var _ = Describe("scsiDevicePathResolver", func() {
 			})
 		})
 
-		Context("when diskSettings does not provides id nor volume_id", func() {
+		Context("when diskSettings does not provides id nor volume_id but lun", func() {
+			Context("When both lun and scsi_host_id are provided", func() {
+				BeforeEach(func() {
+					diskSettings = boshsettings.DiskSettings{
+						Lun: "fake-lun-id",
+						HostDeviceID: "fake-host-device-id",
+					}
+				})
+
+				It("returns the path using SCSILunDevicePathResolver", func() {
+					scsiLunDevicePathResolver.RealDevicePath = "fake-lun-resolved-device-path"
+					realPath, timeout, err := scsiDevicePathResolver.GetRealDevicePath(diskSettings)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(timeout).To(BeFalse())
+					Expect(realPath).To(Equal("fake-lun-resolved-device-path"))
+
+					Expect(scsiLunDevicePathResolver.GetRealDevicePathDiskSettings).To(Equal(diskSettings))
+				})
+			})
+
+			Context("When scsi_host_id is not provided", func() {
+				BeforeEach(func() {
+					diskSettings = boshsettings.DiskSettings{
+						Lun: "fake-lun-id",
+					}
+				})
+
+				It("returns an error", func() {
+					realPath, timeout, err := scsiDevicePathResolver.GetRealDevicePath(diskSettings)
+					Expect(err).To(HaveOccurred())
+					Expect(timeout).To(BeFalse())
+					Expect(realPath).To(Equal(""))
+				})
+			})
+		})
+
+		Context("when diskSettings does not provides id, volume_id nor (lun, scsi_host_id)", func() {
 			BeforeEach(func() {
 				diskSettings = boshsettings.DiskSettings{}
 			})

--- a/infrastructure/devicepathresolver/scsi_lun_device_path_resolver.go
+++ b/infrastructure/devicepathresolver/scsi_lun_device_path_resolver.go
@@ -1,0 +1,121 @@
+package devicepathresolver
+
+import (
+	"fmt"
+	"path"
+	"time"
+	"strings"
+
+	boshsettings "github.com/cloudfoundry/bosh-agent/settings"
+	boshsys "github.com/cloudfoundry/bosh-utils/system"
+	boshlog "github.com/cloudfoundry/bosh-utils/logger"
+	bosherr "github.com/cloudfoundry/bosh-utils/errors"
+)
+
+type SCSILunDevicePathResolver struct {
+	diskWaitTimeout time.Duration
+	fs              boshsys.FileSystem
+
+	logTag string
+	logger boshlog.Logger
+}
+
+func NewSCSILunDevicePathResolver(
+	diskWaitTimeout time.Duration,
+	fs boshsys.FileSystem,
+	logger boshlog.Logger,
+) SCSILunDevicePathResolver {
+	return SCSILunDevicePathResolver{
+		fs:              fs,
+		diskWaitTimeout: diskWaitTimeout,
+
+		logTag: "scsiLunResolver",
+		logger: logger,
+	}
+}
+
+func (ldpr SCSILunDevicePathResolver) GetRealDevicePath(diskSettings boshsettings.DiskSettings) (string, bool, error) {
+	if diskSettings.Lun == "" {
+		return "", false, bosherr.Error("Disk lun is not set")
+	}
+	if diskSettings.HostDeviceID == "" {
+		return "", false, bosherr.Error("Disk host_device_id is not set")
+	}
+
+	hostPaths, err := ldpr.fs.Glob("/sys/class/scsi_host/host*/scan")
+	if err != nil {
+		return "", false, bosherr.WrapError(err, "Could not list SCSI hosts")
+	}
+
+	for _, hostPath := range hostPaths {
+		ldpr.logger.Info(ldpr.logTag, "Performing SCSI rescan of %s", hostPath)
+		err = ldpr.fs.WriteFileString(hostPath, "- - -")
+		if err != nil {
+			return "", false, bosherr.WrapError(err, "Starting SCSI rescan")
+		}
+	}
+
+	stopAfter := time.Now().Add(ldpr.diskWaitTimeout)
+
+	var vmBusDeviceForDataDisks string
+
+	vmBusDevices, err := ldpr.fs.Glob("/sys/bus/vmbus/devices/*/device_id")
+	if err != nil {
+		return "", false, bosherr.WrapError(err, "Could not list vmbus devices")
+	}
+
+	for _, vmBusDevice := range vmBusDevices {
+		deviceID, err := ldpr.fs.ReadFileString(vmBusDevice)
+		if err != nil {
+			continue
+		}
+		if strings.Compare(strings.TrimSpace(deviceID), diskSettings.HostDeviceID) == 0 {
+			vmBusDeviceSplits := strings.Split(vmBusDevice, "/")
+			vmBusDeviceForDataDisks = vmBusDeviceSplits[5]
+			break
+		}
+	}
+
+	if vmBusDeviceForDataDisks == "" {
+		return "", false, bosherr.WrapErrorf(err, "Cannot find the vmbus device by host_device_id '%s'", diskSettings.HostDeviceID)
+	}
+	ldpr.logger.Debug(ldpr.logTag, "Find the vmbus device '%s' by host_device_id '%s'", vmBusDeviceForDataDisks, diskSettings.HostDeviceID)
+
+	deviceGlobPath := fmt.Sprintf("/sys/bus/scsi/devices/*:*:*:%s/block/*", diskSettings.Lun)
+	found := false
+	var realPath string
+	
+	for !found {
+		ldpr.logger.Debug(ldpr.logTag, "Waiting for device to appear")
+
+		if time.Now().After(stopAfter) {
+			return "", true, bosherr.Errorf("Timed out getting real device path by lun '%s' and host_device_id '%s'", diskSettings.Lun, diskSettings.HostDeviceID)
+		}
+
+		time.Sleep(100 * time.Millisecond)
+
+		devicePaths, err := ldpr.fs.Glob(deviceGlobPath)
+		if err != nil {
+			return "", false, bosherr.WrapErrorf(err, "Could not list disks by lun '%s'", diskSettings.Lun)
+		}
+
+		for _, devicePath := range devicePaths {
+			basename := path.Base(devicePath)
+			tempPath, err := ldpr.fs.ReadLink(path.Join("/sys/class/block/", basename))
+			if err != nil {
+				continue
+			}
+
+			if strings.Contains(tempPath, "/" + vmBusDeviceForDataDisks + "/") {
+				realPath = path.Join("/dev/", basename)
+				if ldpr.fs.FileExists(realPath) {
+					ldpr.logger.Debug(ldpr.logTag, "Found real path " + realPath)
+					found = true
+					break
+				}
+			}
+		}
+	}
+
+	return realPath, false, nil
+}

--- a/infrastructure/devicepathresolver/scsi_lun_device_path_resolver_test.go
+++ b/infrastructure/devicepathresolver/scsi_lun_device_path_resolver_test.go
@@ -1,0 +1,223 @@
+package devicepathresolver_test
+
+import (
+	"os"
+	"time"
+
+	boshsettings "github.com/cloudfoundry/bosh-agent/settings"
+	boshlog "github.com/cloudfoundry/bosh-utils/logger"
+	fakesys "github.com/cloudfoundry/bosh-utils/system/fakes"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/cloudfoundry/bosh-agent/infrastructure/devicepathresolver"
+)
+
+var _ = Describe("SCSILunDevicePathResolver", func() {
+	var (
+		fs           *fakesys.FakeFileSystem
+		diskSettings boshsettings.DiskSettings
+		pathResolver DevicePathResolver
+		hosts        []string
+	)
+
+	BeforeEach(func() {
+		lun := "0"
+		fs = fakesys.NewFakeFileSystem()
+		pathResolver = NewSCSILunDevicePathResolver(500*time.Millisecond, fs, boshlog.NewLogger(boshlog.LevelNone))
+		diskSettings = boshsettings.DiskSettings{
+			Lun:     lun,
+			HostDeviceID: "fake-host-device-id",
+		}
+
+		hosts = []string{
+			"/sys/class/scsi_host/host0/scan",
+			"/sys/class/scsi_host/host1/scan",
+			"/sys/class/scsi_host/host2/scan",
+			"/sys/class/scsi_host/host3/scan",
+			"/sys/class/scsi_host/host4/scan",
+			"/sys/class/scsi_host/host5/scan",
+		}
+		fs.SetGlob("/sys/class/scsi_host/host*/scan", hosts)
+		fs.SetGlob("/sys/bus/scsi/devices/*:*:*:" + lun + "/block/*", []string{
+			"/sys/bus/scsi/devices/2:0:0:0/block/sda",
+			"/sys/bus/scsi/devices/3:0:1:0/block/sdb",
+			"/sys/bus/scsi/devices/5:0:0:" + lun + "/block/sdc",
+		})
+		fs.SetGlob("/sys/bus/vmbus/devices/*/device_id", []string{
+			"/sys/bus/vmbus/devices/fake-vmbus-device/device_id",
+			"/sys/bus/vmbus/devices/vmbus_0_12/device_id",
+			"/sys/bus/vmbus/devices/vmbus_12/device_id",
+		})
+	})
+
+	Describe("GetRealDevicePath", func() {
+		Context("when path exists", func() {
+			BeforeEach(func() {
+				deviceIDPath := "/sys/bus/vmbus/devices/fake-vmbus-device/device_id"
+				err := fs.WriteFileString(deviceIDPath, "fake-host-device-id")
+				Expect(err).ToNot(HaveOccurred())
+
+				err = fs.MkdirAll("fake-root/fake-vmbus-device/fake-base", os.FileMode(0750))
+				Expect(err).ToNot(HaveOccurred())
+
+				err = fs.Symlink("fake-root/fake-vmbus-device/fake-base", "/sys/class/block/sdc")
+				Expect(err).ToNot(HaveOccurred())
+
+				err = fs.MkdirAll("/dev/sdc", os.FileMode(0750))
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("returns the real path", func() {
+				path, timeout, err := pathResolver.GetRealDevicePath(diskSettings)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(path).To(Equal("/dev/sdc"))
+				Expect(timeout).To(BeFalse())
+
+				for _, host := range hosts {
+					str, _ := fs.ReadFileString(host)
+					Expect(str).To(Equal("- - -"))
+				}
+			})
+		})
+
+		Context("when the given host device id cannot be found", func() {
+			BeforeEach(func() {
+				deviceIDPath := "/sys/bus/vmbus/devices/fake-vmbus-device/device_id"
+				err := fs.WriteFileString(deviceIDPath, "fake-wrong-host-device-id")
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("returns an error", func() {
+				_, _, err := pathResolver.GetRealDevicePath(diskSettings)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		Context("when symlink does not exist", func() {
+			It("returns an error", func() {
+				deviceIDPath := "/sys/bus/vmbus/devices/fake-vmbus-device/device_id"
+				err := fs.WriteFileString(deviceIDPath, "fake-host-device-id")
+				Expect(err).ToNot(HaveOccurred())
+
+				_, _, err = pathResolver.GetRealDevicePath(diskSettings)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		Context("when path does not exist", func() {
+			BeforeEach(func() {
+				deviceIDPath := "/sys/bus/vmbus/devices/fake-vmbus-device/device_id"
+				err := fs.WriteFileString(deviceIDPath, "fake-host-device-id")
+				Expect(err).ToNot(HaveOccurred())
+
+				err = fs.Symlink("fake-root/fake-vmbus-device/fake-base", "/sys/class/block/sdc")
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("returns an error", func() {
+				_, _, err := pathResolver.GetRealDevicePath(diskSettings)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		Context("when the disk path does not exist", func() {
+			BeforeEach(func() {
+				deviceIDPath := "/sys/bus/vmbus/devices/fake-vmbus-device/device_id"
+				err := fs.WriteFileString(deviceIDPath, "fake-host-device-id")
+				Expect(err).ToNot(HaveOccurred())
+
+				err = fs.MkdirAll("fake-root/fake-vmbus-device/fake-base", os.FileMode(0750))
+				Expect(err).ToNot(HaveOccurred())
+
+				err = fs.Symlink("fake-root/fake-vmbus-device/fake-base", "/sys/class/block/sdc")
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("returns an error", func() {
+				_, _, err := pathResolver.GetRealDevicePath(diskSettings)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		Context("when no matching device is found the first time", func() {
+			Context("when the timeout has not expired", func() {
+				BeforeEach(func() {
+					deviceIDPath := "/sys/bus/vmbus/devices/fake-vmbus-device/device_id"
+					err := fs.WriteFileString(deviceIDPath, "fake-host-device-id")
+					Expect(err).ToNot(HaveOccurred())
+
+					time.AfterFunc(100*time.Millisecond, func() {
+						err := fs.MkdirAll("fake-root/fake-vmbus-device/fake-base", os.FileMode(0750))
+						Expect(err).ToNot(HaveOccurred())
+
+						err = fs.Symlink("fake-root/fake-vmbus-device/fake-base", "/sys/class/block/sdc")
+						Expect(err).ToNot(HaveOccurred())
+
+						err = fs.MkdirAll("/dev/sdc", os.FileMode(0750))
+						Expect(err).ToNot(HaveOccurred())
+					})
+				})
+
+				It("returns the real path", func() {
+					path, timeout, err := pathResolver.GetRealDevicePath(diskSettings)
+					Expect(err).ToNot(HaveOccurred())
+
+					Expect(path).To(Equal("/dev/sdc"))
+					Expect(timeout).To(BeFalse())
+				})
+			})
+
+			Context("when the timeout has expired", func() {
+				BeforeEach(func() {
+					deviceIDPath := "/sys/bus/vmbus/devices/fake-vmbus-device/device_id"
+					err := fs.WriteFileString(deviceIDPath, "fake-host-device-id")
+					Expect(err).ToNot(HaveOccurred())
+
+					fs.SetGlob("/sys/bus/scsi/devices/*:*:*:7/block/*", []string{})
+				})
+
+				It("returns an error", func() {
+					path, timeout, err := pathResolver.GetRealDevicePath(boshsettings.DiskSettings{
+						Lun:     "7",
+						HostDeviceID: "fake-host-device-id",
+					})
+					Expect(err).To(HaveOccurred())
+
+					Expect(path).To(Equal(""))
+					Expect(timeout).To(BeTrue())
+				})
+			})
+		})
+
+		Context("when lun is empty", func() {
+			BeforeEach(func() {
+				diskSettings = boshsettings.DiskSettings{
+					HostDeviceID: "fake-host-device-id",
+				}
+			})
+
+			It("returns an error", func() {
+				_, timeout, err := pathResolver.GetRealDevicePath(diskSettings)
+				Expect(err).To(HaveOccurred())
+				Expect(timeout).To(BeFalse())
+			})
+		})
+
+		Context("when host_device_id is empty", func() {
+			BeforeEach(func() {
+				diskSettings = boshsettings.DiskSettings{
+					Lun:     "0",
+				}
+			})
+
+			It("returns an error", func() {
+				_, timeout, err := pathResolver.GetRealDevicePath(diskSettings)
+				Expect(err).To(HaveOccurred())
+				Expect(timeout).To(BeFalse())
+			})
+		})
+	})
+})

--- a/platform/provider.go
+++ b/platform/provider.go
@@ -93,7 +93,8 @@ func NewProvider(logger boshlog.Logger, dirProvider boshdirs.Provider, statsColl
 	case "scsi":
 		scsiIDPathResolver := devicepathresolver.NewSCSIIDDevicePathResolver(50000*time.Millisecond, fs, logger)
 		scsiVolumeIDPathResolver := devicepathresolver.NewSCSIVolumeIDDevicePathResolver(500*time.Millisecond, fs)
-		devicePathResolver = devicepathresolver.NewScsiDevicePathResolver(scsiVolumeIDPathResolver, scsiIDPathResolver)
+		scsiLunPathResolver := devicepathresolver.NewSCSILunDevicePathResolver(50000*time.Millisecond, fs, logger)
+		devicePathResolver = devicepathresolver.NewScsiDevicePathResolver(scsiVolumeIDPathResolver, scsiIDPathResolver, scsiLunPathResolver)
 	default:
 		devicePathResolver = devicepathresolver.NewIdentityDevicePathResolver()
 	}

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -43,6 +43,7 @@ type Disks struct {
 	// e.g "/dev/sdb", "2"
 	// Newer CPIs will populate it in a hash
 	// e.g {"path" => "/dev/sdc", "volume_id" => "3"}
+	//     {"lun" => "0", "host_device_id" => "{host-device-id}"}
 	Ephemeral interface{} `json:"ephemeral"`
 
 	// Older CPIs returned disk settings as strings
@@ -51,6 +52,7 @@ type Disks struct {
 	// Newer CPIs will populate it in a hash:
 	// e.g {"disk-3845-43758-7243-38754" => {"path" => "/dev/sdc"}}
 	//     {"disk-3845-43758-7243-38754" => {"volume_id" => "3"}}
+	//     {"disk-3845-43758-7243-38754" => {"lun" => "0", "host_device_id" => "{host-device-id}"}}
 	Persistent map[string]interface{} `json:"persistent"`
 
 	RawEphemeral []DiskSettings `json:"raw_ephemeral"`
@@ -60,6 +62,8 @@ type DiskSettings struct {
 	ID             string
 	DeviceID       string
 	VolumeID       string
+	Lun            string
+	HostDeviceID   string
 	Path           string
 	FileSystemType disk.FileSystemType
 }
@@ -84,6 +88,12 @@ func (s Settings) PersistentDiskSettings(diskID string) (DiskSettings, bool) {
 				}
 				if deviceID, ok := hashSettings["id"]; ok {
 					diskSettings.DeviceID = deviceID.(string)
+				}
+				if lun, ok := hashSettings["lun"]; ok {
+					diskSettings.Lun = lun.(string)
+				}
+				if hostDeviceID, ok := hashSettings["host_device_id"]; ok {
+					diskSettings.HostDeviceID = hostDeviceID.(string)
 				}
 			} else {
 				// Old CPIs return disk path (string) or volume id (string) as disk settings
@@ -112,6 +122,12 @@ func (s Settings) EphemeralDiskSettings() DiskSettings {
 			}
 			if deviceID, ok := hashSettings["id"]; ok {
 				diskSettings.DeviceID = deviceID.(string)
+			}
+			if lun, ok := hashSettings["lun"]; ok {
+				diskSettings.Lun = lun.(string)
+			}
+			if hostDeviceID, ok := hashSettings["host_device_id"]; ok {
+				diskSettings.HostDeviceID = hostDeviceID.(string)
 			}
 		} else {
 			// Old CPIs return disk path (string) or volume id (string) as disk settings

--- a/settings/settings_test.go
+++ b/settings/settings_test.go
@@ -21,9 +21,11 @@ var _ = Describe("Settings", func() {
 					Disks: Disks{
 						Persistent: map[string]interface{}{
 							"fake-disk-id": map[string]interface{}{
-								"volume_id": "fake-disk-volume-id",
-								"id":        "fake-disk-device-id",
-								"path":      "fake-disk-path",
+								"volume_id":      "fake-disk-volume-id",
+								"id":             "fake-disk-device-id",
+								"path":           "fake-disk-path",
+								"lun":            "fake-disk-lun",
+								"host_device_id": "fake-disk-host-device-id",
 							},
 						},
 					},
@@ -34,10 +36,12 @@ var _ = Describe("Settings", func() {
 				diskSettings, found := settings.PersistentDiskSettings("fake-disk-id")
 				Expect(found).To(BeTrue())
 				Expect(diskSettings).To(Equal(DiskSettings{
-					ID:       "fake-disk-id",
-					DeviceID: "fake-disk-device-id",
-					VolumeID: "fake-disk-volume-id",
-					Path:     "fake-disk-path",
+					ID:           "fake-disk-id",
+					DeviceID:     "fake-disk-device-id",
+					VolumeID:     "fake-disk-volume-id",
+					Path:         "fake-disk-path",
+					Lun:          "fake-disk-lun",
+					HostDeviceID: "fake-disk-host-device-id",
 				}))
 			})
 
@@ -62,6 +66,8 @@ var _ = Describe("Settings", func() {
 						DeviceID:       "fake-disk-device-id",
 						VolumeID:       "fake-disk-volume-id",
 						Path:           "fake-disk-path",
+						Lun:            "fake-disk-lun",
+						HostDeviceID:   "fake-disk-host-device-id",
 						FileSystemType: "xfs",
 					}))
 				})
@@ -74,10 +80,12 @@ var _ = Describe("Settings", func() {
 					diskSettings, _ := settings.PersistentDiskSettings("fake-disk-id")
 					Expect(settings.Env.PersistentDiskFS).To(Equal(disk.FileSystemDefault))
 					Expect(diskSettings).To(Equal(DiskSettings{
-						ID:       "fake-disk-id",
-						DeviceID: "fake-disk-device-id",
-						VolumeID: "fake-disk-volume-id",
-						Path:     "fake-disk-path",
+						ID:           "fake-disk-id",
+						DeviceID:     "fake-disk-device-id",
+						VolumeID:     "fake-disk-volume-id",
+						Path:         "fake-disk-path",
+						Lun:          "fake-disk-lun",
+						HostDeviceID: "fake-disk-host-device-id",
 					}))
 				})
 
@@ -93,6 +101,8 @@ var _ = Describe("Settings", func() {
 						DeviceID:       "fake-disk-device-id",
 						VolumeID:       "fake-disk-volume-id",
 						Path:           "fake-disk-path",
+						Lun:            "fake-disk-lun",
+						HostDeviceID:   "fake-disk-host-device-id",
 						FileSystemType: disk.FileSystemType("blahblah"),
 					}))
 				})
@@ -135,8 +145,10 @@ var _ = Describe("Settings", func() {
 					Disks: Disks{
 						Persistent: map[string]interface{}{
 							"fake-disk-id": map[string]interface{}{
-								"volume_id": "fake-disk-volume-id",
-								"path":      "fake-disk-path",
+								"volume_id":      "fake-disk-volume-id",
+								"path":           "fake-disk-path",
+								"lun":            "fake-disk-lun",
+								"host_device_id": "fake-disk-host-device-id",
 							},
 						},
 					},
@@ -147,9 +159,11 @@ var _ = Describe("Settings", func() {
 				diskSettings, found := settings.PersistentDiskSettings("fake-disk-id")
 				Expect(found).To(BeTrue())
 				Expect(diskSettings).To(Equal(DiskSettings{
-					ID:       "fake-disk-id",
-					VolumeID: "fake-disk-volume-id",
-					Path:     "fake-disk-path",
+					ID:           "fake-disk-id",
+					VolumeID:     "fake-disk-volume-id",
+					Path:         "fake-disk-path",
+					Lun:          "fake-disk-lun",
+					HostDeviceID: "fake-disk-host-device-id",
 				}))
 			})
 		})
@@ -160,8 +174,10 @@ var _ = Describe("Settings", func() {
 					Disks: Disks{
 						Persistent: map[string]interface{}{
 							"fake-disk-id": map[string]interface{}{
-								"id":   "fake-disk-device-id",
-								"path": "fake-disk-path",
+								"id":             "fake-disk-device-id",
+								"path":           "fake-disk-path",
+								"lun":            "fake-disk-lun",
+								"host_device_id": "fake-disk-host-device-id",
 							},
 						},
 					},
@@ -172,9 +188,11 @@ var _ = Describe("Settings", func() {
 				diskSettings, found := settings.PersistentDiskSettings("fake-disk-id")
 				Expect(found).To(BeTrue())
 				Expect(diskSettings).To(Equal(DiskSettings{
-					ID:       "fake-disk-id",
-					DeviceID: "fake-disk-device-id",
-					Path:     "fake-disk-path",
+					ID:           "fake-disk-id",
+					DeviceID:     "fake-disk-device-id",
+					Path:         "fake-disk-path",
+					Lun:          "fake-disk-lun",
+					HostDeviceID: "fake-disk-host-device-id",
 				}))
 			})
 		})
@@ -185,7 +203,9 @@ var _ = Describe("Settings", func() {
 					Disks: Disks{
 						Persistent: map[string]interface{}{
 							"fake-disk-id": map[string]interface{}{
-								"volume_id": "fake-disk-volume-id",
+								"volume_id":      "fake-disk-volume-id",
+								"lun":            "fake-disk-lun",
+								"host_device_id": "fake-disk-host-device-id",
 							},
 						},
 					},
@@ -196,8 +216,35 @@ var _ = Describe("Settings", func() {
 				diskSettings, found := settings.PersistentDiskSettings("fake-disk-id")
 				Expect(found).To(BeTrue())
 				Expect(diskSettings).To(Equal(DiskSettings{
-					ID:       "fake-disk-id",
-					VolumeID: "fake-disk-volume-id",
+					ID:           "fake-disk-id",
+					VolumeID:     "fake-disk-volume-id",
+					Lun:          "fake-disk-lun",
+					HostDeviceID: "fake-disk-host-device-id",
+				}))
+			})
+		})
+
+		Context("when only (lun, host_device_id) are provided", func() {
+			BeforeEach(func() {
+				settings = Settings{
+					Disks: Disks{
+						Persistent: map[string]interface{}{
+							"fake-disk-id": map[string]interface{}{
+								"lun":            "fake-disk-lun",
+								"host_device_id": "fake-disk-host-device-id",
+							},
+						},
+					},
+				}
+			})
+
+			It("does not set path", func() {
+				diskSettings, found := settings.PersistentDiskSettings("fake-disk-id")
+				Expect(found).To(BeTrue())
+				Expect(diskSettings).To(Equal(DiskSettings{
+					ID:           "fake-disk-id",
+					Lun:          "fake-disk-lun",
+					HostDeviceID: "fake-disk-host-device-id",
 				}))
 			})
 		})
@@ -226,9 +273,11 @@ var _ = Describe("Settings", func() {
 				settings = Settings{
 					Disks: Disks{
 						Ephemeral: map[string]interface{}{
-							"id":        "fake-disk-device-id",
-							"volume_id": "fake-disk-volume-id",
-							"path":      "fake-disk-path",
+							"id":             "fake-disk-device-id",
+							"volume_id":      "fake-disk-volume-id",
+							"path":           "fake-disk-path",
+							"lun":            "fake-disk-lun",
+							"host_device_id": "fake-disk-host-device-id",
 						},
 					},
 				}
@@ -236,9 +285,11 @@ var _ = Describe("Settings", func() {
 
 			It("converts disk settings", func() {
 				Expect(settings.EphemeralDiskSettings()).To(Equal(DiskSettings{
-					DeviceID: "fake-disk-device-id",
-					VolumeID: "fake-disk-volume-id",
-					Path:     "fake-disk-path",
+					DeviceID:     "fake-disk-device-id",
+					VolumeID:     "fake-disk-volume-id",
+					Path:         "fake-disk-path",
+					Lun:          "fake-disk-lun",
+					HostDeviceID: "fake-disk-host-device-id",
 				}))
 			})
 		})


### PR DESCRIPTION
On Azure, a data disk can be found by LUN and the host device id. The device id is the instance id of the SCSI controller which is used to attach the data disk.

1. Find the vmbus device name (e.g. vmbus_12 or vmbus_0_12) with the given host device id by checking "/sys/bus/vmbus/devices/*/device_id"
2. Find all disk names (e.g. sda, sdb, sdc) with the given LUN by checking "/sys/bus/scsi/devices/*:*:*:LUN/block/*"
3. Find above vmbus device name in the symbol link of "/sys/class/block/sdX"

Example:
LUN: 0
Host Device ID: f8b3781b-1e82-4818-a1c3-63d806ec15bb

1.  Get 'vmbus_0_15'
  ```
  $ cat /sys/bus/vmbus/devices/vmbus_0_15/device_id
  {f8b3781b-1e82-4818-a1c3-63d806ec15bb}
  ```

2. Get ['sda', 'sdb', 'sdc']
  ```
  $ ls /sys/bus/scsi/devices/*:*:*:0/block
  /sys/bus/scsi/devices/2:0:0:0/block:
  sda
  
  /sys/bus/scsi/devices/3:0:1:0/block:
  sdb
  
  /sys/bus/scsi/devices/5:0:0:0/block:
  sdc
  ```

3. Get 'sdc' because the symbol link of 5:0:0:0 contains '/vmbus_0_15/'

  ```
  /sys/bus/scsi/devices/5:0:0:0 ->   ../../../devices/LNXSYSTM:00/LNXSYBUS:00/PNP0A03:00/device:07/VMBUS:01/vmbus_0_15/host5/target5:0:0/5:0:0:0
  ```