### PR TITLE
allow enabling of ipv6 through env.bosh.ipv6.enable=true

### DIFF
--- a/agent/bootstrap.go
+++ b/agent/bootstrap.go
@@ -81,6 +81,10 @@ func (boot bootstrap) Run() (err error) {
 		return bosherr.WrapError(err, "Settings user password")
 	}
 
+	if err = boot.platform.SetupIPv6(settings.Env.Bosh.IPv6); err != nil {
+		return bosherr.WrapError(err, "Setting up IPv6")
+	}
+
 	if err = boot.platform.SetupHostname(settings.AgentID); err != nil {
 		return bosherr.WrapError(err, "Setting up hostname")
 	}

--- a/agent/bootstrap_test.go
+++ b/agent/bootstrap_test.go
@@ -152,6 +152,14 @@ func init() {
 				})
 			})
 
+			It("sets up ipv6", func() {
+				settingsService.Settings.Env.Bosh.IPv6.Enable = true
+
+				err := bootstrap()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(platform.SetupIPv6Config).To(Equal(boshsettings.IPv6{Enable: true}))
+			})
+
 			It("sets up hostname", func() {
 				settingsService.Settings.AgentID = "foo-bar-baz-123"
 

--- a/platform/dummy_platform.go
+++ b/platform/dummy_platform.go
@@ -147,6 +147,10 @@ func (p dummyPlatform) SaveDNSRecords(dnsRecords boshsettings.DNSRecords, hostna
 	return p.fs.WriteFileString(etcHostsPath, dnsRecordsContents.String())
 }
 
+func (p dummyPlatform) SetupIPv6(config boshsettings.IPv6) error {
+	return nil
+}
+
 func (p dummyPlatform) SetupHostname(hostname string) (err error) {
 	return
 }

--- a/platform/fakes/fake_platform.go
+++ b/platform/fakes/fake_platform.go
@@ -48,6 +48,9 @@ type FakePlatform struct {
 	UserPasswords         map[string]string
 	SetupHostnameHostname string
 
+	SetupIPv6Config boshsettings.IPv6
+	SetupIPv6Error  error
+
 	SaveDNSRecordsError      error
 	SaveDNSRecordsHostname   string
 	SaveDNSRecordsDNSRecords boshsettings.DNSRecords
@@ -274,6 +277,11 @@ func (p *FakePlatform) SaveDNSRecords(dnsRecords boshsettings.DNSRecords, hostna
 	p.SaveDNSRecordsDNSRecords = dnsRecords
 	p.SaveDNSRecordsHostname = hostname
 	return p.SaveDNSRecordsError
+}
+
+func (p *FakePlatform) SetupIPv6(config boshsettings.IPv6) error {
+	p.SetupIPv6Config = config
+	return p.SetupIPv6Error
 }
 
 func (p *FakePlatform) SetupHostname(hostname string) (err error) {

--- a/platform/linux_platform.go
+++ b/platform/linux_platform.go
@@ -465,6 +465,10 @@ func (p linux) SaveDNSRecords(dnsRecords boshsettings.DNSRecords, hostname strin
 	return nil
 }
 
+func (p linux) SetupIPv6(config boshsettings.IPv6) error {
+	return p.netManager.SetupIPv6(config, nil)
+}
+
 func (p linux) SetupHostname(hostname string) error {
 	if !p.state.Linux.HostsConfigured {
 		_, _, _, err := p.cmdRunner.RunCommand("hostname", hostname)

--- a/platform/linux_platform_test.go
+++ b/platform/linux_platform_test.go
@@ -2993,6 +2993,19 @@ unit: sectors
 		})
 	})
 
+	Describe("SetupIPv6", func() {
+		It("delegates to the NetManager", func() {
+			netManager.SetupIPv6Err = errors.New("fake-err")
+
+			err := platform.SetupIPv6(boshsettings.IPv6{Enable: true})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("fake-err"))
+
+			Expect(netManager.SetupIPv6Config).To(Equal(boshsettings.IPv6{Enable: true}))
+			Expect(netManager.SetupIPv6StopCh).To(BeNil())
+		})
+	})
+
 	Describe("SetupNetworking", func() {
 		It("delegates to the NetManager", func() {
 			networks := boshsettings.Networks{}

--- a/platform/net/centos_net_manager.go
+++ b/platform/net/centos_net_manager.go
@@ -50,6 +50,8 @@ func NewCentosNetManager(
 	}
 }
 
+func (net centosNetManager) SetupIPv6(_ boshsettings.IPv6, _ <-chan struct{}) error { return nil }
+
 func (net centosNetManager) SetupNetworking(networks boshsettings.Networks, errCh chan error) error {
 	nonVipNetworks := boshsettings.Networks{}
 	for networkName, networkSettings := range networks {

--- a/platform/net/fakes/fake_net_manager.go
+++ b/platform/net/fakes/fake_net_manager.go
@@ -10,11 +10,21 @@ type FakeManager struct {
 	SetupNetworkingNetworks boshsettings.Networks
 	SetupNetworkingErr      error
 
+	SetupIPv6Config boshsettings.IPv6
+	SetupIPv6StopCh <-chan struct{}
+	SetupIPv6Err    error
+
 	GetConfiguredNetworkInterfacesInterfaces []string
 	GetConfiguredNetworkInterfacesErr        error
 
 	SetupDhcpNetworks boshsettings.Networks
 	SetupDhcpErr      error
+}
+
+func (net *FakeManager) SetupIPv6(config boshsettings.IPv6, stopCh <-chan struct{}) error {
+	net.SetupIPv6Config = config
+	net.SetupIPv6StopCh = stopCh
+	return net.SetupIPv6Err
 }
 
 func (net *FakeManager) SetupNetworking(networks boshsettings.Networks, errCh chan error) error {

--- a/platform/net/net_manager_interface.go
+++ b/platform/net/net_manager_interface.go
@@ -12,4 +12,6 @@ type Manager interface {
 
 	// Returns the list of interfaces that have configurations for them present
 	GetConfiguredNetworkInterfaces() ([]string, error)
+
+	SetupIPv6(boshsettings.IPv6, <-chan struct{}) error
 }

--- a/platform/net/ubuntu_net_manager.go
+++ b/platform/net/ubuntu_net_manager.go
@@ -85,6 +85,59 @@ func (net UbuntuNetManager) ComputeNetworkConfig(networks boshsettings.Networks)
 	return staticConfigs, dhcpConfigs, dnsServers, nil
 }
 
+func (net UbuntuNetManager) SetupIPv6(config boshsettings.IPv6, stopCh <-chan struct{}) error {
+	const (
+		grubConfPath       = "/boot/grub/grub.conf"
+		grubIPv6DisableOpt = "ipv6.disable=1"
+	)
+
+	if !config.Enable {
+		return nil
+	}
+
+	grubConf, err := net.fs.ReadFileString(grubConfPath)
+	if err != nil {
+		return bosherr.WrapError(err, "Reading grub")
+	}
+
+	if strings.Contains(grubConf, grubIPv6DisableOpt) {
+		grubConf = strings.Replace(grubConf, grubIPv6DisableOpt, "", -1)
+
+		err = net.fs.WriteFileString(grubConfPath, grubConf)
+		if err != nil {
+			return bosherr.WrapError(err, "Writing grub.conf")
+		}
+
+		net.logger.Info(UbuntuNetManagerLogTag, "Rebooting to enable IPv6 in kernel")
+
+		_, _, _, err = net.cmdRunner.RunCommand("shutdown", "-r", "now")
+		if err != nil {
+			return bosherr.WrapError(err, "Rebooting for IPv6")
+		}
+
+		// Wait here for the OS to reboot the machine
+		<-stopCh
+
+		return nil
+	}
+
+	ipv6Sysctls := []string{
+		"net.ipv6.conf.all.accept_ra=1",
+		"net.ipv6.conf.default.accept_ra=1",
+		"net.ipv6.conf.all.disable_ipv6=0",
+		"net.ipv6.conf.default.disable_ipv6=0",
+	}
+
+	for _, sysctl := range ipv6Sysctls {
+		_, _, _, err := net.cmdRunner.RunCommand("sysctl", sysctl)
+		if err != nil {
+			return bosherr.WrapError(err, "Running IPv6 sysctl")
+		}
+	}
+
+	return nil
+}
+
 func (net UbuntuNetManager) SetupNetworking(networks boshsettings.Networks, errCh chan error) error {
 	if networks.IsPreconfigured() {
 		// Note in this case IPs are not broadcasted

--- a/platform/net/windows_net_manager.go
+++ b/platform/net/windows_net_manager.go
@@ -119,6 +119,8 @@ func (net WindowsNetManager) ComputeNetworkConfig(networks boshsettings.Networks
 
 }
 
+func (net WindowsNetManager) SetupIPv6(_ boshsettings.IPv6, _ <-chan struct{}) error { return nil }
+
 func (net WindowsNetManager) SetupNetworking(networks boshsettings.Networks, errCh chan error) error {
 	nonVipNetworks := boshsettings.Networks{}
 	for networkName, networkSettings := range networks {

--- a/platform/platform_interface.go
+++ b/platform/platform_interface.go
@@ -43,6 +43,7 @@ type Platform interface {
 	SetupRootDisk(ephemeralDiskPath string) (err error)
 	SetupSSH(publicKey []string, username string) (err error)
 	SetUserPassword(user, encryptedPwd string) (err error)
+	SetupIPv6(boshsettings.IPv6) error
 	SetupHostname(hostname string) (err error)
 	SetupNetworking(networks boshsettings.Networks) (err error)
 	SetupLogrotate(groupName, basePath, size string) (err error)

--- a/platform/windows_platform.go
+++ b/platform/windows_platform.go
@@ -171,6 +171,10 @@ func (p WindowsPlatform) SaveDNSRecords(dnsRecords boshsettings.DNSRecords, host
 	return
 }
 
+func (p WindowsPlatform) SetupIPv6(config boshsettings.IPv6) error {
+	return nil
+}
+
 func (p WindowsPlatform) SetupHostname(hostname string) (err error) {
 	return
 }

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -202,11 +202,17 @@ type BoshEnv struct {
 	Mbus                  struct {
 		Cert CertKeyPair `json:"cert"`
 	} `json:"mbus"`
+
+	IPv6 IPv6 `json:"ipv6"`
 }
 
 type CertKeyPair struct {
 	PrivateKey  string `json:"private_key"`
 	Certificate string `json:"certificate"`
+}
+
+type IPv6 struct {
+	Enable bool `json:"enable"`
 }
 
 type DNSRecords struct {

--- a/settings/settings_test.go
+++ b/settings/settings_test.go
@@ -656,6 +656,7 @@ var _ = Describe("Settings", func() {
 			Expect(env.GetPassword()).To(Equal("fake-password"))
 			Expect(env.GetKeepRootPassword()).To(BeFalse())
 			Expect(env.GetRemoveDevTools()).To(BeTrue())
+			Expect(env.Bosh.IPv6).To(Equal(IPv6{}))
 			Expect(env.GetAuthorizedKeys()).To(ConsistOf("fake-key"))
 			Expect(*env.GetSwapSizeInBytes()).To(Equal(uint64(2048 * 1024 * 1024)))
 		})
@@ -688,6 +689,18 @@ var _ = Describe("Settings", func() {
 			Expect(env.Bosh.Mbus.Cert.PrivateKey).To(Equal("fake-private-key-pem"))
 			Expect(env.Bosh.Mbus.Cert.Certificate).To(Equal("fake-certificate-pem"))
 			Expect(*env.GetSwapSizeInBytes()).To(Equal(uint64(2048 * 1024 * 1024)))
+		})
+
+		It("can enable ipv6", func() {
+			env := Env{}
+			err := json.Unmarshal([]byte(`{"bosh": {} }`), &env)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(env.Bosh.IPv6).To(Equal(IPv6{}))
+
+			env = Env{}
+			err = json.Unmarshal([]byte(`{"bosh": {"ipv6": {"enable": true} } }`), &env)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(env.Bosh.IPv6).To(Equal(IPv6{Enable: true}))
 		})
 
 		Context("when swap_size is not specified in the json", func() {


### PR DESCRIPTION
Users can force Ubuntu machines to enable IPv6 at the kernel level through agent setting:

```yaml
instance_groups:
- name: my-stuff
  env:
    bosh:
      ipv6:
        enable: true
```