### PR TITLE
OpenStack successfully partitions persistent disks

### DIFF
--- a/infrastructure/devicepathresolver/id_device_path_resolver.go
+++ b/infrastructure/devicepathresolver/id_device_path_resolver.go
@@ -63,16 +63,20 @@ func (idpr idDevicePathResolver) GetRealDevicePath(diskSettings boshsettings.Dis
 		}
 
 		time.Sleep(100 * time.Millisecond)
-		realPathMatches, err := idpr.fs.Glob(deviceIDPathGlobPattern)
+		pathMatches, err := idpr.fs.Glob(deviceIDPathGlobPattern)
 		if err != nil {
 			continue
 		}
 
-		switch len(realPathMatches) {
+		switch len(pathMatches) {
 		case 0:
 			continue
 		case 1:
-			realPath = realPathMatches[0]
+			realPath, err = idpr.fs.Readlink(pathMatches[0])
+			if err != nil {
+				continue
+			}
+
 			if idpr.fs.FileExists(realPath) {
 				found = true
 			}


### PR DESCRIPTION
- the Agent was not properly following the devices' links
- the tests were falsely returning the target of the link instead of the matching fileglobs (fixed)
- error checking in the tests is more stringent (unrelated)
- may affect other IaaSes

fixes:
```
Command 'deploy' failed:
  Deploying:
    Creating instance 'bosh/0':
      Updating instance disks:
        Updating disks:
          Deploying disk:
            Mounting disk:
              Sending 'get_task' to the agent:
                Agent responded with error: Action Failed get_task: Task d5818063-217f-41e3-5110-01a5539d86d2 result: Mounting persistent disk: Formatting partition with : Checking filesystem format of partition: Running command: 'blkid -p /dev/disk/by-id/virtio-7c6dadc7-3231-4f60-a1', stdout: '', stderr: 'error: /dev/disk/by-id/virtio-7c6dadc7-3231-4f60-a1: No such file or directory
```

Signed-off-by: Brian Cunnie <bcunnie@pivotal.io>

[#130668281](https://www.pivotaltracker.com/story/show/130668281)