### PR TITLE
Registry settings fetcher retries on failure

### DIFF
--- a/infrastructure/complex_settings_source.go
+++ b/infrastructure/complex_settings_source.go
@@ -39,3 +39,7 @@ func (s ComplexSettingsSource) Settings() (boshsettings.Settings, error) {
 
 	return registry.GetSettings()
 }
+
+func (s ComplexSettingsSource) GetMetadataService() MetadataService {
+	return s.metadataService
+}

--- a/infrastructure/http_metadata_service_test.go
+++ b/infrastructure/http_metadata_service_test.go
@@ -416,7 +416,7 @@ func describeHTTPMetadataService() {
 
 				_, err := metadataService.GetRegistryEndpoint()
 				Expect(err).ToNot(BeNil())
-				Expect(err.Error()).To(Equal(fmt.Sprintf("Getting user data: Getting user data from url %s/user-data: Request failed, response: Response{ StatusCode: 500, Status: '500 Internal Server Error' }", ts.URL)))
+				Expect(err.Error()).To(Equal(fmt.Sprintf("Getting user data: Getting user data from url %s/user-data: Performing GET request: Request failed, response: Response{ StatusCode: 500, Status: '500 Internal Server Error' }", ts.URL)))
 			})
 
 		})

--- a/infrastructure/http_registry.go
+++ b/infrastructure/http_registry.go
@@ -10,6 +10,7 @@ import (
 	boshsettings "github.com/cloudfoundry/bosh-agent/settings"
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 	boshhttp "github.com/cloudfoundry/bosh-utils/http"
+	boshhttpclient "github.com/cloudfoundry/bosh-utils/httpclient"
 	boshlog "github.com/cloudfoundry/bosh-utils/logger"
 )
 
@@ -92,7 +93,8 @@ func (r httpRegistry) GetSettings() (boshsettings.Settings, error) {
 	}
 
 	settingsURL := fmt.Sprintf("%s/instances/%s/settings", registryEndpoint, identifier)
-	wrapperResponse, err := boshhttp.NewDefaultRetryClient(10, r.retryDelay, r.logger).Get(settingsURL)
+	retryClient := boshhttp.NewRetryClient(boshhttpclient.CreateDefaultClientInsecureSkipVerify(), 10, r.retryDelay, r.logger)
+	wrapperResponse, err := boshhttpclient.NewHTTPClient(retryClient, r.logger).Get(settingsURL)
 	if err != nil {
 		return settings, bosherr.WrapError(err, "Getting settings from url")
 	}

--- a/infrastructure/http_registry.go
+++ b/infrastructure/http_registry.go
@@ -4,28 +4,51 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"net/http"
+	"time"
 
 	boshplat "github.com/cloudfoundry/bosh-agent/platform"
 	boshsettings "github.com/cloudfoundry/bosh-agent/settings"
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
+	boshhttp "github.com/cloudfoundry/bosh-utils/http"
+	boshlog "github.com/cloudfoundry/bosh-utils/logger"
 )
 
 type httpRegistry struct {
 	metadataService   MetadataService
 	platform          boshplat.Platform
 	useServerNameAsID bool
+	logger            boshlog.Logger
+	retryDelay        time.Duration
+}
+
+func NewHTTPRegistryWithCustomDelay(
+	metadataService MetadataService,
+	platform boshplat.Platform,
+	useServerNameAsID bool,
+	logger boshlog.Logger,
+	retryDelay time.Duration,
+) Registry {
+	return httpRegistry{
+		metadataService:   metadataService,
+		platform:          platform,
+		useServerNameAsID: useServerNameAsID,
+		logger:            logger,
+		retryDelay:        retryDelay,
+	}
 }
 
 func NewHTTPRegistry(
 	metadataService MetadataService,
 	platform boshplat.Platform,
 	useServerNameAsID bool,
+	logger boshlog.Logger,
 ) Registry {
 	return httpRegistry{
 		metadataService:   metadataService,
 		platform:          platform,
 		useServerNameAsID: useServerNameAsID,
+		logger:            logger,
+		retryDelay:        1 * time.Second,
 	}
 }
 
@@ -69,7 +92,7 @@ func (r httpRegistry) GetSettings() (boshsettings.Settings, error) {
 	}
 
 	settingsURL := fmt.Sprintf("%s/instances/%s/settings", registryEndpoint, identifier)
-	wrapperResponse, err := http.Get(settingsURL)
+	wrapperResponse, err := boshhttp.NewDefaultRetryClient(10, r.retryDelay, r.logger).Get(settingsURL)
 	if err != nil {
 		return settings, bosherr.WrapError(err, "Getting settings from url")
 	}

--- a/infrastructure/http_registry.go
+++ b/infrastructure/http_registry.go
@@ -93,8 +93,8 @@ func (r httpRegistry) GetSettings() (boshsettings.Settings, error) {
 	}
 
 	settingsURL := fmt.Sprintf("%s/instances/%s/settings", registryEndpoint, identifier)
-	retryClient := boshhttp.NewRetryClient(boshhttpclient.CreateDefaultClientInsecureSkipVerify(), 10, r.retryDelay, r.logger)
-	wrapperResponse, err := boshhttpclient.NewHTTPClient(retryClient, r.logger).Get(settingsURL)
+	client := boshhttp.NewRetryClient(boshhttpclient.CreateDefaultClient(nil), 10, r.retryDelay, r.logger)
+	wrapperResponse, err := boshhttpclient.NewHTTPClient(client, r.logger).Get(settingsURL)
 	if err != nil {
 		return settings, bosherr.WrapError(err, "Getting settings from url")
 	}

--- a/infrastructure/http_registry_test.go
+++ b/infrastructure/http_registry_test.go
@@ -14,11 +14,15 @@ import (
 	fakeinf "github.com/cloudfoundry/bosh-agent/infrastructure/fakes"
 	fakeplat "github.com/cloudfoundry/bosh-agent/platform/fakes"
 	boshsettings "github.com/cloudfoundry/bosh-agent/settings"
+	boshlog "github.com/cloudfoundry/bosh-utils/logger"
+	"time"
 )
 
 var _ = Describe("httpRegistry", describeHTTPRegistry)
 
 func describeHTTPRegistry() {
+	logger := boshlog.NewLogger(boshlog.LevelNone)
+
 	var (
 		metadataService *fakeinf.FakeMetadataService
 		registry        Registry
@@ -28,7 +32,7 @@ func describeHTTPRegistry() {
 	BeforeEach(func() {
 		metadataService = &fakeinf.FakeMetadataService{}
 		platform = &fakeplat.FakePlatform{}
-		registry = NewHTTPRegistry(metadataService, platform, false)
+		registry = NewHTTPRegistry(metadataService, platform, false, logger)
 	})
 
 	Describe("GetSettings", func() {
@@ -37,145 +41,146 @@ func describeHTTPRegistry() {
 			settingsJSON string
 		)
 
-		BeforeEach(func() {
-			boshRegistryHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				GinkgoRecover()
-
-				Expect(r.Method).To(Equal("GET"))
-				Expect(r.URL.Path).To(Equal("/instances/fake-identifier/settings"))
-
-				w.Write([]byte(settingsJSON))
-			})
-
-			ts = httptest.NewServer(boshRegistryHandler)
-		})
-
-		AfterEach(func() {
-			ts.Close()
-		})
-
-		Describe("Network bootstrapping", func() {
+		Context("when server responds successfully to the first request", func() {
 			BeforeEach(func() {
-				settingsJSON = `{"settings": "{\"agent_id\":\"my-agent-id\"}"}`
-				metadataService.InstanceID = "fake-identifier"
-				metadataService.RegistryEndpoint = ts.URL
-				registry = NewHTTPRegistry(metadataService, platform, false)
+				boshRegistryHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					GinkgoRecover()
+
+					Expect(r.Method).To(Equal("GET"))
+					Expect(r.URL.Path).To(Equal("/instances/fake-identifier/settings"))
+
+					w.Write([]byte(settingsJSON))
+				})
+
+				ts = httptest.NewServer(boshRegistryHandler)
 			})
 
-			Context("when the metadata has Networks information", func() {
-				It("configures the network with those settings before hitting the registry", func() {
-					networkSettings := boshsettings.Networks{
-						"net1": boshsettings.Network{IP: "1.2.3.4"},
-						"net2": boshsettings.Network{IP: "2.3.4.5"},
-					}
-					metadataService.Networks = networkSettings
+			AfterEach(func() {
+				ts.Close()
+			})
 
-					_, err := registry.GetSettings()
+			Describe("Network bootstrapping", func() {
+				BeforeEach(func() {
+					settingsJSON = `{"settings": "{\"agent_id\":\"my-agent-id\"}"}`
+					metadataService.InstanceID = "fake-identifier"
+					metadataService.RegistryEndpoint = ts.URL
+					registry = NewHTTPRegistry(metadataService, platform, false, logger)
+				})
+
+				Context("when the metadata has Networks information", func() {
+					It("configures the network with those settings before hitting the registry", func() {
+						networkSettings := boshsettings.Networks{
+							"net1": boshsettings.Network{IP: "1.2.3.4"},
+							"net2": boshsettings.Network{IP: "2.3.4.5"},
+						}
+						metadataService.Networks = networkSettings
+
+						_, err := registry.GetSettings()
+						Expect(err).ToNot(HaveOccurred())
+
+						Expect(platform.SetupNetworkingCalled).To(BeTrue())
+						Expect(platform.SetupNetworkingNetworks).To(Equal(networkSettings))
+					})
+				})
+
+				Context("when the metadata has no Networks information", func() {
+					It("does no network configuration for now (the stemcell set up dhcp already)", func() {
+						metadataService.Networks = boshsettings.Networks{}
+
+						_, err := registry.GetSettings()
+						Expect(err).ToNot(HaveOccurred())
+
+						Expect(platform.SetupNetworkingCalled).To(BeFalse())
+					})
+				})
+
+				Context("when the metadata service fails to get Networks information", func() {
+					It("wraps the error", func() {
+						metadataService.Networks = boshsettings.Networks{}
+						metadataService.NetworksErr = errors.New("fake-get-networks-err")
+
+						_, err := registry.GetSettings()
+						Expect(err).To(HaveOccurred())
+
+						Expect(err.Error()).To(Equal("Getting networks: fake-get-networks-err"))
+					})
+				})
+
+				Context("when the SetupNetworking fails", func() {
+					It("wraps the error", func() {
+						networkSettings := boshsettings.Networks{
+							"net1": boshsettings.Network{IP: "1.2.3.4"},
+							"net2": boshsettings.Network{IP: "2.3.4.5"},
+						}
+						metadataService.Networks = networkSettings
+						platform.SetupNetworkingErr = errors.New("fake-setup-networking-error")
+
+						_, err := registry.GetSettings()
+						Expect(err).To(HaveOccurred())
+
+						Expect(err.Error()).To(Equal("Setting up networks: fake-setup-networking-error"))
+					})
+				})
+			})
+
+			Context("when registry is configured to not use server name as id", func() {
+				BeforeEach(func() {
+					registry = NewHTTPRegistry(metadataService, platform, false, logger)
+					metadataService.InstanceID = "fake-identifier"
+					metadataService.RegistryEndpoint = ts.URL
+				})
+
+				It("returns settings fetched from http server based on instance id", func() {
+					settingsJSON = `{"settings": "{\"agent_id\":\"my-agent-id\"}"}`
+
+					settings, err := registry.GetSettings()
 					Expect(err).ToNot(HaveOccurred())
-
-					Expect(platform.SetupNetworkingCalled).To(BeTrue())
-					Expect(platform.SetupNetworkingNetworks).To(Equal(networkSettings))
+					Expect(settings).To(Equal(boshsettings.Settings{AgentID: "my-agent-id"}))
 				})
-			})
 
-			Context("when the metadata has no Networks information", func() {
-				It("does no network configuration for now (the stemcell set up dhcp already)", func() {
-					metadataService.Networks = boshsettings.Networks{}
+				It("returns error if registry settings wrapper cannot be parsed", func() {
+					settingsJSON = "invalid-json"
 
-					_, err := registry.GetSettings()
-					Expect(err).ToNot(HaveOccurred())
-
-					Expect(platform.SetupNetworkingCalled).To(BeFalse())
-				})
-			})
-
-			Context("when the metadata service fails to get Networks information", func() {
-				It("wraps the error", func() {
-					metadataService.Networks = boshsettings.Networks{}
-					metadataService.NetworksErr = errors.New("fake-get-networks-err")
-
-					_, err := registry.GetSettings()
+					settings, err := registry.GetSettings()
 					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("Unmarshalling settings wrapper"))
 
-					Expect(err.Error()).To(Equal("Getting networks: fake-get-networks-err"))
+					Expect(settings).To(Equal(boshsettings.Settings{}))
 				})
-			})
 
-			Context("when the SetupNetworking fails", func() {
-				It("wraps the error", func() {
-					networkSettings := boshsettings.Networks{
-						"net1": boshsettings.Network{IP: "1.2.3.4"},
-						"net2": boshsettings.Network{IP: "2.3.4.5"},
-					}
-					metadataService.Networks = networkSettings
-					platform.SetupNetworkingErr = errors.New("fake-setup-networking-error")
+				It("returns error if registry settings wrapper contains invalid json", func() {
+					settingsJSON = `{"settings": "invalid-json"}`
 
-					_, err := registry.GetSettings()
+					settings, err := registry.GetSettings()
 					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("Unmarshalling wrapped settings"))
 
-					Expect(err.Error()).To(Equal("Setting up networks: fake-setup-networking-error"))
+					Expect(settings).To(Equal(boshsettings.Settings{}))
 				})
-			})
-		})
 
-		Context("when registry is configured to not use server name as id", func() {
-			BeforeEach(func() {
-				registry = NewHTTPRegistry(metadataService, platform, false)
-				metadataService.InstanceID = "fake-identifier"
-				metadataService.RegistryEndpoint = ts.URL
-			})
+				It("returns error if metadata service fails to return instance id", func() {
+					metadataService.GetInstanceIDErr = errors.New("fake-get-instance-id-err")
 
-			It("returns settings fetched from http server based on instance id", func() {
-				settingsJSON = `{"settings": "{\"agent_id\":\"my-agent-id\"}"}`
+					settings, err := registry.GetSettings()
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("fake-get-instance-id-err"))
 
-				settings, err := registry.GetSettings()
-				Expect(err).ToNot(HaveOccurred())
-				Expect(settings).To(Equal(boshsettings.Settings{AgentID: "my-agent-id"}))
-			})
+					Expect(settings).To(Equal(boshsettings.Settings{}))
+				})
 
-			It("returns error if registry settings wrapper cannot be parsed", func() {
-				settingsJSON = "invalid-json"
+				It("returns error if metadata service fails to return registry endpoint", func() {
+					metadataService.GetRegistryEndpointErr = errors.New("fake-get-registry-endpoint-err")
 
-				settings, err := registry.GetSettings()
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("Unmarshalling settings wrapper"))
+					settings, err := registry.GetSettings()
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("fake-get-registry-endpoint-err"))
 
-				Expect(settings).To(Equal(boshsettings.Settings{}))
-			})
+					Expect(settings).To(Equal(boshsettings.Settings{}))
+				})
 
-			It("returns error if registry settings wrapper contains invalid json", func() {
-				settingsJSON = `{"settings": "invalid-json"}`
-
-				settings, err := registry.GetSettings()
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("Unmarshalling wrapped settings"))
-
-				Expect(settings).To(Equal(boshsettings.Settings{}))
-			})
-
-			It("returns error if metadata service fails to return instance id", func() {
-				metadataService.GetInstanceIDErr = errors.New("fake-get-instance-id-err")
-
-				settings, err := registry.GetSettings()
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("fake-get-instance-id-err"))
-
-				Expect(settings).To(Equal(boshsettings.Settings{}))
-			})
-
-			It("returns error if metadata service fails to return registry endpoint", func() {
-				metadataService.GetRegistryEndpointErr = errors.New("fake-get-registry-endpoint-err")
-
-				settings, err := registry.GetSettings()
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("fake-get-registry-endpoint-err"))
-
-				Expect(settings).To(Equal(boshsettings.Settings{}))
-			})
-
-			Describe("setting fields", func() {
-				It("unmarshalls JSON properly", func() {
-					settingsJSON = `{
+				Describe("setting fields", func() {
+					It("unmarshalls JSON properly", func() {
+						settingsJSON = `{
 						"agent_id": "my-agent-id",
 						"blobstore": {
 							"options": {
@@ -224,118 +229,175 @@ func describeHTTPRegistry() {
 							"name": "vm-abc-def"
 						}
 					}`
-					settingsJSON = strings.Replace(settingsJSON, `"`, `\"`, -1)
-					settingsJSON = strings.Replace(settingsJSON, "\n", "", -1)
-					settingsJSON = strings.Replace(settingsJSON, "\t", "", -1)
-					settingsJSON = fmt.Sprintf(`{"settings": "%s"}`, settingsJSON)
+						settingsJSON = strings.Replace(settingsJSON, `"`, `\"`, -1)
+						settingsJSON = strings.Replace(settingsJSON, "\n", "", -1)
+						settingsJSON = strings.Replace(settingsJSON, "\t", "", -1)
+						settingsJSON = fmt.Sprintf(`{"settings": "%s"}`, settingsJSON)
 
-					expectedSettings := boshsettings.Settings{
-						AgentID: "my-agent-id",
-						Blobstore: boshsettings.Blobstore{
-							Type: "s3",
-							Options: map[string]interface{}{
-								"bucket_name":       "george",
-								"encryption_key":    "optional encryption key",
-								"access_key_id":     "optional access key id",
-								"secret_access_key": "optional secret access key",
-								"port":              443.0,
+						expectedSettings := boshsettings.Settings{
+							AgentID: "my-agent-id",
+							Blobstore: boshsettings.Blobstore{
+								Type: "s3",
+								Options: map[string]interface{}{
+									"bucket_name":       "george",
+									"encryption_key":    "optional encryption key",
+									"access_key_id":     "optional access key id",
+									"secret_access_key": "optional secret access key",
+									"port":              443.0,
+								},
 							},
-						},
-						Disks: boshsettings.Disks{
-							Ephemeral:  "/dev/sdb",
-							Persistent: map[string]interface{}{"vol-xxxxxx": "/dev/sdf"},
-							System:     "/dev/sda1",
-						},
-						Env: boshsettings.Env{
-							Bosh: boshsettings.BoshEnv{
-								Password:         "some encrypted password",
-								KeepRootPassword: false,
+							Disks: boshsettings.Disks{
+								Ephemeral:  "/dev/sdb",
+								Persistent: map[string]interface{}{"vol-xxxxxx": "/dev/sdf"},
+								System:     "/dev/sda1",
 							},
-						},
-						Networks: boshsettings.Networks{
-							"netA": boshsettings.Network{
-								Default: []string{"dns", "gateway"},
-								IP:      "ww.ww.ww.ww",
-								DNS:     []string{"xx.xx.xx.xx", "yy.yy.yy.yy"},
+							Env: boshsettings.Env{
+								Bosh: boshsettings.BoshEnv{
+									Password:         "some encrypted password",
+									KeepRootPassword: false,
+								},
 							},
-							"netB": boshsettings.Network{
-								DNS: []string{"zz.zz.zz.zz"},
+							Networks: boshsettings.Networks{
+								"netA": boshsettings.Network{
+									Default: []string{"dns", "gateway"},
+									IP:      "ww.ww.ww.ww",
+									DNS:     []string{"xx.xx.xx.xx", "yy.yy.yy.yy"},
+								},
+								"netB": boshsettings.Network{
+									DNS: []string{"zz.zz.zz.zz"},
+								},
 							},
-						},
-						Mbus: "https://vcap:b00tstrap@0.0.0.0:6868",
-						Ntp: []string{
-							"0.north-america.pool.ntp.org",
-							"1.north-america.pool.ntp.org",
-						},
-						VM: boshsettings.VM{
-							Name: "vm-abc-def",
-						},
-					}
+							Mbus: "https://vcap:b00tstrap@0.0.0.0:6868",
+							Ntp: []string{
+								"0.north-america.pool.ntp.org",
+								"1.north-america.pool.ntp.org",
+							},
+							VM: boshsettings.VM{
+								Name: "vm-abc-def",
+							},
+						}
 
-					metadataService.InstanceID = "fake-identifier"
+						metadataService.InstanceID = "fake-identifier"
+						metadataService.RegistryEndpoint = ts.URL
+
+						settings, err := registry.GetSettings()
+						Expect(err).ToNot(HaveOccurred())
+						Expect(settings).To(Equal(expectedSettings))
+					})
+				})
+			})
+
+			Context("when registry is configured to use server name as id", func() {
+				BeforeEach(func() {
+					registry = NewHTTPRegistry(metadataService, platform, true, logger)
+					metadataService.ServerName = "fake-identifier"
 					metadataService.RegistryEndpoint = ts.URL
+				})
+
+				It("returns settings fetched from http server based on server name", func() {
+					settingsJSON = `{"settings": "{\"agent_id\":\"my-agent-id\"}"}`
 
 					settings, err := registry.GetSettings()
 					Expect(err).ToNot(HaveOccurred())
-					Expect(settings).To(Equal(expectedSettings))
+					Expect(settings).To(Equal(boshsettings.Settings{AgentID: "my-agent-id"}))
+				})
+
+				It("returns error if registry settings wrapper cannot be parsed", func() {
+					settingsJSON = "invalid-json"
+
+					settings, err := registry.GetSettings()
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("Unmarshalling settings wrapper"))
+
+					Expect(settings).To(Equal(boshsettings.Settings{}))
+				})
+
+				It("returns error if registry settings wrapper contains invalid json", func() {
+					settingsJSON = `{"settings": "invalid-json"}`
+
+					settings, err := registry.GetSettings()
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("Unmarshalling wrapped settings"))
+
+					Expect(settings).To(Equal(boshsettings.Settings{}))
+				})
+
+				It("returns error if metadata service fails to return server name", func() {
+					metadataService.GetServerNameErr = errors.New("fake-get-server-name-err")
+
+					settings, err := registry.GetSettings()
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("fake-get-server-name-err"))
+
+					Expect(settings).To(Equal(boshsettings.Settings{}))
+				})
+
+				It("returns error if metadata service fails to return registry endpoint", func() {
+					metadataService.GetRegistryEndpointErr = errors.New("fake-get-registry-endpoint-err")
+
+					settings, err := registry.GetSettings()
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("fake-get-registry-endpoint-err"))
+
+					Expect(settings).To(Equal(boshsettings.Settings{}))
 				})
 			})
 		})
 
-		Context("when registry is configured to use server name as id", func() {
-			BeforeEach(func() {
-				registry = NewHTTPRegistry(metadataService, platform, true)
-				metadataService.ServerName = "fake-identifier"
+		Context("when server does not respond successfully to the first request", func() {
+			successfulAfter := func(count int) func(http.ResponseWriter, *http.Request) {
+				initialCount := 0
+				return func(w http.ResponseWriter, r *http.Request) {
+					if initialCount < count {
+						initialCount++
+						http.Error(w, http.StatusText(500), 500)
+						return
+					}
+
+					GinkgoRecover()
+
+					w.Write([]byte(settingsJSON))
+				}
+			}
+
+			var handlerFunc http.Handler
+
+			JustBeforeEach(func() {
+				settingsJSON = `{"settings": "{\"agent_id\":\"my-agent-id\"}"}`
+				ts = httptest.NewServer(handlerFunc)
+				registry = NewHTTPRegistryWithCustomDelay(metadataService, platform, false, logger, 0*time.Second)
+				metadataService.InstanceID = "fake-identifier"
 				metadataService.RegistryEndpoint = ts.URL
 			})
 
-			It("returns settings fetched from http server based on server name", func() {
-				settingsJSON = `{"settings": "{\"agent_id\":\"my-agent-id\"}"}`
-
-				settings, err := registry.GetSettings()
-				Expect(err).ToNot(HaveOccurred())
-				Expect(settings).To(Equal(boshsettings.Settings{AgentID: "my-agent-id"}))
+			AfterEach(func() {
+				ts.Close()
 			})
 
-			It("returns error if registry settings wrapper cannot be parsed", func() {
-				settingsJSON = "invalid-json"
+			Context("when server responds successfully within 10 retries", func() {
+				BeforeEach(func() {
+					handlerFunc = http.HandlerFunc(successfulAfter(9))
+				})
 
-				settings, err := registry.GetSettings()
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("Unmarshalling settings wrapper"))
-
-				Expect(settings).To(Equal(boshsettings.Settings{}))
+				It("returns settings fetched from http server", func() {
+					settings, err := registry.GetSettings()
+					Expect(err).ToNot(HaveOccurred())
+					Expect(settings).To(Equal(boshsettings.Settings{AgentID: "my-agent-id"}))
+				})
 			})
 
-			It("returns error if registry settings wrapper contains invalid json", func() {
-				settingsJSON = `{"settings": "invalid-json"}`
+			Context("when server does NOT respond successfully within 10 retries", func() {
+				BeforeEach(func() {
+					handlerFunc = http.HandlerFunc(successfulAfter(10))
+				})
 
-				settings, err := registry.GetSettings()
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("Unmarshalling wrapped settings"))
-
-				Expect(settings).To(Equal(boshsettings.Settings{}))
+				It("returns settings fetched from http server", func() {
+					_, err := registry.GetSettings()
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("Response{ StatusCode: 500, Status: '500 Internal Server Error' }"))
+				})
 			})
 
-			It("returns error if metadata service fails to return server name", func() {
-				metadataService.GetServerNameErr = errors.New("fake-get-server-name-err")
-
-				settings, err := registry.GetSettings()
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("fake-get-server-name-err"))
-
-				Expect(settings).To(Equal(boshsettings.Settings{}))
-			})
-
-			It("returns error if metadata service fails to return registry endpoint", func() {
-				metadataService.GetRegistryEndpointErr = errors.New("fake-get-registry-endpoint-err")
-
-				settings, err := registry.GetSettings()
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("fake-get-registry-endpoint-err"))
-
-				Expect(settings).To(Equal(boshsettings.Settings{}))
-			})
 		})
 	})
 }

--- a/infrastructure/registry_provider.go
+++ b/infrastructure/registry_provider.go
@@ -47,7 +47,7 @@ func (p *registryProvider) GetRegistry() (Registry, error) {
 
 	if strings.HasPrefix(registryEndpoint, "http") {
 		p.logger.Debug(p.logTag, "Using http registry at %s", registryEndpoint)
-		return NewHTTPRegistry(p.metadataService, p.platform, p.useServerName), nil
+		return NewHTTPRegistry(p.metadataService, p.platform, p.useServerName, p.logger), nil
 	}
 
 	p.logger.Debug(p.logTag, "Using file registry at %s", registryEndpoint)

--- a/infrastructure/registry_provider_test.go
+++ b/infrastructure/registry_provider_test.go
@@ -20,6 +20,7 @@ var _ = Describe("RegistryProvider", func() {
 		useServerName    bool
 		fs               *fakesys.FakeFileSystem
 		registryProvider RegistryProvider
+		logger           boshlog.Logger
 	)
 
 	BeforeEach(func() {
@@ -30,7 +31,7 @@ var _ = Describe("RegistryProvider", func() {
 	})
 
 	JustBeforeEach(func() {
-		logger := boshlog.NewLogger(boshlog.LevelNone)
+		logger = boshlog.NewLogger(boshlog.LevelNone)
 		registryProvider = NewRegistryProvider(metadataService, platform, useServerName, fs, logger)
 	})
 
@@ -46,7 +47,7 @@ var _ = Describe("RegistryProvider", func() {
 				It("returns an http registry that does not use server name as id", func() {
 					registry, err := registryProvider.GetRegistry()
 					Expect(err).ToNot(HaveOccurred())
-					Expect(registry).To(Equal(NewHTTPRegistry(metadataService, platform, false)))
+					Expect(registry).To(Equal(NewHTTPRegistry(metadataService, platform, false, logger)))
 				})
 			})
 
@@ -56,7 +57,7 @@ var _ = Describe("RegistryProvider", func() {
 				It("returns an http registry that uses server name as id", func() {
 					registry, err := registryProvider.GetRegistry()
 					Expect(err).ToNot(HaveOccurred())
-					Expect(registry).To(Equal(NewHTTPRegistry(metadataService, platform, true)))
+					Expect(registry).To(Equal(NewHTTPRegistry(metadataService, platform, true, logger)))
 				})
 			})
 		})

--- a/infrastructure/settings_source_factory_test.go
+++ b/infrastructure/settings_source_factory_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/cloudfoundry/bosh-agent/infrastructure"
 	fakeplat "github.com/cloudfoundry/bosh-agent/platform/fakes"
 	boshlog "github.com/cloudfoundry/bosh-utils/logger"
+	"reflect"
 )
 
 var _ = Describe("SettingsSourceFactory", func() {
@@ -42,15 +43,13 @@ var _ = Describe("SettingsSourceFactory", func() {
 					})
 
 					It("returns a settings source that uses HTTP to fetch settings", func() {
-						resolver := NewRegistryEndpointResolver(NewDigDNSResolver(platform.GetRunner(), logger))
-						httpMetadataService := NewHTTPMetadataService("http://fake-url", nil, "", "", "", resolver, platform, logger)
-						multiSourceMetadataService := NewMultiSourceMetadataService(httpMetadataService)
-						registryProvider := NewRegistryProvider(multiSourceMetadataService, platform, useServerName, platform.GetFs(), logger)
-						httpSettingsSource := NewComplexSettingsSource(multiSourceMetadataService, registryProvider, logger)
-
 						settingsSource, err := factory.New()
 						Expect(err).ToNot(HaveOccurred())
-						Expect(settingsSource).To(Equal(httpSettingsSource))
+
+						metadataService := settingsSource.(ComplexSettingsSource).GetMetadataService()
+						httpMetadataService := metadataService.(*MultiSourceMetadataService).Services[0]
+
+						Expect(reflect.TypeOf(httpMetadataService).Name()).To(Equal(reflect.TypeOf(HTTPMetadataService{}).Name()))
 					})
 				})
 

--- a/jobsupervisor/monit/monit_retry_client.go
+++ b/jobsupervisor/monit/monit_retry_client.go
@@ -34,7 +34,7 @@ func NewMonitRetryClient(
 }
 
 func (r *monitRetryClient) Do(req *http.Request) (*http.Response, error) {
-	requestRetryable := boshhttp.NewRequestRetryable(req, r.delegate, r.logger)
+	requestRetryable := boshhttp.NewRequestRetryable(req, r.delegate, r.logger, nil)
 	timeService := clock.NewClock()
 	retryStrategy := NewMonitRetryStrategy(
 		requestRetryable,

--- a/jobsupervisor/monit/monit_retry_client.go
+++ b/jobsupervisor/monit/monit_retry_client.go
@@ -34,7 +34,7 @@ func NewMonitRetryClient(
 }
 
 func (r *monitRetryClient) Do(req *http.Request) (*http.Response, error) {
-	requestRetryable := boshhttp.NewRequestRetryable(req, r.delegate, r.logger, nil)
+	requestRetryable := boshhttp.NewRequestRetryable(req, r.delegate, r.logger)
 	timeService := clock.NewClock()
 	retryStrategy := NewMonitRetryStrategy(
 		requestRetryable,


### PR DESCRIPTION
This change requires changes introduced to bosh-utils: https://github.com/cloudfoundry/bosh-utils/pull/8. Please merge that one first, and bump bosh-utils in bosh-agent before merging this PR.

- make fetching from registry settings more
  resilient by using the RetryClient
- retry 10 times with 1s delay

[#135338075](https://www.pivotaltracker.com/story/show/135338075)

Signed-off-by: Beyhan Veli <beyhan.veli@sap.com>