### PR TITLE
Fix 404 response error for getting public ssh key

### DIFF
--- a/infrastructure/http_metadata_service.go
+++ b/infrastructure/http_metadata_service.go
@@ -97,6 +97,10 @@ func (ms HTTPMetadataService) GetPublicKey() (string, error) {
 	if err != nil {
 		return "", bosherr.WrapErrorf(err, "Getting open ssh key from url %s", url)
 	}
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
+		ms.logger.Warn(ms.logTag, "The open ssh keys path is not present: %s.", url)
+		return "", nil
+	}
 
 	defer func() {
 		if err := resp.Body.Close(); err != nil {

--- a/infrastructure/http_metadata_service_test.go
+++ b/infrastructure/http_metadata_service_test.go
@@ -132,6 +132,45 @@ func describeHTTPMetadataService() {
 		})
 	})
 
+	Describe("GetEmptyPublicKey", func() {
+		var (
+			ts          *httptest.Server
+			sshKeysPath string
+		)
+
+		BeforeEach(func() {
+			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				defer GinkgoRecover()
+
+				Expect(r.Method).To(Equal("GET"))
+				Expect(r.URL.Path).To(Equal("/ssh-keys"))
+				Expect(r.Header.Get("key")).To(Equal("value"))
+			})
+			ts = httptest.NewServer(handler)
+		})
+
+		AfterEach(func() {
+			ts.Close()
+		})
+
+		Context("when the ssh keys path is present but key value is empty", func() {
+			BeforeEach(func() {
+				sshKeysPath = "/ssh-keys"
+				metadataService = NewHTTPMetadataService(ts.URL, metadataHeaders, "/user-data", "/instanceid", sshKeysPath, dnsResolver, platform, logger)
+			})
+
+			It("returns empty public key", func() {
+				publicKey, err := metadataService.GetPublicKey()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(publicKey).To(BeEmpty())
+			})
+
+			ItEnsuresMinimalNetworkSetup(func() (string, error) {
+				return metadataService.GetPublicKey()
+			})
+		})
+	})
+
 	Describe("GetInstanceID", func() {
 		var (
 			ts             *httptest.Server


### PR DESCRIPTION
The PR want to fix a defect that if there is no setting public ssh key, a 404 response error will happen while deploying cloud foundry. Public ssh key is optional for deployment CF and the error breaks up CF deployment.

The PR has a bosh-utils's [PR 41](https://github.com/cloudfoundry/bosh-utils/pull/41).