### PR TITLE
Retry metadata service request

### DIFF
--- a/infrastructure/http_metadata_service_test.go
+++ b/infrastructure/http_metadata_service_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -15,7 +16,6 @@ import (
 	boshlog "github.com/cloudfoundry/bosh-utils/logger"
 
 	. "github.com/cloudfoundry/bosh-agent/infrastructure"
-	"time"
 )
 
 var _ = Describe("HTTPMetadataService", describeHTTPMetadataService)

--- a/infrastructure/http_metadata_service_test.go
+++ b/infrastructure/http_metadata_service_test.go
@@ -15,6 +15,7 @@ import (
 	boshlog "github.com/cloudfoundry/bosh-utils/logger"
 
 	. "github.com/cloudfoundry/bosh-agent/infrastructure"
+	"time"
 )
 
 var _ = Describe("HTTPMetadataService", describeHTTPMetadataService)
@@ -344,5 +345,81 @@ func describeHTTPMetadataService() {
 		It("returns nil networks, since you don't need them for bootstrapping since your network must be set up before you can get the metadata", func() {
 			Expect(metadataService.GetNetworks()).To(BeNil())
 		})
+	})
+
+	Describe("Retryable Metadata Service Request", func() {
+		var (
+			ts          *httptest.Server
+			registryURL *string
+			dnsServer   *string
+		)
+
+		createHandlerFunc := func(count int) func(http.ResponseWriter, *http.Request) {
+			initialCount := 0
+			return func(w http.ResponseWriter, r *http.Request) {
+				if initialCount < count {
+					initialCount++
+					http.Error(w, http.StatusText(500), 500)
+					return
+				}
+
+				var jsonStr string
+				if dnsServer == nil {
+					jsonStr = fmt.Sprintf(`{"registry":{"endpoint":"%s"}}`, *registryURL)
+				} else {
+					jsonStr = fmt.Sprintf(`{
+					"registry":{"endpoint":"%s"},
+					"dns":{"nameserver":["%s"]}
+				}`, *registryURL, *dnsServer)
+				}
+				w.Write([]byte(jsonStr))
+			}
+		}
+
+		BeforeEach(func() {
+			url := "http://fake-registry.com"
+			registryURL = &url
+			dnsServer = nil
+		})
+
+		AfterEach(func() {
+			ts.Close()
+		})
+
+		Context("when server returns an HTTP Response with status code ==2xx (as defined by the request retryable) within 10 retries", func() {
+
+			BeforeEach(func() {
+				dnsResolver.RegisterRecord(fakeinf.FakeDNSRecord{
+					DNSServers: []string{"fake-dns-server-ip"},
+					Host:       "http://fake-registry.com",
+					IP:         "http://fake-registry-ip",
+				})
+			})
+
+			It("returns the successfully resolved registry endpoint", func() {
+				handler := http.HandlerFunc(createHandlerFunc(9))
+				ts = httptest.NewServer(handler)
+				metadataService = NewHTTPMetadataServiceWithCustomRetryDelay(ts.URL, metadataHeaders, "/user-data", "/instanceid", "/ssh-keys", dnsResolver, platform, logger, 0*time.Second)
+
+				endpoint, err := metadataService.GetRegistryEndpoint()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(endpoint).To(Equal("http://fake-registry.com"))
+			})
+
+		})
+
+		Context("when server returns an HTTP Response with status code !=2xx (as defined by the request retryable) more than 10 times", func() {
+			It("returns an error containing the HTTP Response", func() {
+				handler := http.HandlerFunc(createHandlerFunc(10))
+				ts = httptest.NewServer(handler)
+				metadataService = NewHTTPMetadataServiceWithCustomRetryDelay(ts.URL, metadataHeaders, "/user-data", "/instanceid", "/ssh-keys", dnsResolver, platform, logger, 0*time.Second)
+
+				_, err := metadataService.GetRegistryEndpoint()
+				Expect(err).ToNot(BeNil())
+				Expect(err.Error()).To(Equal(fmt.Sprintf("Getting user data: Getting user data from url %s/user-data: Request failed, response: Response{ StatusCode: 500, Status: '500 Internal Server Error' }", ts.URL)))
+			})
+
+		})
+
 	})
 }

--- a/infrastructure/instance_metadata_settings_source.go
+++ b/infrastructure/instance_metadata_settings_source.go
@@ -3,12 +3,12 @@ package infrastructure
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	boshplatform "github.com/cloudfoundry/bosh-agent/platform"
 	boshsettings "github.com/cloudfoundry/bosh-agent/settings"
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 	boshlog "github.com/cloudfoundry/bosh-utils/logger"
-	"time"
 )
 
 type InstanceMetadataSettingsSource struct {

--- a/infrastructure/instance_metadata_settings_source.go
+++ b/infrastructure/instance_metadata_settings_source.go
@@ -8,6 +8,7 @@ import (
 	boshsettings "github.com/cloudfoundry/bosh-agent/settings"
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 	boshlog "github.com/cloudfoundry/bosh-utils/logger"
+	"time"
 )
 
 type InstanceMetadataSettingsSource struct {
@@ -42,6 +43,29 @@ func NewInstanceMetadataSettingsSource(
 		// The HTTPMetadataService provides more functionality than we need (like custom DNS), so we
 		// pass zero values to the New function and only use its GetValueAtPath method.
 		metadataService: NewHTTPMetadataService(metadataHost, metadataHeaders, "", "", "", nil, platform, logger),
+	}
+}
+
+func NewInstanceMetadataSettingsSourceWithoutRetryDelay(
+	metadataHost string,
+	metadataHeaders map[string]string,
+	settingsPath string,
+	platform boshplatform.Platform,
+	logger boshlog.Logger,
+) *InstanceMetadataSettingsSource {
+	logTag := "InstanceMetadataSettingsSource"
+	return &InstanceMetadataSettingsSource{
+		metadataHost:    metadataHost,
+		metadataHeaders: metadataHeaders,
+		settingsPath:    settingsPath,
+
+		platform: platform,
+		logger:   logger,
+
+		logTag: logTag,
+		// The HTTPMetadataService provides more functionality than we need (like custom DNS), so we
+		// pass zero values to the New function and only use its GetValueAtPath method.
+		metadataService: NewHTTPMetadataServiceWithCustomRetryDelay(metadataHost, metadataHeaders, "", "", "", nil, platform, logger, 0*time.Second),
 	}
 }
 

--- a/infrastructure/instance_metadata_settings_source_test.go
+++ b/infrastructure/instance_metadata_settings_source_test.go
@@ -77,7 +77,7 @@ func describeInstanceMetadataSettingsSource() {
 		})
 
 		It("returns an error if reading from the instance metadata endpoint fails", func() {
-			metadataSource = NewInstanceMetadataSettingsSource("bad-registry-endpoint", metadataHeaders, settingsPath, platform, logger)
+			metadataSource = NewInstanceMetadataSettingsSourceWithoutRetryDelay("bad-registry-endpoint", metadataHeaders, settingsPath, platform, logger)
 			_, err := metadataSource.Settings()
 			Expect(err).To(HaveOccurred())
 		})

--- a/jobsupervisor/pipe/winsw_pipe_suite_test.go
+++ b/jobsupervisor/pipe/winsw_pipe_suite_test.go
@@ -15,6 +15,7 @@ var pathToPipeCLI string
 var GoSequencePath string
 var shell string
 var echoCmdArgs []string
+
 const echoOutput = "hello"
 
 func TestWinswPipe(t *testing.T) {


### PR DESCRIPTION
Each request to the metadata service is now potentially retried up to 10 times with a delay of 1 second, if the response is non-2xx. We reused the client retryable that is also used to check monit status for this.
The change affects at least the AWS, Google and OpenStack stemcell's metadata retrieval.
@evandbrown @ljfranklin @cppforlife Please let us know, if this a problem. At least for the Google CPI, which wraps the metadata service, this behavior could be deactivated.

[#133431439](https://www.pivotaltracker.com/story/show/133431439)