### PR TITLE
Clean up root_tmp during bootstrap

### DIFF
--- a/platform/linux_platform.go
+++ b/platform/linux_platform.go
@@ -852,6 +852,11 @@ func (p linux) SetupTmpDir() error {
 		return nil
 	}
 
+	err = p.fs.RemoveAll(boshRootTmpPath)
+	if err != nil {
+		return bosherr.WrapError(err, fmt.Sprintf("cleaning up %s", boshRootTmpPath))
+	}
+
 	_, _, _, err = p.cmdRunner.RunCommand("mkdir", "-p", boshRootTmpPath)
 	if err != nil {
 		return bosherr.WrapError(err, "Creating root tmp dir")

--- a/platform/linux_platform_test.go
+++ b/platform/linux_platform_test.go
@@ -1618,6 +1618,15 @@ Number  Start   End     Size    File system  Name             Flags
 				options.UseDefaultTmpDir = false
 			})
 
+			It("returns error when removing root_tmp dir", func() {
+				fs.RemoveAllStub = func(_ string) error {
+					return errors.New("fake-remove-all-error")
+				}
+
+				err := act()
+				Expect(err).To(HaveOccurred())
+			})
+
 			It("creates a root_tmp folder", func() {
 				err := act()
 				Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
For addressing [issue 110](https://github.com/cloudfoundry/bosh-agent/issues/110), clean up root_tmp before creating it during bootstrap.

/cc @maximilien 