### PR TITLE
Send heartbeats every 30s

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -210,7 +210,7 @@ func (app *app) Setup(args []string) error {
 		jobSupervisor,
 		specService,
 		syslogServer,
-		time.Minute,
+		time.Second*30,
 		settingsService,
 		uuidGen,
 		timeService,


### PR DESCRIPTION
previously they were sent every 60s, which is dangerous with the default BOSH HM agent timeout of 60s.