### PR TITLE
infrastructure/devicepathresolver: Use wildcard as prefix for ID.

### DIFF
--- a/infrastructure/devicepathresolver/id_device_path_resolver.go
+++ b/infrastructure/devicepathresolver/id_device_path_resolver.go
@@ -11,24 +11,19 @@ import (
 	boshsys "github.com/cloudfoundry/bosh-utils/system"
 )
 
-const defaultDevicePrefix = "virtio"
-
 type idDevicePathResolver struct {
 	diskWaitTimeout time.Duration
-	devicePrefix    string
 	udev            boshudev.UdevDevice
 	fs              boshsys.FileSystem
 }
 
 func NewIDDevicePathResolver(
 	diskWaitTimeout time.Duration,
-	devicePrefix string,
 	udev boshudev.UdevDevice,
 	fs boshsys.FileSystem,
 ) DevicePathResolver {
 	return idDevicePathResolver{
 		diskWaitTimeout: diskWaitTimeout,
-		devicePrefix:    devicePrefix,
 		udev:            udev,
 		fs:              fs,
 	}
@@ -59,10 +54,8 @@ func (idpr idDevicePathResolver) GetRealDevicePath(diskSettings boshsettings.Dis
 	var realPath string
 
 	diskID := diskSettings.ID[0:20]
-	deviceID := fmt.Sprintf("%s-%s", defaultDevicePrefix, diskID)
-	if idpr.devicePrefix != "" {
-		deviceID = fmt.Sprintf("%s-%s", idpr.devicePrefix, diskID)
-	}
+	deviceGlobPattern := fmt.Sprintf("*%s", diskID)
+	deviceIDPathGlobPattern := path.Join("/", "dev", "disk", "by-id", deviceGlobPattern)
 
 	for !found {
 		if time.Now().After(stopAfter) {
@@ -70,15 +63,21 @@ func (idpr idDevicePathResolver) GetRealDevicePath(diskSettings boshsettings.Dis
 		}
 
 		time.Sleep(100 * time.Millisecond)
-
-		deviceIDPath := path.Join("/", "dev", "disk", "by-id", deviceID)
-		realPath, err = idpr.fs.ReadLink(deviceIDPath)
+		realPathMatches, err := idpr.fs.Glob(deviceIDPathGlobPattern)
 		if err != nil {
 			continue
 		}
 
-		if idpr.fs.FileExists(realPath) {
-			found = true
+		switch len(realPathMatches) {
+		case 0:
+			continue
+		case 1:
+			realPath = realPathMatches[0]
+			if idpr.fs.FileExists(realPath) {
+				found = true
+			}
+		default:
+			return "", true, bosherr.Errorf("More than one disk matched glob %q while getting real device path for %q", deviceIDPathGlobPattern, diskID)
 		}
 	}
 

--- a/platform/linux_platform.go
+++ b/platform/linux_platform.go
@@ -67,9 +67,6 @@ type LinuxOptions struct {
 	// Strategy for resolving device paths;
 	// possible values: virtio, scsi, ''
 	DevicePathResolutionType string
-
-	// Device prexix when using virtio (defaults to 'virtio')
-	VirtioDevicePrefix string
 }
 
 type linux struct {

--- a/platform/provider.go
+++ b/platform/provider.go
@@ -89,7 +89,7 @@ func NewProvider(logger boshlog.Logger, dirProvider boshdirs.Provider, statsColl
 	switch options.Linux.DevicePathResolutionType {
 	case "virtio":
 		udev := boshudev.NewConcreteUdevDevice(runner, logger)
-		idDevicePathResolver := devicepathresolver.NewIDDevicePathResolver(500*time.Millisecond, options.Linux.VirtioDevicePrefix, udev, fs)
+		idDevicePathResolver := devicepathresolver.NewIDDevicePathResolver(500*time.Millisecond, udev, fs)
 		mappedDevicePathResolver := devicepathresolver.NewMappedDevicePathResolver(30000*time.Millisecond, fs)
 		devicePathResolver = devicepathresolver.NewVirtioDevicePathResolver(idDevicePathResolver, mappedDevicePathResolver, logger)
 	case "scsi":


### PR DESCRIPTION
Currently the bosh-agent `idDevicePathResolver` requires a prefix to look up a disk by ID (`prefix-id`). Prefixes have shown to be unstable (e.g., if udev rules are changed), and a change will break disk mounting.

This change removes the prefix-based search and replaces it with a `*-id` glob match.

`bin/test-unit` passes. This change has also been baked into the Google [stemcell](https://s3.amazonaws.com/bosh-cpi-artifacts/bosh-stemcell-3262-google-kvm-ubuntu-trusty-go_agent.tgz) (and [sha1](https://s3.amazonaws.com/bosh-cpi-artifacts/bosh-stemcell-3262-google-kvm-ubuntu-trusty-go_agent.tgz.sha1)) and passed BATS.

https://www.pivotaltracker.com/story/show/116497687