### PR TITLE
Can pass mount options to persistent disk

### DIFF
--- a/agent/action/unmount_disk_test.go
+++ b/agent/action/unmount_disk_test.go
@@ -64,7 +64,7 @@ var _ = Describe("UnmountDiskAction", func() {
 
 		result, err := action.Run("vol-123")
 		Expect(err).ToNot(HaveOccurred())
-		boshassert.MatchesJSONString(GinkgoT(), result, `{"message":"Unmounted partition of {ID:vol-123 DeviceID: VolumeID:2 Lun:0 HostDeviceID:fake-host-device-id Path:/dev/sdf FileSystemType:ext4}"}`)
+		boshassert.MatchesJSONString(GinkgoT(), result, `{"message":"Unmounted partition of {ID:vol-123 DeviceID: VolumeID:2 Lun:0 HostDeviceID:fake-host-device-id Path:/dev/sdf FileSystemType:ext4 MountOptions:[]}"}`)
 
 		Expect(platform.UnmountPersistentDiskSettings).To(Equal(expectedDiskSettings))
 	})
@@ -74,7 +74,7 @@ var _ = Describe("UnmountDiskAction", func() {
 
 		result, err := action.Run("vol-123")
 		Expect(err).ToNot(HaveOccurred())
-		boshassert.MatchesJSONString(GinkgoT(), result, `{"message":"Partition of {ID:vol-123 DeviceID: VolumeID:2 Lun:0 HostDeviceID:fake-host-device-id Path:/dev/sdf FileSystemType:ext4} is not mounted"}`)
+		boshassert.MatchesJSONString(GinkgoT(), result, `{"message":"Partition of {ID:vol-123 DeviceID: VolumeID:2 Lun:0 HostDeviceID:fake-host-device-id Path:/dev/sdf FileSystemType:ext4 MountOptions:[]} is not mounted"}`)
 
 		Expect(platform.UnmountPersistentDiskSettings).To(Equal(expectedDiskSettings))
 	})

--- a/platform/disk/diskutil.go
+++ b/platform/disk/diskutil.go
@@ -2,13 +2,13 @@ package disk
 
 import (
 	"path"
+	"strconv"
+	"strings"
 
 	boshdevutil "github.com/cloudfoundry/bosh-agent/platform/deviceutil"
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 	boshlog "github.com/cloudfoundry/bosh-utils/logger"
 	boshsys "github.com/cloudfoundry/bosh-utils/system"
-	"strconv"
-	"strings"
 )
 
 type diskUtil struct {

--- a/platform/disk/fakes/fake_mounter.go
+++ b/platform/disk/fakes/fake_mounter.go
@@ -7,6 +7,13 @@ type FakeMounter struct {
 	MountMountOptions   [][]string
 	MountErr            error
 
+	MountFilesystemCalled         bool
+	MountFilesystemPartitionPaths []string
+	MountFilesystemMountPoints    []string
+	MountFilesystemFstypes        []string
+	MountFilesystemMountOptions   [][]string
+	MountFilesystemErr            error
+
 	RemountInPlaceCalled       bool
 	RemountInPlaceMountPoints  []string
 	RemountInPlaceMountOptions [][]string
@@ -45,6 +52,15 @@ func (m *FakeMounter) Mount(partitionPath, mountPoint string, mountOptions ...st
 	m.MountMountPoints = append(m.MountMountPoints, mountPoint)
 	m.MountMountOptions = append(m.MountMountOptions, mountOptions)
 	return m.MountErr
+}
+
+func (m *FakeMounter) MountFilesystem(partitionPath, mountPoint, fstype string, mountOptions ...string) error {
+	m.MountFilesystemCalled = true
+	m.MountFilesystemPartitionPaths = append(m.MountFilesystemPartitionPaths, partitionPath)
+	m.MountFilesystemMountPoints = append(m.MountFilesystemMountPoints, mountPoint)
+	m.MountFilesystemFstypes = append(m.MountFilesystemFstypes, fstype)
+	m.MountFilesystemMountOptions = append(m.MountFilesystemMountOptions, mountOptions)
+	return m.MountFilesystemErr
 }
 
 func (m *FakeMounter) RemountAsReadonly(mountPoint string) (err error) {

--- a/platform/disk/linux_bind_mounter.go
+++ b/platform/disk/linux_bind_mounter.go
@@ -9,12 +9,16 @@ func NewLinuxBindMounter(delegateMounter Mounter) Mounter {
 }
 
 func (m linuxBindMounter) Mount(partitionPath, mountPoint string, mountOptions ...string) error {
+	return m.MountFilesystem(partitionPath, mountPoint, "", mountOptions...)
+}
+
+func (m linuxBindMounter) MountFilesystem(partitionPath, mountPoint, fstype string, mountOptions ...string) error {
 	// Filesystems should not be bind mounted
-	if partitionPath != "tmpfs" {
-		mountOptions = append(mountOptions, "--bind")
+	if fstype != "tmpfs" {
+		mountOptions = append(mountOptions, "bind")
 	}
 
-	return m.delegateMounter.Mount(partitionPath, mountPoint, mountOptions...)
+	return m.delegateMounter.MountFilesystem(partitionPath, mountPoint, fstype, mountOptions...)
 }
 
 func (m linuxBindMounter) RemountAsReadonly(mountPoint string) error {
@@ -24,7 +28,7 @@ func (m linuxBindMounter) RemountAsReadonly(mountPoint string) error {
 }
 
 func (m linuxBindMounter) Remount(fromMountPoint, toMountPoint string, mountOptions ...string) error {
-	mountOptions = append(mountOptions, "--bind")
+	mountOptions = append(mountOptions, "bind")
 	return m.delegateMounter.Remount(fromMountPoint, toMountPoint, mountOptions...)
 }
 

--- a/platform/disk/linux_mounter_test.go
+++ b/platform/disk/linux_mounter_test.go
@@ -43,12 +43,21 @@ var _ = Describe("linuxMounter", func() {
 		mounter = NewLinuxMounter(runner, mountsSearcher, 1*time.Millisecond)
 	})
 
-	Describe("Mount", func() {
+	Describe("MountFilesystem", func() {
 		It("allows to mount disk at given mount point", func() {
-			err := mounter.Mount("/dev/foo", "/mnt/foo")
+			err := mounter.MountFilesystem("/dev/foo", "/mnt/foo", "goodfs")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(1).To(Equal(len(runner.RunCommands)))
-			Expect(runner.RunCommands[0]).To(Equal([]string{"mount", "/dev/foo", "/mnt/foo"}))
+			Expect(runner.RunCommands[0]).To(Equal([]string{"mount", "/dev/foo", "/mnt/foo", "-t", "goodfs"}))
+		})
+
+		Context("when there are mount options", func() {
+			It("mounts the disk with specified options", func() {
+				err := mounter.MountFilesystem("/dev/foo", "/mnt/foo", "goodfs", "opt1", "opt2")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(1).To(Equal(len(runner.RunCommands)))
+				Expect(runner.RunCommands[0]).To(Equal([]string{"mount", "/dev/foo", "/mnt/foo", "-t", "goodfs", "-o", "opt1", "-o", "opt2"}))
+			})
 		})
 
 		It("does not try to mount disk again when disk is already mounted to the expected mount point", func() {
@@ -57,7 +66,7 @@ var _ = Describe("linuxMounter", func() {
 				Mount{PartitionPath: "/dev/bar", MountPoint: "/mnt/bar"},
 			}
 
-			err := mounter.Mount("/dev/foo", "/mnt/foo")
+			err := mounter.MountFilesystem("/dev/foo", "/mnt/foo", "goodfs")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(0).To(Equal(len(runner.RunCommands)))
 		})
@@ -68,7 +77,7 @@ var _ = Describe("linuxMounter", func() {
 				Mount{PartitionPath: "/dev/bar", MountPoint: "/mnt/bar"},
 			}
 
-			err := mounter.Mount("/dev/foo", "/mnt/foo")
+			err := mounter.MountFilesystem("/dev/foo", "/mnt/foo", "goodfs")
 			Expect(err).To(HaveOccurred())
 			Expect(0).To(Equal(len(runner.RunCommands)))
 		})
@@ -78,10 +87,10 @@ var _ = Describe("linuxMounter", func() {
 				Mount{PartitionPath: "tmpfs", MountPoint: "/mnt/foo1"},
 			}
 
-			err := mounter.Mount("tmpfs", "/mnt/foo2")
+			err := mounter.MountFilesystem("tmpfs", "/mnt/foo2", "tmpfs")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(1).To(Equal(len(runner.RunCommands)))
-			Expect(runner.RunCommands[0]).To(Equal([]string{"mount", "tmpfs", "/mnt/foo2"}))
+			Expect(runner.RunCommands[0]).To(Equal([]string{"mount", "tmpfs", "/mnt/foo2", "-t", "tmpfs"}))
 		})
 
 		It("returns error when another disk is already mounted to mount point", func() {
@@ -90,7 +99,7 @@ var _ = Describe("linuxMounter", func() {
 				Mount{PartitionPath: "/dev/bar", MountPoint: "/mnt/bar"},
 			}
 
-			err := mounter.Mount("/dev/foo", "/mnt/foo")
+			err := mounter.MountFilesystem("/dev/foo", "/mnt/foo", "goodfs")
 			Expect(err).To(HaveOccurred())
 			Expect(0).To(Equal(len(runner.RunCommands)))
 		})
@@ -98,16 +107,35 @@ var _ = Describe("linuxMounter", func() {
 		It("returns error and does not try to mount anything when searching mounts fails", func() {
 			mountsSearcher.SearchMountsErr = errors.New("fake-search-mounts-err")
 
-			err := mounter.Mount("/dev/foo", "/mnt/foo")
+			err := mounter.MountFilesystem("/dev/foo", "/mnt/foo", "goodfs")
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("fake-search-mounts-err"))
 			Expect(0).To(Equal(len(runner.RunCommands)))
 		})
+
+		Context("when the filesystem type is empty", func() {
+			It("mounts the disk without filesystem type (so that it can be inferred)", func() {
+				err := mounter.MountFilesystem("/dev/foo", "/mnt/foo", "")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(1).To(Equal(len(runner.RunCommands)))
+				Expect(runner.RunCommands[0]).To(Equal([]string{"mount", "/dev/foo", "/mnt/foo"}))
+			})
+		})
 	})
+
+	Describe("Mount", func() {
+		It("mounts the disk without filesystem type (so that it can be inferred)", func() {
+			err := mounter.Mount("/dev/foo", "/mnt/foo")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(1).To(Equal(len(runner.RunCommands)))
+			Expect(runner.RunCommands[0]).To(Equal([]string{"mount", "/dev/foo", "/mnt/foo"}))
+		})
+	})
+
 	Describe("RemountInPlace", func() {
 		Context("when the mount exists", func() {
 			BeforeEach(func() {
-				err := mounter.Mount("/mnt/foo", "/mnt/foo", "-o", "bind")
+				err := mounter.Mount("/mnt/foo", "/mnt/foo", "bind")
 				Expect(err).ToNot(HaveOccurred())
 
 				mountsSearcher.SearchMountsMounts = []Mount{
@@ -116,15 +144,16 @@ var _ = Describe("linuxMounter", func() {
 			})
 
 			It("remounts in place", func() {
-				err := mounter.RemountInPlace("/mnt/foo", "-o", "nodev")
+				err := mounter.RemountInPlace("/mnt/foo", "nodev")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(runner.RunCommands[1]).To(Equal([]string{"mount", "/mnt/foo", "/mnt/foo", "-o", "nodev", "-o", "remount"}))
+				Expect(runner.RunCommands).To(HaveLen(2))
+				Expect(runner.RunCommands[1]).To(Equal([]string{"mount", "", "/mnt/foo", "-o", "remount", "-o", "nodev"}))
 			})
 		})
 
 		Context("when the mount does not exist", func() {
 			It("raises error", func() {
-				err := mounter.RemountInPlace("/mnt/foo", "-o", "remount,nodev")
+				err := mounter.RemountInPlace("/mnt/foo", "remount,nodev")
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Error finding existing mount point /mnt/foo"))
 			})

--- a/platform/disk/mounter_interface.go
+++ b/platform/disk/mounter_interface.go
@@ -2,6 +2,7 @@ package disk
 
 type Mounter interface {
 	Mount(partitionPath, mountPoint string, mountOptions ...string) (err error)
+	MountFilesystem(partitionPath, mountPoint, fstype string, mountOptions ...string) (err error)
 	Unmount(partitionOrMountPoint string) (didUnmount bool, err error)
 
 	RemountAsReadonly(mountPoint string) (err error)

--- a/platform/dummy_platform.go
+++ b/platform/dummy_platform.go
@@ -21,8 +21,9 @@ import (
 )
 
 type mount struct {
-	MountDir string
-	DiskCid  string
+	MountDir     string
+	MountOptions []string
+	DiskCid      string
 }
 
 type formattedDisk struct {
@@ -263,7 +264,11 @@ func (p dummyPlatform) MountPersistentDisk(diskSettings boshsettings.DiskSetting
 
 	p.fs.WriteFile(filepath.Join(p.dirProvider.BoshDir(), "formatted_disks.json"), diskJSON)
 
-	mounts = append(mounts, mount{MountDir: mountPoint, DiskCid: diskSettings.ID})
+	mounts = append(mounts, mount{
+		MountDir:     mountPoint,
+		MountOptions: diskSettings.MountOptions,
+		DiskCid:      diskSettings.ID,
+	})
 	mountsJSON, err := json.Marshal(mounts)
 	if err != nil {
 		return err

--- a/platform/dummy_platform_test.go
+++ b/platform/dummy_platform_test.go
@@ -9,6 +9,8 @@ import (
 
 	"encoding/json"
 
+	"os"
+
 	boshdpresolv "github.com/cloudfoundry/bosh-agent/infrastructure/devicepathresolver"
 	fakedpresolv "github.com/cloudfoundry/bosh-agent/infrastructure/devicepathresolver/fakes"
 	"github.com/cloudfoundry/bosh-agent/platform/fakes"
@@ -20,7 +22,6 @@ import (
 	boshlog "github.com/cloudfoundry/bosh-utils/logger"
 	boshsys "github.com/cloudfoundry/bosh-utils/system"
 	fakesys "github.com/cloudfoundry/bosh-utils/system/fakes"
-	"os"
 )
 
 type mount struct {
@@ -89,7 +90,7 @@ func describeDummyPlatform() {
 		var mountsPath, managedSettingsPath, formattedDisksPath string
 
 		BeforeEach(func() {
-			diskSettings = boshsettings.DiskSettings{ID: "somediskid"}
+			diskSettings = boshsettings.DiskSettings{ID: "somediskid", MountOptions: []string{"mountOption1", "mountOption2"}}
 			mountsPath = filepath.Join(dirProvider.BoshDir(), "mounts.json")
 			managedSettingsPath = filepath.Join(dirProvider.BoshDir(), "managed_disk_settings.json")
 			formattedDisksPath = filepath.Join(dirProvider.BoshDir(), "formatted_disks.json")
@@ -103,7 +104,7 @@ func describeDummyPlatform() {
 			Expect(err).NotTo(HaveOccurred())
 
 			mountsContent, _ = fs.ReadFileString(mountsPath)
-			Expect(mountsContent).To(Equal(`[{"MountDir":"/dev/potato","DiskCid":"somediskid"}]`))
+			Expect(mountsContent).To(Equal(`[{"MountDir":"/dev/potato","MountOptions":["mountOption1","mountOption2"],"DiskCid":"somediskid"}]`))
 		})
 
 		It("Updates the managed disk settings", func() {

--- a/platform/linux_platform.go
+++ b/platform/linux_platform.go
@@ -798,7 +798,7 @@ func (p linux) setupRunDir(sysDir string) error {
 			return bosherr.WrapErrorf(err, "Making %s dir", runDir)
 		}
 
-		err = p.diskManager.GetMounter().Mount("tmpfs", runDir, "-t", "tmpfs", "-o", "size=1m")
+		err = p.diskManager.GetMounter().MountFilesystem("tmpfs", runDir, "tmpfs", "size=1m")
 		if err != nil {
 			return bosherr.WrapErrorf(err, "Mounting tmpfs to %s", runDir)
 		}
@@ -823,7 +823,7 @@ func (p linux) SetupHomeDir() error {
 		if err != nil {
 			return bosherr.WrapError(err, "Setup home dir, mounting home")
 		}
-		err = mounter.RemountInPlace("/home", "-o", "nodev")
+		err = mounter.RemountInPlace("/home", "nodev")
 		if err != nil {
 			return bosherr.WrapError(err, "Setup home dir, remount in place")
 		}
@@ -1004,7 +1004,7 @@ func (p linux) bindMountDir(mountSource, mountPoint string) error {
 		return err
 	}
 
-	return bindMounter.RemountInPlace(mountPoint, "-o", "nodev", "-o", "noexec", "-o", "nosuid")
+	return bindMounter.RemountInPlace(mountPoint, "nodev", "noexec", "nosuid")
 }
 
 func (p linux) changeTmpDirPermissions(path string) error {
@@ -1092,7 +1092,7 @@ func (p linux) MountPersistentDisk(diskSetting boshsettings.DiskSettings, mountP
 		realPath = partitionPath
 	}
 
-	err = p.diskManager.GetMounter().Mount(realPath, mountPoint)
+	err = p.diskManager.GetMounter().Mount(realPath, mountPoint, diskSetting.MountOptions...)
 
 	if err != nil {
 		return bosherr.WrapError(err, "Mounting partition")

--- a/platform/linux_platform_test.go
+++ b/platform/linux_platform_test.go
@@ -1583,10 +1583,11 @@ Number  Start   End     Size    File system  Name             Flags
 				err := platform.SetupDataDir()
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(len(mounter.MountPartitionPaths)).To(Equal(1))
-				Expect(mounter.MountPartitionPaths[0]).To(Equal("tmpfs"))
-				Expect(mounter.MountMountPoints[0]).To(Equal("/fake-dir/data/sys/run"))
-				Expect(mounter.MountMountOptions[0]).To(Equal([]string{"-t", "tmpfs", "-o", "size=1m"}))
+				Expect(len(mounter.MountFilesystemPartitionPaths)).To(Equal(1))
+				Expect(mounter.MountFilesystemPartitionPaths[0]).To(Equal("tmpfs"))
+				Expect(mounter.MountFilesystemMountPoints[0]).To(Equal("/fake-dir/data/sys/run"))
+				Expect(mounter.MountFilesystemFstypes[0]).To(Equal("tmpfs"))
+				Expect(mounter.MountFilesystemMountOptions[0]).To(Equal([]string{"size=1m"}))
 			})
 
 			It("returns an error if creation of mount point fails", func() {
@@ -1598,7 +1599,7 @@ Number  Start   End     Size    File system  Name             Flags
 			})
 
 			It("returns an error if mounting tmpfs fails", func() {
-				mounter.MountErr = errors.New("fake-mount-error")
+				mounter.MountFilesystemErr = errors.New("fake-mount-error")
 
 				err := platform.SetupDataDir()
 				Expect(err).To(HaveOccurred())
@@ -1621,17 +1622,17 @@ Number  Start   End     Size    File system  Name             Flags
 			It("mounts the /home dir", func() {
 				err := act()
 				Expect(err).NotTo(HaveOccurred())
-				Expect(mounter.MountCalled).To(BeTrue())
-				Expect(mounter.MountPartitionPaths).To(ContainElement("/home"))
-				Expect(mounter.MountMountPoints).To(ContainElement("/home"))
-				Expect(mounter.MountMountOptions).To(ContainElement([]string{"--bind"}))
+				Expect(mounter.MountFilesystemCalled).To(BeTrue())
+				Expect(mounter.MountFilesystemPartitionPaths).To(ContainElement("/home"))
+				Expect(mounter.MountFilesystemMountPoints).To(ContainElement("/home"))
+				Expect(mounter.MountFilesystemMountOptions).To(ContainElement([]string{"bind"}))
 				Expect(mounter.RemountInPlaceCalled).To(BeTrue())
 				Expect(mounter.RemountInPlaceMountPoints).To(ContainElement("/home"))
-				Expect(mounter.RemountInPlaceMountOptions).To(ContainElement([]string{"-o", "nodev"}))
+				Expect(mounter.RemountInPlaceMountOptions).To(ContainElement([]string{"nodev"}))
 			})
 
 			It("return error if it cannot mount", func() {
-				mounter.MountErr = errors.New("fake-mount-error")
+				mounter.MountFilesystemErr = errors.New("fake-mount-error")
 				err := act()
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("fake-mount-error"))
@@ -1643,7 +1644,7 @@ Number  Start   End     Size    File system  Name             Flags
 				err := act()
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("fake-remount-error"))
-				Expect(mounter.MountCalled).To(BeTrue())
+				Expect(mounter.MountFilesystemCalled).To(BeTrue())
 			})
 		})
 
@@ -1741,13 +1742,13 @@ Number  Start   End     Size    File system  Name             Flags
 						err := act()
 						Expect(err).NotTo(HaveOccurred())
 
-						Expect(mounter.MountPartitionPaths).To(ContainElement("/fake-dir/data/root_tmp"))
-						Expect(mounter.MountMountPoints).To(ContainElement("/tmp"))
-						Expect(mounter.MountMountOptions).To(ContainElement([]string{"--bind"}))
+						Expect(mounter.MountFilesystemPartitionPaths).To(ContainElement("/fake-dir/data/root_tmp"))
+						Expect(mounter.MountFilesystemMountPoints).To(ContainElement("/tmp"))
+						Expect(mounter.MountFilesystemMountOptions).To(ContainElement([]string{"bind"}))
 
 						Expect(mounter.RemountInPlaceCalled).To(Equal(true))
 						Expect(mounter.RemountInPlaceMountPoints).To(ContainElement("/tmp"))
-						Expect(mounter.RemountInPlaceMountOptions).To(ContainElement([]string{"-o", "nodev", "-o", "noexec", "-o", "nosuid"}))
+						Expect(mounter.RemountInPlaceMountOptions).To(ContainElement([]string{"nodev", "noexec", "nosuid"}))
 					})
 
 					It("changes permissions for the system /tmp folder", func() {
@@ -1786,7 +1787,7 @@ Number  Start   End     Size    File system  Name             Flags
 
 						Expect(mounter.RemountInPlaceCalled).To(Equal(true))
 						Expect(mounter.RemountInPlaceMountPoints).To(ContainElement("/tmp"))
-						Expect(mounter.RemountInPlaceMountOptions).To(ContainElement([]string{"-o", "nodev", "-o", "noexec", "-o", "nosuid"}))
+						Expect(mounter.RemountInPlaceMountOptions).To(ContainElement([]string{"nodev", "noexec", "nosuid"}))
 					})
 
 					It("does not create new tmp filesystem", func() {
@@ -1844,14 +1845,14 @@ Number  Start   End     Size    File system  Name             Flags
 						err := act()
 						Expect(err).NotTo(HaveOccurred())
 
-						Expect(len(mounter.MountPartitionPaths)).To(Equal(2))
-						Expect(mounter.MountPartitionPaths[1]).To(Equal("/fake-dir/data/root_tmp"))
-						Expect(mounter.MountMountPoints[1]).To(Equal("/var/tmp"))
-						Expect(mounter.MountMountOptions[1]).To(ConsistOf("--bind"))
+						Expect(len(mounter.MountFilesystemPartitionPaths)).To(Equal(2))
+						Expect(mounter.MountFilesystemPartitionPaths[1]).To(Equal("/fake-dir/data/root_tmp"))
+						Expect(mounter.MountFilesystemMountPoints[1]).To(Equal("/var/tmp"))
+						Expect(mounter.MountFilesystemMountOptions[1]).To(ConsistOf("bind"))
 
 						Expect(mounter.RemountInPlaceCalled).To(Equal(true))
 						Expect(mounter.RemountInPlaceMountPoints).To(ContainElement("/var/tmp"))
-						Expect(mounter.RemountInPlaceMountOptions).To(ContainElement([]string{"-o", "nodev", "-o", "noexec", "-o", "nosuid"}))
+						Expect(mounter.RemountInPlaceMountOptions).To(ContainElement([]string{"nodev", "noexec", "nosuid"}))
 					})
 
 					It("changes permissions for the system /var/tmp folder", func() {
@@ -1937,8 +1938,8 @@ Number  Start   End     Size    File system  Name             Flags
 				It("mounts unmounted tmp dirs", func() {
 					err := act()
 					Expect(err).ToNot(HaveOccurred())
-					Expect(mounter.MountMountPoints).To(ContainElement("/var/tmp"))
-					Expect(mounter.MountMountPoints).ToNot(ContainElement("/tmp"))
+					Expect(mounter.MountFilesystemMountPoints).To(ContainElement("/var/tmp"))
+					Expect(mounter.MountFilesystemMountPoints).ToNot(ContainElement("/tmp"))
 				})
 			})
 		})
@@ -2049,9 +2050,9 @@ Number  Start   End     Size    File system  Name             Flags
 					err := act()
 					Expect(err).NotTo(HaveOccurred())
 
-					Expect(mounter.MountPartitionPaths).To(ContainElement("/fake-dir/data/root_log"))
-					Expect(mounter.MountMountPoints).To(ContainElement("/var/log"))
-					Expect(mounter.MountMountOptions).To(ContainElement([]string{"--bind"}))
+					Expect(mounter.MountFilesystemPartitionPaths).To(ContainElement("/fake-dir/data/root_log"))
+					Expect(mounter.MountFilesystemMountPoints).To(ContainElement("/var/log"))
+					Expect(mounter.MountFilesystemMountOptions).To(ContainElement([]string{"bind"}))
 				})
 			})
 
@@ -2158,7 +2159,7 @@ Number  Start   End     Size    File system  Name             Flags
 	Describe("MountPersistentDisk", func() {
 		act := func() error {
 			return platform.MountPersistentDisk(
-				boshsettings.DiskSettings{ID: "fake-unique-id", Path: "fake-volume-id"},
+				boshsettings.DiskSettings{ID: "fake-unique-id", Path: "fake-volume-id", MountOptions: []string{"mntOpt1", "mntOpt2"}},
 				"/mnt/point",
 			)
 		}
@@ -2253,7 +2254,7 @@ Number  Start   End     Size    File system  Name             Flags
 						Expect(fs.GetFileTestStat("/fake-dir/store_migration_target").FileType).To(Equal(fakesys.FakeFileTypeDir))
 						Expect(mounter.MountPartitionPaths).To(Equal([]string{"/dev/mapper/fake-real-device-path-part1"}))
 						Expect(mounter.MountMountPoints).To(Equal([]string{"/fake-dir/store_migration_target"}))
-						Expect(mounter.MountMountOptions).To(Equal([][]string{nil}))
+						Expect(mounter.MountMountOptions).To(Equal([][]string{{"mntOpt1", "mntOpt2"}}))
 					})
 				})
 			})
@@ -2310,7 +2311,7 @@ Number  Start   End     Size    File system  Name             Flags
 					Expect(err).ToNot(HaveOccurred())
 					Expect(mounter.MountPartitionPaths).To(Equal([]string{"/dev/mapper/fake-real-device-path-part1"}))
 					Expect(mounter.MountMountPoints).To(Equal([]string{"/mnt/point"}))
-					Expect(mounter.MountMountOptions).To(Equal([][]string{nil}))
+					Expect(mounter.MountMountOptions).To(Equal([][]string{{"mntOpt1", "mntOpt2"}}))
 				})
 
 				It("generates the managed disk settings file", func() {
@@ -2434,7 +2435,7 @@ Number  Start   End     Size    File system  Name             Flags
 					Expect(err).ToNot(HaveOccurred())
 					Expect(mounter.MountPartitionPaths).To(Equal([]string{"fake-real-device-path1"}))
 					Expect(mounter.MountMountPoints).To(Equal([]string{"/mnt/point"}))
-					Expect(mounter.MountMountOptions).To(Equal([][]string{nil}))
+					Expect(mounter.MountMountOptions).To(Equal([][]string{{"mntOpt1", "mntOpt2"}}))
 				})
 			})
 
@@ -2467,7 +2468,7 @@ Number  Start   End     Size    File system  Name             Flags
 					Expect(len(mounter.MountPartitionPaths)).To(Equal(1))
 					Expect(mounter.MountPartitionPaths).To(Equal([]string{"fake-real-device-path"})) // no '1' because no partition
 					Expect(mounter.MountMountPoints).To(Equal([]string{"/mnt/point"}))
-					Expect(mounter.MountMountOptions).To(Equal([][]string{nil}))
+					Expect(mounter.MountMountOptions).To(Equal([][]string{{"mntOpt1", "mntOpt2"}}))
 				})
 
 				It("returns error when mounting fails", func() {

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -79,6 +79,7 @@ type DiskSettings struct {
 	HostDeviceID   string
 	Path           string
 	FileSystemType disk.FileSystemType
+	MountOptions   []string
 }
 
 type VM struct {
@@ -115,6 +116,7 @@ func (s Settings) PersistentDiskSettings(diskID string) (DiskSettings, bool) {
 			}
 
 			diskSettings.FileSystemType = s.Env.PersistentDiskFS
+			diskSettings.MountOptions = s.Env.PersistentDiskMountOptions
 			return diskSettings, true
 		}
 	}
@@ -172,8 +174,9 @@ func (s Settings) GetBlobstore() Blobstore {
 }
 
 type Env struct {
-	Bosh             BoshEnv             `json:"bosh"`
-	PersistentDiskFS disk.FileSystemType `json:"persistent_disk_fs"`
+	Bosh                       BoshEnv             `json:"bosh"`
+	PersistentDiskFS           disk.FileSystemType `json:"persistent_disk_fs"`
+	PersistentDiskMountOptions []string            `json:"persistent_disk_mount_options"`
 }
 
 func (e Env) GetPassword() string {

--- a/settings/settings_test.go
+++ b/settings/settings_test.go
@@ -56,8 +56,8 @@ var _ = Describe("Settings", func() {
 			})
 
 			Context("when Env is provided", func() {
-				It("gets filesystem type from env", func() {
-					settingsJSON := `{"env": {"persistent_disk_fs": "xfs"}}`
+				It("gets persistent disk settings from env", func() {
+					settingsJSON := `{"env": {"persistent_disk_fs": "xfs", "persistent_disk_mount_options": ["opt1", "opt2"]}}`
 
 					err := json.Unmarshal([]byte(settingsJSON), &settings)
 					Expect(err).NotTo(HaveOccurred())
@@ -71,6 +71,7 @@ var _ = Describe("Settings", func() {
 						Lun:            "fake-disk-lun",
 						HostDeviceID:   "fake-disk-host-device-id",
 						FileSystemType: "xfs",
+						MountOptions:   []string{"opt1", "opt2"},
 					}))
 				})
 


### PR DESCRIPTION
We'd like to be able to pass persistent disk mount options through the env, in a similar fashion to [the filesystem type](https://bosh.io/docs/persistent-disk-fs.html).

This commit adds the ability to do this, using the `env` key `persistent_disk_mount_options`. We (Garden+Groot team) want this feature to allow us to deploy xfs-formatted disks with project quotas enabled (without having to use loopback devices).

We ran `bin/test-unit` and `bin/test-integration`, and also kicked the tires on an AWS stemcell we built using the scripts in `bin/repack-stemcell`. If there's anything else we should run please let us know.

Cheers,
@callisto13 & Craig