### PR TITLE
Document GCS as blobstore provider

### DIFF
--- a/docs/dev_setup.md
+++ b/docs/dev_setup.md
@@ -21,10 +21,11 @@ To publish:
 
 ### Blobstores
 
-The Go Agent ships with 4 default blobstores:
+The Go Agent ships with 5 default blobstores:
 
 - Local filesystem
 - S3
+- GCS (Google Cloud Storage)
 - DAV
 - Dummy (for testing)
 


### PR DESCRIPTION
bosh-cli has merged support for using GCS as a director blobstore. BOSH director and the google CPI are merging support. The stemcell has an open PR for bosh-gcscli inclusion.
This change documents GCS is usable as a blobstore.
cloudfoundry/bosh#1732
cloudfoundry/bosh-cli#238
cloudfoundry-incubator/bosh-google-cpi-release#218
cloudfoundry/bosh-linux-stemcell-builder/pull/16

Do not merge until cloudfoundry-incubator/bosh-google-cpi-release#218, cloudfoundry/bosh#1732, and https://github.com/cloudfoundry/bosh-linux-stemcell-builder/pull/16 are merged.