### PR TITLE
Always make sure that there is a gpt partition table

### DIFF
--- a/platform/disk/parted_partitioner.go
+++ b/platform/disk/parted_partitioner.go
@@ -197,8 +197,9 @@ func (p partedPartitioner) convertFromKbToBytes(sizeInKb uint64) uint64 {
 func (p partedPartitioner) runPartedPrint(devicePath string) (stdout, stderr string, exitStatus int, err error) {
 	stdout, stderr, exitStatus, err = p.cmdRunner.RunCommand("parted", "-m", devicePath, "unit", "B", "print")
 
-	// If the error is not having a partition table, create one
-	if strings.Contains(fmt.Sprintf("%s\n%s", stdout, stderr), "unrecognised disk label") {
+	// If the error is not having a gpt partition table, create one
+	if strings.Contains(fmt.Sprintf("%s\n%s", stdout, stderr), "unrecognised disk label") ||
+		(err == nil && !strings.Contains(stdout, "gpt")) {
 		stdout, stderr, exitStatus, err = p.getPartitionTable(devicePath)
 
 		if err != nil {


### PR DESCRIPTION
Instead of only creating a new gpt partition table when the disk label
is unrecognized, the agent will now always create one if there is no gpt
table yet.

The problem is that OpenStack creates ephemeral disks with msdos
partition tables. The SUSE stemcell always uses `parted` to create
partitions [1] while the ubuntu:trusty one decides based on the disk
size [2]. The bosh-agent's parted command [3] cannot work on msdos
partition tables because it tries to set a partition name which is
only supported on gpt tables.
Partition names are required to fulfill the story [4].

Running it on a msdos table leads to the error:

```stderr: 'parted: invalid token: bosh-partition-0```

The same error can be reproduced in ubuntu:trusty as a special case
when swiching from the sfdisk to the parted partitioner as described
here: https://github.com/cloudfoundry/bosh/issues/1870

Alternatively - e.g. if there's risk of data loss with this approach - the 
code could distinguish between the different partition table sizes and
not set a name on msdos ones.

[1]: https://github.com/cloudfoundry/bosh-linux-stemcell-builder/blob/master/stemcell_builder/lib/prelude_agent.bash#L2-L8
[2]: https://github.com/cloudfoundry/bosh-agent/blob/854ccbb9213cff43fbbd4aef098c8b07427e5e21/platform/linux_platform.go#L1066-L1072
[3]: https://github.com/cloudfoundry/bosh-agent/blob/1df0f93957a6655650c1c6715f7e61b764895567/platform/disk/parted_partitioner.go#L265
[4]: https://www.pivotaltracker.com/n/projects/956238/stories/141166603

Signed-off-by: Dimitris Karakasilis <dkarakasilis@suse.com>