### PR TITLE
Fixed issue #83

### DIFF
--- a/platform/linux_platform.go
+++ b/platform/linux_platform.go
@@ -49,6 +49,10 @@ type LinuxOptions struct {
 	// is not going to be overlayed over /tmp to limit /tmp dir size
 	UseDefaultTmpDir bool
 
+	// When set to true the agent will scrub ephemeral disk if agent version is
+	// different with stemcell version
+	ScrubEphemeralDisk bool
+
 	// When set to true persistent disk will be assumed to be pre-formatted;
 	// otherwise agent will partition and format it right before mounting
 	UsePreformattedPersistentDisk bool
@@ -567,6 +571,49 @@ func (p linux) SetupEphemeralDiskWithPath(realPath string) error {
 	err = p.diskManager.GetMounter().Mount(dataPartitionPath, mountPoint)
 	if err != nil {
 		return bosherr.WrapError(err, "Mounting data partition")
+	}
+
+	if p.options.ScrubEphemeralDisk {
+		agentVersionFilePath := path.Join(p.dirProvider.DataDir(), ".bosh", "agent_version")
+		stemcellVersionFilePath := path.Join(p.dirProvider.BaseDir(), "bosh", "etc", "stemcell_version")
+		stemcellVersion, err := p.fs.ReadFileString(stemcellVersionFilePath)
+		if err != nil {
+			return bosherr.WrapError(err, "Reading stemcell version file")
+		}
+
+		if !p.fs.FileExists(agentVersionFilePath) {
+			err = p.fs.WriteFileString(agentVersionFilePath, stemcellVersion)
+			if err != nil {
+				return bosherr.WrapError(err, "Writting agent version file")
+			}
+		} else {
+			agentVersion, err := p.fs.ReadFileString(agentVersionFilePath)
+			if err != nil {
+				return bosherr.WrapError(err, "Reading agent version file")
+			}
+
+			if agentVersion != stemcellVersion {
+				sysRunPath := path.Join(p.dirProvider.DataDir(), "sys", "run")
+				_, err = p.diskManager.GetMounter().Unmount(sysRunPath)
+				if err != nil {
+					return bosherr.WrapErrorf(err, "Unmounting '%s'", sysRunPath)
+				}
+
+				dataGlob := path.Join(p.dirProvider.DataDir(), "*")
+				contents, err := p.fs.Glob(dataGlob)
+				for _, content := range contents {
+					err = p.fs.RemoveAll(content)
+					if err != nil {
+						return bosherr.WrapErrorf(err, "Removing '%s'", content)
+					}
+				}
+
+				err = p.fs.WriteFileString(agentVersionFilePath, stemcellVersion)
+				if err != nil {
+					return bosherr.WrapError(err, "Updating agent version file")
+				}
+			}
+		}
 	}
 
 	return nil

--- a/platform/linux_platform_test.go
+++ b/platform/linux_platform_test.go
@@ -1030,6 +1030,136 @@ fake-base-path/data/sys/log/*.log fake-base-path/data/sys/log/.*.log fake-base-p
 				Expect(mounter.MountCalled).To(BeFalse())
 			})
 		})
+
+		Context("when ScrubEphemeralDisk is true", func() {
+			BeforeEach(func() {
+				options.ScrubEphemeralDisk = true
+				fs.WriteFileString(path.Join(dirProvider.BaseDir(), "bosh", "etc", "stemcell_version"), "1235")
+				fs.WriteFileString(path.Join(dirProvider.DataDir(), ".bosh", "agent_version"), "1234")
+			})
+
+			act := func() error {
+				return platform.SetupEphemeralDiskWithPath("/dev/xvda")
+			}
+
+			Context("when stemcell_version file does not exist", func() {
+				BeforeEach(func() {
+					fs.RemoveAll(path.Join(dirProvider.BaseDir(), "bosh", "etc", "stemcell_version"))
+				})
+
+				It("returns error", func() {
+					fs.WriteFileError = errors.New("Reading stemcell version file")
+					err := act()
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("Reading stemcell version file"))
+				})
+			})
+
+			Context("when stemcell_version file exists", func() {
+				Context("when agent_version file does not exist", func() {
+					BeforeEach(func() {
+						fs.RemoveAll(path.Join(dirProvider.DataDir(), ".bosh", "agent_version"))
+					})
+
+					It("writes agent_version file", func() {
+						err := act()
+						Expect(err).ToNot(HaveOccurred())
+
+						agentVersionStats := fs.GetFileTestStat(path.Join(dirProvider.DataDir(), ".bosh", "agent_version"))
+						Expect(agentVersionStats).ToNot(BeNil())
+						Expect(agentVersionStats.StringContents()).To(Equal("1235"))
+					})
+
+					It("returns an error if writing agent_version file fails", func() {
+						fs.WriteFileError = errors.New("fake-write-file-err")
+						err := act()
+						Expect(err).To(HaveOccurred())
+						Expect(err.Error()).To(ContainSubstring("fake-write-file-err"))
+					})
+				})
+
+				Context("when agent_version file exists", func() {
+					It("returns an error if reading agent_version file fails", func() {
+						fs.ReadFileError = errors.New("fake-read-file-err")
+						err := act()
+						Expect(err).To(HaveOccurred())
+						Expect(err.Error()).To(ContainSubstring("fake-read-file-err"))
+					})
+
+
+					Context("when agent version is same with stemcell version", func() {
+						BeforeEach(func() {
+							fs.WriteFileString(path.Join(dirProvider.BaseDir(), "bosh", "etc", "stemcell_version"), "1236")
+							fs.WriteFileString(path.Join(dirProvider.DataDir(), ".bosh", "agent_version"), "1236")
+						})
+
+						It("does nothing", func() {
+							err := act()
+							Expect(err).ToNot(HaveOccurred())
+
+							agentVersionStats := fs.GetFileTestStat(path.Join(dirProvider.DataDir(), ".bosh", "agent_version"))
+							Expect(agentVersionStats).ToNot(BeNil())
+							stemcellVersionStats := fs.GetFileTestStat(path.Join(dirProvider.BaseDir(), "bosh", "etc", "stemcell_version"))
+							Expect(stemcellVersionStats).ToNot(BeNil())
+							Expect(agentVersionStats.StringContents()).To(Equal(stemcellVersionStats.StringContents()))
+						})
+					})
+
+
+					Context("when agent version differs with stemcell version", func() {
+						BeforeEach(func() {
+							fs.WriteFileString(path.Join(dirProvider.BaseDir(), "bosh", "etc", "stemcell_version"), "1239")
+							fs.WriteFileString(path.Join(dirProvider.DataDir(), ".bosh", "agent_version"), "1238")
+							fs.SetGlob(path.Join("/fake-dir", "data", "", "*"), []string{"/fake-dir/data/fake-file1", "/fake-dir/data/fakedir"})
+						})
+
+						It("returns an error if unmounting fails", func() {
+							mounter.UnmountErr = errors.New("fake-unmount-err")
+							err := act()
+							Expect(err).To(HaveOccurred())
+							Expect(err.Error()).To(ContainSubstring("fake-unmount-err"))
+
+						})
+
+						It("returns an error if removing files fails", func() {
+							fs.RemoveAllStub = func(_ string) error {
+								return errors.New("fake-remove-all-error")
+							}
+
+							err := act()
+							Expect(err).To(HaveOccurred())
+							Expect(err.Error()).To(ContainSubstring("fake-remove-all-error"))
+						})
+
+						It("returns an error if updating agent_version file fails", func() {
+							fs.WriteFileError = errors.New("fake-update-file-err")
+							err := act()
+							Expect(err).To(HaveOccurred())
+							Expect(err.Error()).To(ContainSubstring("fake-update-file-err"))
+						})
+
+						It("removes all contents", func() {
+							fs.WriteFileString(path.Join(dirProvider.DataDir(), "fake-file1"), "fake")
+							fs.WriteFileString(path.Join(dirProvider.DataDir(), "fakedir", "fake-file2"), "1234")
+							err := act()
+							Expect(err).ToNot(HaveOccurred())
+							Expect(fs.FileExists(path.Join(dirProvider.DataDir(), "fake-file1"))).To(BeFalse())
+							Expect(fs.FileExists(path.Join(dirProvider.DataDir(), "fakedir", "fake-file2"))).To(BeFalse())
+						})
+
+						It("updates agent_version file", func() {
+							err := act()
+							Expect(err).ToNot(HaveOccurred())
+
+							agentVersionStats := fs.GetFileTestStat(path.Join(dirProvider.DataDir(), ".bosh", "agent_version"))
+							Expect(agentVersionStats).ToNot(BeNil())
+							Expect(agentVersionStats.StringContents()).To(Equal("1239"))
+						})
+					})
+				})
+			})
+		})
+
 	})
 
 	Describe("SetupRawEphemeralDisks", func() {


### PR DESCRIPTION
Bosh agent will scrub ephemeral disk if agent version is
different with stemcell version

[issue #83](https://github.com/cloudfoundry/bosh-agent/issues/83)