### PR TITLE
Support building Alibaba Cloud bosh agent

### DIFF
--- a/infrastructure/http_metadata_service.go
+++ b/infrastructure/http_metadata_service.go
@@ -95,6 +95,10 @@ func (ms HTTPMetadataService) GetPublicKey() (string, error) {
 	url := fmt.Sprintf("%s%s", ms.metadataHost, ms.sshKeysPath)
 	resp, err := ms.client.GetCustomized(url, ms.addHeaders())
 	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			ms.logger.Warn(ms.logTag, "There is no setting ssh key: %s", err.Error())
+			return "", nil
+		}
 		return "", bosherr.WrapErrorf(err, "Getting open ssh key from url %s", url)
 	}
 

--- a/vendor/github.com/cloudfoundry/bosh-utils/httpclient/http_client.go
+++ b/vendor/github.com/cloudfoundry/bosh-utils/httpclient/http_client.go
@@ -129,7 +129,7 @@ func (c *HTTPClient) GetCustomized(endpoint string, f func(*http.Request)) (*htt
 
 	response, err := c.client.Do(request)
 	if err != nil {
-		return nil, bosherr.WrapError(scrubErrorOutput(err), "Performing GET request")
+		return response, bosherr.WrapError(scrubErrorOutput(err), "Performing GET request")
 	}
 
 	return response, nil


### PR DESCRIPTION
This PR can help user to build bosh agent on Alibaba Cloud.

At present, we must run twice curl command to get final SSHPublicKey value in alicloud ECS instance, so we add the code to achieve it. We are promoting alicloud ECS to make change, and now I hope it can be accepted. Thanks a lot.