### PR TITLE
Fix Linux hosts file formatting

### DIFF
--- a/platform/linux_platform.go
+++ b/platform/linux_platform.go
@@ -421,7 +421,8 @@ func (p linux) SetupRecordsJSONPermission(path string) error {
 	return nil
 }
 
-const EtcHostsTemplate = `127.0.0.1 localhost {{ . }}
+const EtcHostsTemplate = `127.0.0.1 localhost
+127.0.1.1 {{ . }}
 
 # The following lines are desirable for IPv6 capable hosts
 ::1 localhost ip6-localhost ip6-loopback {{ . }}

--- a/platform/linux_platform_test.go
+++ b/platform/linux_platform_test.go
@@ -618,7 +618,8 @@ bosh_foobar:...`
 	})
 
 	Describe("SetupHostname", func() {
-		const expectedEtcHosts = `127.0.0.1 localhost foobar.local
+		const expectedEtcHosts = `127.0.0.1 localhost
+127.0.1.1 foobar.local
 
 # The following lines are desirable for IPv6 capable hosts
 ::1 localhost ip6-localhost ip6-loopback foobar.local


### PR DESCRIPTION
[This](https://www.debian.org/doc/manuals/debian-reference/ch05.en.html#_the_hostname_resolution) is the Debian documentation I reference in the commit.

Debian documentation says that the hostname entry should be on a
seperate line from `localhost`.

Having it on the same line causes queries for fully qualified domain
names (e.g. `hostname -f`) to return "localhost".