### PR TITLE
Add vm uptime information into vitals

### DIFF
--- a/agent/heartbeat_test.go
+++ b/agent/heartbeat_test.go
@@ -32,7 +32,7 @@ func init() {
 					NodeID: "node-id",
 				}
 
-				expectedJSON := `{"deployment":"FakeDeployment","job":"foo","index":0,"job_state":"running","vitals":{"cpu":{},"disk":{"ephemeral":{},"persistent":{},"system":{}},"mem":{},"swap":{}},"node_id":"node-id"}`
+				expectedJSON := `{"deployment":"FakeDeployment","job":"foo","index":0,"job_state":"running","vitals":{"cpu":{},"disk":{"ephemeral":{},"persistent":{},"system":{}},"mem":{},"swap":{},"uptime":{}},"node_id":"node-id"}`
 
 				hbBytes, err := json.Marshal(hb)
 				Expect(err).ToNot(HaveOccurred())
@@ -55,7 +55,7 @@ func init() {
 					NodeID: "node-id",
 				}
 
-				expectedJSON := `{"deployment":"FakeDeployment","job":null,"index":null,"job_state":"running","vitals":{"cpu":{},"disk":{"ephemeral":{},"persistent":{},"system":{}},"mem":{},"swap":{}},"node_id":"node-id"}`
+				expectedJSON := `{"deployment":"FakeDeployment","job":null,"index":null,"job_state":"running","vitals":{"cpu":{},"disk":{"ephemeral":{},"persistent":{},"system":{}},"mem":{},"swap":{},"uptime":{}},"node_id":"node-id"}`
 
 				hbBytes, err := json.Marshal(hb)
 				Expect(err).ToNot(HaveOccurred())

--- a/platform/stats/dummy_stats_collector.go
+++ b/platform/stats/dummy_stats_collector.go
@@ -38,7 +38,7 @@ func (p dummyStatsCollector) GetDiskStats(devicePath string) (stats DiskStats, e
 	return
 }
 
-func (p dummyStatsCollector) GetVMStats() (stats VMStats, err error) {
-	stats.Uptime.Seconds = 5
+func (p dummyStatsCollector) GetUptimeStats() (stats UptimeStats, err error) {
+	stats.Secs = 5
 	return
 }

--- a/platform/stats/dummy_stats_collector.go
+++ b/platform/stats/dummy_stats_collector.go
@@ -37,3 +37,8 @@ func (p dummyStatsCollector) GetDiskStats(devicePath string) (stats DiskStats, e
 	stats.InodeUsage.Total = 1
 	return
 }
+
+func (p dummyStatsCollector) GetVMStats() (stats VMStats, err error) {
+	stats.Uptime.Seconds = 5
+	return
+}

--- a/platform/stats/fakes/fake_stats_collector.go
+++ b/platform/stats/fakes/fake_stats_collector.go
@@ -19,7 +19,7 @@ type FakeCollector struct {
 	SwapStats boshstats.Usage
 	DiskStats map[string]boshstats.DiskStats
 
-	VMStats boshstats.VMStats
+	UptimeStats boshstats.UptimeStats
 }
 
 func (c *FakeCollector) StartCollecting(collectionInterval time.Duration, latestGotUpdated chan struct{}) {
@@ -53,7 +53,7 @@ func (c *FakeCollector) GetDiskStats(devicePath string) (stats boshstats.DiskSta
 	return
 }
 
-func (c *FakeCollector) GetVMStats() (stats boshstats.VMStats, err error) {
-	stats = c.VMStats
+func (c *FakeCollector) GetUptimeStats() (stats boshstats.UptimeStats, err error) {
+	stats = c.UptimeStats
 	return
 }

--- a/platform/stats/fakes/fake_stats_collector.go
+++ b/platform/stats/fakes/fake_stats_collector.go
@@ -18,6 +18,8 @@ type FakeCollector struct {
 
 	SwapStats boshstats.Usage
 	DiskStats map[string]boshstats.DiskStats
+
+	VMStats boshstats.VMStats
 }
 
 func (c *FakeCollector) StartCollecting(collectionInterval time.Duration, latestGotUpdated chan struct{}) {
@@ -48,5 +50,10 @@ func (c *FakeCollector) GetDiskStats(devicePath string) (stats boshstats.DiskSta
 	if !found {
 		err = errors.New("Disk not found")
 	}
+	return
+}
+
+func (c *FakeCollector) GetVMStats() (stats boshstats.VMStats, err error) {
+	stats = c.VMStats
 	return
 }

--- a/platform/stats/stats_collector_interface.go
+++ b/platform/stats/stats_collector_interface.go
@@ -26,6 +26,14 @@ type DiskStats struct {
 	InodeUsage Usage
 }
 
+type Seconds struct {
+	Seconds uint64
+}
+
+type VMStats struct {
+	Uptime Seconds
+}
+
 type Collector interface {
 	StartCollecting(time.Duration, chan struct{})
 
@@ -35,6 +43,8 @@ type Collector interface {
 	GetMemStats() (usage Usage, err error)
 	GetSwapStats() (usage Usage, err error)
 	GetDiskStats(mountedPath string) (stats DiskStats, err error)
+
+	GetVMStats() (stats VMStats, err error)
 }
 
 func (cpuStats CPUStats) UserPercent() Percentage {

--- a/platform/stats/stats_collector_interface.go
+++ b/platform/stats/stats_collector_interface.go
@@ -26,12 +26,8 @@ type DiskStats struct {
 	InodeUsage Usage
 }
 
-type Seconds struct {
-	Seconds uint64
-}
-
-type VMStats struct {
-	Uptime Seconds
+type UptimeStats struct {
+	Secs uint64
 }
 
 type Collector interface {
@@ -44,7 +40,7 @@ type Collector interface {
 	GetSwapStats() (usage Usage, err error)
 	GetDiskStats(mountedPath string) (stats DiskStats, err error)
 
-	GetVMStats() (stats VMStats, err error)
+	GetUptimeStats() (stats UptimeStats, err error)
 }
 
 func (cpuStats CPUStats) UserPercent() Percentage {

--- a/platform/vitals/service.go
+++ b/platform/vitals/service.go
@@ -28,12 +28,12 @@ func NewService(statsCollector boshstats.Collector, dirProvider boshdirs.Provide
 
 func (s concreteService) Get() (vitals Vitals, err error) {
 	var (
-		loadStats boshstats.CPULoad
-		cpuStats  boshstats.CPUStats
-		memStats  boshstats.Usage
-		swapStats boshstats.Usage
-		vmStats   boshstats.VMStats
-		diskStats DiskVitals
+		loadStats   boshstats.CPULoad
+		cpuStats    boshstats.CPUStats
+		memStats    boshstats.Usage
+		swapStats   boshstats.Usage
+		uptimeStats boshstats.UptimeStats
+		diskStats   DiskVitals
 	)
 
 	loadStats, err = s.statsCollector.GetCPULoad()
@@ -66,9 +66,9 @@ func (s concreteService) Get() (vitals Vitals, err error) {
 		return
 	}
 
-	vmStats, err = s.statsCollector.GetVMStats()
+	uptimeStats, err = s.statsCollector.GetUptimeStats()
 	if err != nil {
-		err = bosherr.WrapError(err, "Getting VM Stats")
+		err = bosherr.WrapError(err, "Getting Uptime Stats")
 		return
 	}
 
@@ -82,7 +82,7 @@ func (s concreteService) Get() (vitals Vitals, err error) {
 		Mem:    createMemVitals(memStats),
 		Swap:   createMemVitals(swapStats),
 		Disk:   diskStats,
-		Uptime: UptimeVitals{Seconds: vmStats.Uptime.Seconds},
+		Uptime: UptimeVitals{Secs: uptimeStats.Secs},
 	}
 	return
 }

--- a/platform/vitals/service.go
+++ b/platform/vitals/service.go
@@ -32,6 +32,7 @@ func (s concreteService) Get() (vitals Vitals, err error) {
 		cpuStats  boshstats.CPUStats
 		memStats  boshstats.Usage
 		swapStats boshstats.Usage
+		vmStats   boshstats.VMStats
 		diskStats DiskVitals
 	)
 
@@ -65,6 +66,12 @@ func (s concreteService) Get() (vitals Vitals, err error) {
 		return
 	}
 
+	vmStats, err = s.statsCollector.GetVMStats()
+	if err != nil {
+		err = bosherr.WrapError(err, "Getting VM Stats")
+		return
+	}
+
 	vitals = Vitals{
 		Load: createLoadVitals(loadStats),
 		CPU: CPUVitals{
@@ -72,9 +79,10 @@ func (s concreteService) Get() (vitals Vitals, err error) {
 			Sys:  cpuStats.SysPercent().FormatFractionOf100(1),
 			Wait: cpuStats.WaitPercent().FormatFractionOf100(1),
 		},
-		Mem:  createMemVitals(memStats),
-		Swap: createMemVitals(swapStats),
-		Disk: diskStats,
+		Mem:    createMemVitals(memStats),
+		Swap:   createMemVitals(swapStats),
+		Disk:   diskStats,
+		Uptime: UptimeVitals{Seconds: vmStats.Uptime.Seconds},
 	}
 	return
 }

--- a/platform/vitals/service_test.go
+++ b/platform/vitals/service_test.go
@@ -38,6 +38,11 @@ func buildVitalsService() (statsCollector *fakestats.FakeCollector, service Serv
 			Used:  600 * 1024,
 			Total: 1000 * 1024,
 		},
+		VMStats: boshstats.VMStats{
+			Uptime: boshstats.Seconds{
+				Seconds: 5,
+			},
+		},
 		DiskStats: map[string]boshstats.DiskStats{
 			"/": boshstats.DiskStats{
 				DiskUsage:  boshstats.Usage{Used: 100, Total: 200},
@@ -91,6 +96,9 @@ var _ = Describe("Vitals service", func() {
 			"swap": map[string]string{
 				"kb":      "600",
 				"percent": "60",
+			},
+			"uptime": map[string]uint64{
+				"secs": 5,
 			},
 		}
 		if Windows {

--- a/platform/vitals/service_test.go
+++ b/platform/vitals/service_test.go
@@ -38,10 +38,8 @@ func buildVitalsService() (statsCollector *fakestats.FakeCollector, service Serv
 			Used:  600 * 1024,
 			Total: 1000 * 1024,
 		},
-		VMStats: boshstats.VMStats{
-			Uptime: boshstats.Seconds{
-				Seconds: 5,
-			},
+		UptimeStats: boshstats.UptimeStats{
+			Secs: 5,
 		},
 		DiskStats: map[string]boshstats.DiskStats{
 			"/": boshstats.DiskStats{

--- a/platform/vitals/vitals.go
+++ b/platform/vitals/vitals.go
@@ -28,5 +28,5 @@ type MemoryVitals struct {
 }
 
 type UptimeVitals struct {
-	Seconds uint64 `json:"secs,omitempty"`
+	Secs uint64 `json:"secs,omitempty"`
 }

--- a/platform/vitals/vitals.go
+++ b/platform/vitals/vitals.go
@@ -1,11 +1,12 @@
 package vitals
 
 type Vitals struct {
-	CPU  CPUVitals    `json:"cpu"`
-	Disk DiskVitals   `json:"disk,omitempty"`
-	Load []string     `json:"load,omitempty"`
-	Mem  MemoryVitals `json:"mem"`
-	Swap MemoryVitals `json:"swap"`
+	CPU    CPUVitals    `json:"cpu"`
+	Disk   DiskVitals   `json:"disk,omitempty"`
+	Load   []string     `json:"load,omitempty"`
+	Mem    MemoryVitals `json:"mem"`
+	Swap   MemoryVitals `json:"swap"`
+	Uptime UptimeVitals `json:"uptime"`
 }
 
 type CPUVitals struct {
@@ -24,4 +25,8 @@ type SpecificDiskVitals struct {
 type MemoryVitals struct {
 	Kb      string `json:"kb,omitempty"`
 	Percent string `json:"percent,omitempty"`
+}
+
+type UptimeVitals struct {
+	Seconds uint64 `json:"secs,omitempty"`
 }

--- a/sigar/sigar_stats_collector.go
+++ b/sigar/sigar_stats_collector.go
@@ -109,7 +109,7 @@ func (s *sigarStatsCollector) GetDiskStats(mountedPath string) (stats boshstats.
 	return
 }
 
-func (s *sigarStatsCollector) GetVMStats() (stats boshstats.VMStats, err error) {
+func (s *sigarStatsCollector) GetUptimeStats() (stats boshstats.UptimeStats, err error) {
 
 	uptime := sigar.Uptime{}
 	err = uptime.Get()
@@ -119,6 +119,6 @@ func (s *sigarStatsCollector) GetVMStats() (stats boshstats.VMStats, err error) 
 		return
 	}
 
-	stats.Uptime.Seconds = uint64(uptime.Length)
+	stats.Secs = uint64(uptime.Length)
 	return
 }

--- a/sigar/sigar_stats_collector.go
+++ b/sigar/sigar_stats_collector.go
@@ -108,3 +108,17 @@ func (s *sigarStatsCollector) GetDiskStats(mountedPath string) (stats boshstats.
 
 	return
 }
+
+func (s *sigarStatsCollector) GetVMStats() (stats boshstats.VMStats, err error) {
+
+	uptime := sigar.Uptime{}
+	err = uptime.Get()
+
+	if err != nil {
+		err = bosherr.WrapError(err, "Getting Sigar Uptime")
+		return
+	}
+
+	stats.Uptime.Seconds = uint64(uptime.Length)
+	return
+}


### PR DESCRIPTION
vitals.uptime.secs field is added as expected by bosh-cli

[#146195069](https://www.pivotaltracker.com/story/show/146195069)