### PR TITLE
Configure networking on the virtual machine for SoftLayer

### DIFF
--- a/factory/factory.go
+++ b/factory/factory.go
@@ -15,6 +15,8 @@ type Network struct {
 	DNS     *[]string
 
 	Mac string
+
+	LinkName string
 }
 
 func (n Network) Build() settings.Network {

--- a/settings/service.go
+++ b/settings/service.go
@@ -122,6 +122,10 @@ func (s *settingsService) GetSettings() Settings {
 	}
 	s.settingsMutex.Unlock()
 
+	if settingsCopy.Networks.HasLinkName() {
+		return settingsCopy
+	}
+
 	for networkName, network := range settingsCopy.Networks {
 		if !network.IsDHCP() {
 			continue

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -222,7 +222,8 @@ type Network struct {
 
 	Mac string `json:"mac"`
 
-	Preconfigured bool `json:"preconfigured"`
+	LinkName string `json:"link_name,omitempty"`
+	Routes   Routes `json:"routes,omitempty"`
 }
 
 type Networks map[string]Network
@@ -291,25 +292,25 @@ func (n Networks) IPs() (ips []string) {
 	return
 }
 
-func (n Networks) IsPreconfigured() bool {
+func (n Networks) HasLinkName() bool {
 	for _, network := range n {
 		if network.IsVIP() {
 			// Skip VIP networks since we do not configure interfaces for them
 			continue
 		}
 
-		if !network.Preconfigured {
-			return false
+		if network.LinkName != "" {
+			return true
 		}
 	}
 
-	return true
+	return false
 }
 
 func (n Network) String() string {
 	return fmt.Sprintf(
-		"type: '%s', ip: '%s', netmask: '%s', gateway: '%s', mac: '%s', resolved: '%t', preconfigured: '%t', use_dhcp: '%t'",
-		n.Type, n.IP, n.Netmask, n.Gateway, n.Mac, n.Resolved, n.Preconfigured, n.UseDHCP,
+		"type: '%s', ip: '%s', netmask: '%s', gateway: '%s', mac: '%s', resolved: '%t', use_dhcp: '%t', link_name: '%s'",
+		n.Type, n.IP, n.Netmask, n.Gateway, n.Mac, n.Resolved, n.UseDHCP, n.LinkName,
 	)
 }
 


### PR DESCRIPTION
To configure networking of the VM in SoftLayer is quite different with other IaaS, SoftLayer currently offers 2 different types of IP blocks, Static and Portable. For most cases, we are using Portable IPs to provision VM` networking. [https://knowledgelayer.softlayer.com/learning/virtual-machine-network-setup] is the reference we followed, in short, network configuration is done through a single configuration file and this file will need to be manually edited. In this PR, we implement bosh-agent to setup the networking by editing /etc/network/interfaces file. For example, 
```
Example public IP block – 192.0.2.0/29

·IP Address – 192.0.2.2
·Gateway – 192.0.2.1
·Subnet Mask – 255.255.255.248

Example private IP block – 10.0.0.0/29

·IP Address – 10.0.0.2
·Gateway – 10.0.0.1
·Subnet Mask – 255.255.255.248

Public and Private Network

Edit the following file with any text editor. Replace example IP addresses with the correct IP’s from your Public and Private IP blocks.

·/etc/network/interfaces
auto lo
iface lo inet loopback

auto eth1
iface eth1 inet static
address 192.0.2.2
netmask 255.255.255.248
gateway 192.0.2.1

auto eth0
iface eth0 inet static
address 10.0.0.2
netmask 255.255.255.248

#Static route for backend service network
up route add -net 10.0.0.0/8 gw 10.0.0.1
```

As the property `preconfigured` is no longer useful for SoftLayer, we get rid of it.
It includes two more properties in `network_settings`, `LinkName` and `Routes`.
About `Routes`,  it needs to setup persistent static route by SoftLayer, such as `setup persistent static route`, so we add this parameter to store this kind of static routes.
About `LinkName`, bosh-agent could detect mac address, and map interface name to network settings by mac address, but for SoftLayer, it is not entirely appropriate,  we use this property to indicate interface name, softlayer_cpi will propagate it through network_settings.