### PR TITLE
Agent will add authorized keys from `env`

### DIFF
--- a/agent/action/ssh.go
+++ b/agent/action/ssh.go
@@ -83,7 +83,7 @@ func (a SSHAction) setupSSH(params SSHParams) (SSHResult, error) {
 		return result, bosherr.WrapError(err, "Adding user to groups")
 	}
 
-	err = a.platform.SetupSSH(params.PublicKey, params.User)
+	err = a.platform.SetupSSH([]string{params.PublicKey}, params.User)
 	if err != nil {
 		return result, bosherr.WrapError(err, "Setting ssh public key")
 	}

--- a/agent/action/ssh_test.go
+++ b/agent/action/ssh_test.go
@@ -22,7 +22,7 @@ func validatePlatformSetupWithPassword(platform *fakeplatform.FakePlatform, expe
 	Expect(platform.AddUserToGroupsGroups["fake-user"]).To(Equal(
 		[]string{boshsettings.VCAPUsername, boshsettings.AdminGroup, boshsettings.SudoersGroup},
 	))
-	Expect(platform.SetupSSHPublicKeys["fake-user"]).To(Equal("fake-public-key"))
+	Expect(platform.SetupSSHPublicKeys["fake-user"]).To(ConsistOf("fake-public-key"))
 }
 
 func buildSSHAction(settingsService boshsettings.Service) (*fakeplatform.FakePlatform, SSHAction) {

--- a/agent/bootstrap.go
+++ b/agent/bootstrap.go
@@ -44,22 +44,28 @@ func (boot bootstrap) Run() (err error) {
 		return bosherr.WrapError(err, "Setting up runtime configuration")
 	}
 
-	publicKey, err := boot.settingsService.PublicSSHKeyForUsername(boshsettings.VCAPUsername)
-	if err != nil {
-		return bosherr.WrapError(err, "Setting up ssh: Getting public key")
-	}
-
-	if len(publicKey) > 0 {
-		if err = boot.platform.SetupSSH(publicKey, boshsettings.VCAPUsername); err != nil {
-			return bosherr.WrapError(err, "Setting up ssh")
-		}
-	}
-
 	if err = boot.settingsService.LoadSettings(); err != nil {
 		return bosherr.WrapError(err, "Fetching settings")
 	}
 
 	settings := boot.settingsService.GetSettings()
+
+	envPublicKeys := settings.Env.GetAuthorizedKeys()
+	iaasPublicKey, err := boot.settingsService.PublicSSHKeyForUsername(boshsettings.VCAPUsername)
+	if err != nil {
+		return bosherr.WrapError(err, "Setting up ssh: Getting public key")
+	}
+
+	publicKeys := envPublicKeys
+	if len(iaasPublicKey) > 0 {
+		publicKeys = append(publicKeys, iaasPublicKey)
+	}
+
+	if len(publicKeys) > 0 {
+		if err = boot.platform.SetupSSH(publicKeys, boshsettings.VCAPUsername); err != nil {
+			return bosherr.WrapError(err, "Setting up ssh")
+		}
+	}
 
 	if err = boot.setUserPasswords(settings.Env); err != nil {
 		return bosherr.WrapError(err, "Settings user password")

--- a/agent/bootstrap_test.go
+++ b/agent/bootstrap_test.go
@@ -91,7 +91,7 @@ func init() {
 						err := bootstrap()
 						Expect(err).NotTo(HaveOccurred())
 
-						Expect(platform.SetupSSHPublicKey).To(Equal("fake-public-key"))
+						Expect(platform.SetupSSHPublicKey).To(ConsistOf("fake-public-key"))
 						Expect(platform.SetupSSHUsername).To(Equal("vcap"))
 					})
 
@@ -106,7 +106,7 @@ func init() {
 
 				Context("when public key key is empty", func() {
 					BeforeEach(func() {
-						settingsSource.PublicKey = ""
+						settingsService.PublicKey = ""
 					})
 
 					It("gets the public key and does not setup SSH", func() {
@@ -116,6 +116,39 @@ func init() {
 						Expect(platform.SetupSSHCalled).To(BeFalse())
 					})
 				})
+
+				Context("when the environment has authorized keys", func() {
+					BeforeEach(func() {
+						settingsService.Settings.Env.Bosh.AuthorizedKeys = []string{"fake-public-key", "another-fake-public-key"}
+						settingsService.PublicKey = ""
+					})
+
+					It("gets the public key and sets up SSH", func() {
+						err := bootstrap()
+						Expect(err).NotTo(HaveOccurred())
+
+						Expect(platform.SetupSSHCalled).To(BeTrue())
+						Expect(platform.SetupSSHPublicKey).To(ConsistOf("fake-public-key", "another-fake-public-key"))
+						Expect(platform.SetupSSHUsername).To(Equal("vcap"))
+					})
+				})
+
+				Context("when both have authorized keys", func() {
+					BeforeEach(func() {
+						settingsService.Settings.Env.Bosh.AuthorizedKeys = []string{"another-fake-public-key"}
+						settingsService.PublicKey = "fake-public-key"
+					})
+
+					It("gets the public key and sets up SSH", func() {
+						err := bootstrap()
+						Expect(err).NotTo(HaveOccurred())
+
+						Expect(platform.SetupSSHCalled).To(BeTrue())
+						Expect(platform.SetupSSHPublicKey).To(ConsistOf("fake-public-key", "another-fake-public-key"))
+						Expect(platform.SetupSSHUsername).To(Equal("vcap"))
+					})
+				})
+
 			})
 
 			It("sets up hostname", func() {

--- a/docs/dev_setup.md
+++ b/docs/dev_setup.md
@@ -75,7 +75,7 @@ All dependencies:
 ./update-dep github.com/cloudfoundry/bosh-utils/...
 ```
 
-An example for a single depdency:
+An example for a single dependency:
 
 ```
 ./update-dep github.com/pivotal-golang/clock/fakeclock

--- a/platform/dummy_platform.go
+++ b/platform/dummy_platform.go
@@ -116,7 +116,7 @@ func (p dummyPlatform) SetupRootDisk(ephemeralDiskPath string) (err error) {
 	return
 }
 
-func (p dummyPlatform) SetupSSH(publicKey, username string) (err error) {
+func (p dummyPlatform) SetupSSH(publicKey []string, username string) (err error) {
 	return
 }
 

--- a/platform/fakes/fake_platform.go
+++ b/platform/fakes/fake_platform.go
@@ -37,10 +37,10 @@ type FakePlatform struct {
 
 	AddUserToGroupsGroups             map[string][]string
 	DeleteEphemeralUsersMatchingRegex string
-	SetupSSHPublicKeys                map[string]string
+	SetupSSHPublicKeys                map[string][]string
 
 	SetupSSHCalled    bool
-	SetupSSHPublicKey string
+	SetupSSHPublicKey []string
 	SetupSSHUsername  string
 	SetupSSHErr       error
 
@@ -163,7 +163,7 @@ func NewFakePlatform() (platform *FakePlatform) {
 	platform.FakeVitalsService = fakevitals.NewFakeService()
 	platform.DevicePathResolver = fakedpresolv.NewFakeDevicePathResolver()
 	platform.AddUserToGroupsGroups = make(map[string][]string)
-	platform.SetupSSHPublicKeys = make(map[string]string)
+	platform.SetupSSHPublicKeys = make(map[string][]string)
 	platform.UserPasswords = make(map[string]string)
 	platform.ScsiDiskMap = make(map[string]string)
 	platform.GetFileContentsFromDiskDiskPaths = []string{}
@@ -243,7 +243,7 @@ func (p *FakePlatform) SetupRootDisk(ephemeralDiskPath string) (err error) {
 	return
 }
 
-func (p *FakePlatform) SetupSSH(publicKey, username string) error {
+func (p *FakePlatform) SetupSSH(publicKey []string, username string) error {
 	p.SetupSSHCalled = true
 	p.SetupSSHPublicKeys[username] = publicKey
 	p.SetupSSHPublicKey = publicKey

--- a/platform/linux_platform.go
+++ b/platform/linux_platform.go
@@ -347,7 +347,7 @@ func (p linux) SetupRootDisk(ephemeralDiskPath string) error {
 	return nil
 }
 
-func (p linux) SetupSSH(publicKey, username string) error {
+func (p linux) SetupSSH(publicKeys []string, username string) error {
 	homeDir, err := p.fs.HomeDir(username)
 	if err != nil {
 		return bosherr.WrapError(err, "Finding home dir for user")
@@ -364,7 +364,8 @@ func (p linux) SetupSSH(publicKey, username string) error {
 	}
 
 	authKeysPath := path.Join(sshPath, "authorized_keys")
-	err = p.fs.WriteFileString(authKeysPath, publicKey)
+	publicKeyString := strings.Join(publicKeys, "\n")
+	err = p.fs.WriteFileString(authKeysPath, publicKeyString)
 	if err != nil {
 		return bosherr.WrapError(err, "Creating authorized_keys file")
 	}

--- a/platform/linux_platform_test.go
+++ b/platform/linux_platform_test.go
@@ -365,10 +365,10 @@ bosh_foobar:...`
 	})
 
 	Describe("SetupSSH", func() {
-		It("setup ssh", func() {
+		It("setup ssh with a single key", func() {
 			fs.HomeDirHomePath = "/some/home/dir"
 
-			platform.SetupSSH("some public key", "vcap")
+			platform.SetupSSH([]string{"some public key"}, "vcap")
 
 			sshDirPath := "/some/home/dir/.ssh"
 			sshDirStat := fs.GetFileTestStat(sshDirPath)
@@ -387,6 +387,30 @@ bosh_foobar:...`
 			Expect(os.FileMode(0600)).To(Equal(authKeysStat.FileMode))
 			Expect("vcap").To(Equal(authKeysStat.Username))
 			Expect("some public key").To(Equal(authKeysStat.StringContents()))
+		})
+
+		It("setup ssh with multiple keys", func() {
+			fs.HomeDirHomePath = "/some/home/dir"
+
+			platform.SetupSSH([]string{"some public key", "some other public key"}, "vcap")
+
+			sshDirPath := "/some/home/dir/.ssh"
+			sshDirStat := fs.GetFileTestStat(sshDirPath)
+
+			Expect("vcap").To(Equal(fs.HomeDirUsername))
+
+			Expect(sshDirStat).NotTo(BeNil())
+			Expect(sshDirStat.FileType).To(Equal(fakesys.FakeFileTypeDir))
+			Expect(os.FileMode(0700)).To(Equal(sshDirStat.FileMode))
+			Expect("vcap").To(Equal(sshDirStat.Username))
+
+			authKeysStat := fs.GetFileTestStat(path.Join(sshDirPath, "authorized_keys"))
+
+			Expect(authKeysStat).NotTo(BeNil())
+			Expect(fakesys.FakeFileTypeFile).To(Equal(authKeysStat.FileType))
+			Expect(os.FileMode(0600)).To(Equal(authKeysStat.FileMode))
+			Expect("vcap").To(Equal(authKeysStat.Username))
+			Expect("some public key\nsome other public key").To(Equal(authKeysStat.StringContents()))
 		})
 
 	})

--- a/platform/platform_interface.go
+++ b/platform/platform_interface.go
@@ -28,7 +28,7 @@ type Platform interface {
 
 	// Bootstrap functionality
 	SetupRootDisk(ephemeralDiskPath string) (err error)
-	SetupSSH(publicKey, username string) (err error)
+	SetupSSH(publicKey []string, username string) (err error)
 	SetUserPassword(user, encryptedPwd string) (err error)
 	SetupHostname(hostname string) (err error)
 	SetupNetworking(networks boshsettings.Networks) (err error)

--- a/platform/windows_platform.go
+++ b/platform/windows_platform.go
@@ -111,7 +111,7 @@ func (p WindowsPlatform) SetupRootDisk(ephemeralDiskPath string) (err error) {
 	return
 }
 
-func (p WindowsPlatform) SetupSSH(publicKey, username string) (err error) {
+func (p WindowsPlatform) SetupSSH(publicKey []string, username string) (err error) {
 	return
 }
 

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -174,10 +174,15 @@ func (e Env) GetRemoveDevTools() bool {
 	return e.Bosh.RemoveDevTools
 }
 
+func (e Env) GetAuthorizedKeys() []string {
+	return e.Bosh.AuthorizedKeys
+}
+
 type BoshEnv struct {
-	Password         string `json:"password"`
-	KeepRootPassword bool   `json:"keep_root_password"`
-	RemoveDevTools   bool   `json:"remove_dev_tools"`
+	Password         string   `json:"password"`
+	KeepRootPassword bool     `json:"keep_root_password"`
+	RemoveDevTools   bool     `json:"remove_dev_tools"`
+	AuthorizedKeys   []string `json:"authorized_keys"`
 }
 
 type DNSRecords struct {

--- a/settings/settings_test.go
+++ b/settings/settings_test.go
@@ -640,13 +640,14 @@ var _ = Describe("Settings", func() {
 	Describe("Env", func() {
 		It("unmarshal env value correctly", func() {
 			var env Env
-			envJSON := `{"bosh": {"password": "fake-password", "keep_root_password": false, "remove_dev_tools": true}}`
+			envJSON := `{"bosh": {"password": "fake-password", "keep_root_password": false, "remove_dev_tools": true, "authorized_keys": ["fake-key"]}}`
 
 			err := json.Unmarshal([]byte(envJSON), &env)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(env.GetPassword()).To(Equal("fake-password"))
 			Expect(env.GetKeepRootPassword()).To(BeFalse())
 			Expect(env.GetRemoveDevTools()).To(BeTrue())
+			Expect(env.GetAuthorizedKeys()).To(ConsistOf("fake-key"))
 		})
 	})
 


### PR DESCRIPTION
- Makes generation of authorized SSH keys more consistent
  across different IaaS
- Still allows agent to get public keys from IaaS, e.g. `/openssh-key` on AWS,
  keys specified in `env` are appended to these keys

**Important:** Make sure to bump bosh-agent submodule in bosh repo.

Signed-off-by: Mark Fussell <mfussell@pivotal.io>

[#130786799](https://www.pivotaltracker.com/story/show/130786799)