### PR TITLE
Allow overriding source volume readahead during persistent disk migration

### DIFF
--- a/agent/bootstrap.go
+++ b/agent/bootstrap.go
@@ -131,6 +131,11 @@ func (boot bootstrap) Run() (err error) {
 		return bosherr.WrapError(err, "Setting up blobs dir")
 	}
 
+	ra := settings.GetPersistentDiskMigrationReadahead()
+	if err = boot.platform.SetPersistentDiskMigrationReadahead(ra); err != nil {
+		return bosherr.WrapError(err, "Setting persistent disk migration readahead")
+	}
+
 	if err = boot.comparePersistentDisk(); err != nil {
 		return bosherr.WrapError(err, "Comparing persistent disks")
 	}

--- a/agent/bootstrap_test.go
+++ b/agent/bootstrap_test.go
@@ -404,6 +404,16 @@ func init() {
 				})
 			})
 
+			Describe("sets migration readahead", func() {
+				It("propagates disk migration readahead", func() {
+					settingsService.Settings.Env.Bosh.PersistentDiskMigrationReadahead = 1024
+					err := bootstrap()
+					Expect(err).NotTo(HaveOccurred())
+					Expect(platform.SetPersistentDiskMigrationReadaheadCalled).To(BeTrue())
+					Expect(platform.SetPersistentDiskMigrationReadaheadValue).To(Equal(1024))
+				})
+			})
+
 			Describe("checking persistent disks", func() {
 				Context("managed persistent disk", func() {
 					BeforeEach(func() {

--- a/micro/https_handler_test.go
+++ b/micro/https_handler_test.go
@@ -107,6 +107,7 @@ var _ = Describe("HTTPSHandler", func() {
 				fs.WriteFileString(blobPath, "Some data")
 
 				httpResponse, err := httpClient.Get(serverURL + "/blobs/a5/123-456-789")
+				Expect(err).ToNot(HaveOccurred())
 
 				defer httpResponse.Body.Close()
 				fileStats, err := fs.FindFileStats(blobPath)

--- a/platform/dummy_platform.go
+++ b/platform/dummy_platform.go
@@ -487,3 +487,7 @@ func (p dummyPlatform) existingMounts() ([]mount, error) {
 func (p dummyPlatform) SetupRecordsJSONPermission(path string) error {
 	return nil
 }
+
+func (p dummyPlatform) SetPersistentDiskMigrationReadahead(_ int) error {
+	return nil
+}

--- a/platform/fakes/fake_platform.go
+++ b/platform/fakes/fake_platform.go
@@ -162,6 +162,10 @@ type FakePlatform struct {
 
 	SetupRecordsJSONPermissionPath string
 	SetupRecordsJSONPermissionErr  error
+
+	SetPersistentDiskMigrationReadaheadCalled bool
+	SetPersistentDiskMigrationReadaheadValue  int
+	SetPersistentDiskMigrationReadaheadErr    error
 }
 
 func NewFakePlatform() (platform *FakePlatform) {
@@ -491,4 +495,10 @@ func (p *FakePlatform) AssociateDiskArgsForCall(i int) (string, boshsettings.Dis
 func (p *FakePlatform) SetupRecordsJSONPermission(path string) error {
 	p.SetupRecordsJSONPermissionPath = path
 	return p.SetupRecordsJSONPermissionErr
+}
+
+func (p *FakePlatform) SetPersistentDiskMigrationReadahead(readahead int) error {
+	p.SetPersistentDiskMigrationReadaheadCalled = true
+	p.SetPersistentDiskMigrationReadaheadValue = readahead
+	return p.SetPersistentDiskMigrationReadaheadErr
 }

--- a/platform/platform_interface.go
+++ b/platform/platform_interface.go
@@ -59,6 +59,7 @@ type Platform interface {
 	SetupLogDir() (err error)
 	SetupLoggingAndAuditing() (err error)
 	SetupRecordsJSONPermission(path string) error
+	SetPersistentDiskMigrationReadahead(readahead int) error
 
 	// Disk management
 	MountPersistentDisk(diskSettings boshsettings.DiskSettings, mountPoint string) error

--- a/platform/windows_platform.go
+++ b/platform/windows_platform.go
@@ -365,3 +365,7 @@ func (p WindowsPlatform) DeleteARPEntryWithIP(ip string) error {
 func (p WindowsPlatform) SetupRecordsJSONPermission(path string) error {
 	return nil
 }
+
+func (p WindowsPlatform) SetPersistentDiskMigrationReadahead(_ int) error {
+	return nil
+}

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -156,6 +156,10 @@ func (s Settings) RawEphemeralDiskSettings() (devices []DiskSettings) {
 	return s.Disks.RawEphemeral
 }
 
+func (s Settings) GetPersistentDiskMigrationReadahead() int {
+	return s.Env.Bosh.PersistentDiskMigrationReadahead
+}
+
 func (s Settings) GetMbusURL() string {
 	if s.Env.Bosh.Mbus != nil && len(s.Env.Bosh.Mbus.URL) > 0 {
 		return s.Env.Bosh.Mbus.URL
@@ -202,13 +206,14 @@ func (e Env) IsNatsTLSSupported() bool {
 }
 
 type BoshEnv struct {
-	Password              string   `json:"password"`
-	KeepRootPassword      bool     `json:"keep_root_password"`
-	RemoveDevTools        bool     `json:"remove_dev_tools"`
-	RemoveStaticLibraries bool     `json:"remove_static_libraries"`
-	AuthorizedKeys        []string `json:"authorized_keys"`
-	SwapSizeInMB          *uint64  `json:"swap_size"`
-	Mbus                  *MBus    `json:"mbus"`
+	Password                         string   `json:"password"`
+	KeepRootPassword                 bool     `json:"keep_root_password"`
+	RemoveDevTools                   bool     `json:"remove_dev_tools"`
+	RemoveStaticLibraries            bool     `json:"remove_static_libraries"`
+	AuthorizedKeys                   []string `json:"authorized_keys"`
+	SwapSizeInMB                     *uint64  `json:"swap_size"`
+	Mbus                             *MBus    `json:"mbus"`
+	PersistentDiskMigrationReadahead int      `json:"persistent_disk_migration_readahead"`
 }
 
 type DNSRecords struct {

--- a/settings/settings_test.go
+++ b/settings/settings_test.go
@@ -651,6 +651,7 @@ var _ = Describe("Settings", func() {
 			Expect(*env.GetSwapSizeInBytes()).To(Equal(uint64(2048 * 1024 * 1024)))
 			Expect(*env.GetSwapSizeInBytes()).To(Equal(uint64(2048 * 1024 * 1024)))
 			Expect(*env.GetSwapSizeInBytes()).To(Equal(uint64(2048 * 1024 * 1024)))
+			Expect(env.Bosh.PersistentDiskMigrationReadahead).To(BeZero())
 		})
 		Context("when swap_size is not specified in the json", func() {
 			It("unmarshalls correctly", func() {
@@ -661,6 +662,17 @@ var _ = Describe("Settings", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(env.GetSwapSizeInBytes()).To(BeNil())
+			})
+		})
+		Context("when persistent_disk_migration_readahead is specified in the json", func() {
+			It("unmarshalls correctly", func() {
+				var env Env
+				envJSON := `{"bosh": {"password": "fake-password", "keep_root_password": false, "remove_dev_tools": true, "authorized_keys": ["fake-key"], "persistent_disk_migration_readahead": 1024}}`
+
+				err := json.Unmarshal([]byte(envJSON), &env)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(env.Bosh.PersistentDiskMigrationReadahead).To(Equal(1024))
 			})
 		})
 


### PR DESCRIPTION
This implements the workaround discussed in https://github.com/cloudfoundry/bosh-agent/issues/107#issuecomment-282908446. We have validated that raising readahead consistently gives a 3-4x improvement in migration throughput in our vSphere infrastructure.

Unit tests are passing and the approach has been validated, but we're currently unable to run the full bosh acceptance test suite.