### PR TITLE
fixes formatting using parted on centOS

### DIFF
--- a/platform/disk/parted_partitioner.go
+++ b/platform/disk/parted_partitioner.go
@@ -177,7 +177,7 @@ func (p partedPartitioner) runPartedPrint(devicePath string) (stdout, stderr str
 	stdout, stderr, exitStatus, err = p.cmdRunner.RunCommand("parted", "-m", devicePath, "unit", "B", "print")
 
 	// If the error is not having a partition table, create one
-	if err != nil && strings.Contains(err.Error(), "unrecognised disk label") {
+	if strings.Contains(stderr, "unrecognised disk label") {
 		stdout, stderr, exitStatus, err = p.getPartitionTable(devicePath)
 
 		if err != nil {

--- a/platform/disk/parted_partitioner_test.go
+++ b/platform/disk/parted_partitioner_test.go
@@ -34,7 +34,7 @@ var _ = Describe("PartedPartitioner", func() {
 					fakeCmdRunner.AddCmdResult(
 						"parted -m /dev/sda unit B print",
 						fakesys.FakeCmdResult{
-							Stdout: "Error: /dev/sda: unrecognised disk label", ExitStatus: 1, Error: errors.New("Error: /dev/sda: unrecognised disk label")},
+							Stderr: "Error: /dev/sda: unrecognised disk label", ExitStatus: 0},
 					)
 					fakeCmdRunner.AddCmdResult(
 						"parted -m /dev/sda unit B print",
@@ -291,7 +291,7 @@ var _ = Describe("PartedPartitioner", func() {
 					fakeCmdRunner.AddCmdResult(
 						"parted -m /dev/sda unit B print",
 						fakesys.FakeCmdResult{
-							Stdout: "Error: /dev/sda: unrecognised disk label", ExitStatus: 1, Error: errors.New("Error: /dev/sda: unrecognised disk label")},
+							Stderr: "Error: /dev/sda: unrecognised disk label", ExitStatus: 0},
 					)
 					fakeCmdRunner.AddCmdResult(
 						"parted -s /dev/sda mklabel gpt",
@@ -317,7 +317,7 @@ var _ = Describe("PartedPartitioner", func() {
 					fakeCmdRunner.AddCmdResult(
 						"parted -m /dev/sda unit B print",
 						fakesys.FakeCmdResult{
-							Stdout: "Error: /dev/sda: unrecognised disk label", ExitStatus: 1, Error: errors.New("Error: /dev/sda: unrecognised disk label")},
+							Stderr: "Error: /dev/sda: unrecognised disk label", ExitStatus: 0},
 					)
 					fakeCmdRunner.AddCmdResult(
 						"parted -m /dev/sda unit B print",


### PR DESCRIPTION
Signed-off-by: Tanzeeb Khalili <tkhalili@pivotal.io>

`parted -m` exits with 0 on centos. Fix checks stderr instead of error objects.