### PR TITLE
take desiredSwapSizeInBytes into account when partitioning root device

### DIFF
--- a/platform/linux_platform.go
+++ b/platform/linux_platform.go
@@ -578,7 +578,7 @@ func (p linux) SetupEphemeralDiskWithPath(realPath string, desiredSwapSizeInByte
 			return bosherr.Error("No ephemeral disk found, cannot use root partition as ephemeral disk")
 		}
 
-		swapPartitionPath, dataPartitionPath, err = p.createEphemeralPartitionsOnRootDevice()
+		swapPartitionPath, dataPartitionPath, err = p.createEphemeralPartitionsOnRootDevice(desiredSwapSizeInBytes)
 		if err != nil {
 			return bosherr.WrapError(err, "Creating ephemeral partitions on root device")
 		}
@@ -1310,7 +1310,7 @@ func (p linux) findRootDevicePathAndNumber() (string, int, error) {
 	return "", 0, bosherr.Error("Getting root partition device")
 }
 
-func (p linux) createEphemeralPartitionsOnRootDevice() (string, string, error) {
+func (p linux) createEphemeralPartitionsOnRootDevice(desiredSwapSizeInBytes *uint64) (string, string, error) {
 	p.logger.Info(logTag, "Creating swap & ephemeral partitions on root disk...")
 	p.logger.Debug(logTag, "Determining root device")
 
@@ -1331,14 +1331,28 @@ func (p linux) createEphemeralPartitionsOnRootDevice() (string, string, error) {
 	}
 
 	p.logger.Debug(logTag, "Calculating partition sizes of `%s', remaining size: %dB", rootDevicePath, remainingSizeInBytes)
-	swapSizeInBytes, linuxSizeInBytes, err := p.calculateEphemeralDiskPartitionSizes(remainingSizeInBytes, nil)
+	swapSizeInBytes, linuxSizeInBytes, err := p.calculateEphemeralDiskPartitionSizes(remainingSizeInBytes, desiredSwapSizeInBytes)
 	if err != nil {
 		return "", "", bosherr.WrapError(err, "Calculating partition sizes")
 	}
 
-	partitions := []boshdisk.Partition{
-		{SizeInBytes: swapSizeInBytes, Type: boshdisk.PartitionTypeSwap},
-		{SizeInBytes: linuxSizeInBytes, Type: boshdisk.PartitionTypeLinux},
+	var partitions []boshdisk.Partition
+	var swapPartitionPath string
+	var dataPartitionPath string
+
+	if swapSizeInBytes == 0 {
+		partitions = []boshdisk.Partition{
+			{SizeInBytes: linuxSizeInBytes, Type: boshdisk.PartitionTypeLinux},
+		}
+		swapPartitionPath = ""
+		dataPartitionPath := rootDevicePath + strconv.Itoa(rootDeviceNumber+1)
+	} else {
+		partitions = []boshdisk.Partition{
+			{SizeInBytes: swapSizeInBytes, Type: boshdisk.PartitionTypeSwap},
+			{SizeInBytes: linuxSizeInBytes, Type: boshdisk.PartitionTypeLinux},
+		}
+		swapPartitionPath := rootDevicePath + strconv.Itoa(rootDeviceNumber+1)
+		dataPartitionPath := rootDevicePath + strconv.Itoa(rootDeviceNumber+2)
 	}
 
 	for _, partition := range partitions {
@@ -1350,8 +1364,6 @@ func (p linux) createEphemeralPartitionsOnRootDevice() (string, string, error) {
 		return "", "", bosherr.WrapErrorf(err, "Partitioning root device `%s'", rootDevicePath)
 	}
 
-	swapPartitionPath := rootDevicePath + strconv.Itoa(rootDeviceNumber+1)
-	dataPartitionPath := rootDevicePath + strconv.Itoa(rootDeviceNumber+2)
 	return swapPartitionPath, dataPartitionPath, nil
 }
 


### PR DESCRIPTION
We're currently working on a Kubernetes bosh-release. We noticed some warnings that with Kubernetes 1.6 swap will be a fatal error.

`W0308 08:27:30.075226 6465 container_manager_linux.go:205] Running with swap on is not supported, please disable swap! This will be a fatal error by default starting in K8s v1.6! In the meantime, you can opt-in to making this a fatal e`

Therefore we set "env.bosh.swap_size: 0" (stemcell 3363.12), but our bosh vms are still getting swap space. This is probably because the ephemeral path is not recognized and therefore we use [p.createEphemeralPartitionsOnRootDevice](https://github.com/cloudfoundry/bosh-agent/blob/master/platform/linux_platform.go#L581) instead of p.partitionEphemeralDisk.

@tjvman  Maybe there is a reason why desiredSwapSizeInBytes is not considered in createEphemeralPartitionsOnRootDevice but since I don't see why, I propose this PR.

The feature to define swap size was introduced with this commit [066ddb38409e217a06618643e223e9d4f30685fc](https://github.com/cloudfoundry/bosh-agent/commit/066ddb38409e217a06618643e223e9d4f30685fc).