### PR TITLE
Move data in 64KB blocks when migrating persistent disks

### DIFF
--- a/platform/linux_platform.go
+++ b/platform/linux_platform.go
@@ -1132,7 +1132,7 @@ func (p linux) MigratePersistentDisk(fromMountPoint, toMountPoint string) (err e
 
 	// Golang does not implement a file copy that would allow us to preserve dates...
 	// So we have to shell out to tar to perform the copy instead of delegating to the FileSystem
-	tarCopy := fmt.Sprintf("(tar -C %s -cf - .) | (tar -C %s -xpf -)", fromMountPoint, toMountPoint)
+	tarCopy := fmt.Sprintf("(tar -C %s -b 128 -cf - .) | (tar -C %s -b 128 -xpf -)", fromMountPoint, toMountPoint)
 	_, _, _, err = p.cmdRunner.RunCommand("sh", "-c", tarCopy)
 	if err != nil {
 		err = bosherr.WrapError(err, "Copying files from old disk to new disk")

--- a/platform/linux_platform_test.go
+++ b/platform/linux_platform_test.go
@@ -2633,7 +2633,7 @@ Number  Start   End     Size    File system  Name             Flags
 			Expect(mounter.RemountAsReadonlyPath).To(Equal("/from/path"))
 
 			Expect(len(cmdRunner.RunCommands)).To(Equal(1))
-			Expect(cmdRunner.RunCommands[0]).To(Equal([]string{"sh", "-c", "(tar -C /from/path -cf - .) | (tar -C /to/path -xpf -)"}))
+			Expect(cmdRunner.RunCommands[0]).To(Equal([]string{"sh", "-c", "(tar -C /from/path -b 128 -cf - .) | (tar -C /to/path -b 128 -xpf -)"}))
 
 			Expect(mounter.UnmountPartitionPathOrMountPoint).To(Equal("/from/path"))
 			Expect(mounter.RemountFromMountPoint).To(Equal("/to/path"))


### PR DESCRIPTION
instead of using the default (10KB)

See #107