### PR TITLE
DNS servers for preconfigured networks

### DIFF
--- a/platform/net/ubuntu_net_manager.go
+++ b/platform/net/ubuntu_net_manager.go
@@ -98,8 +98,10 @@ func (net UbuntuNetManager) SetupIPv6(config boshsettings.IPv6, stopCh <-chan st
 
 func (net UbuntuNetManager) SetupNetworking(networks boshsettings.Networks, errCh chan error) error {
 	if networks.IsPreconfigured() {
-		// Note in this case IPs are not broadcast
-		return net.writeResolvConf(networks)
+		err := net.writeResolvConf(networks)
+		if err != nil {
+			return bosherr.WrapError(err, "Writing resolvconf")
+		}
 	}
 
 	staticConfigs, dhcpConfigs, dnsServers, err := net.ComputeNetworkConfig(networks)

--- a/platform/net/ubuntu_net_manager_test.go
+++ b/platform/net/ubuntu_net_manager_test.go
@@ -242,6 +242,16 @@ dns-nameservers 8.8.8.8 9.9.9.9`
 		Context("networks is preconfigured", func() {
 			var networks boshsettings.Networks
 			BeforeEach(func() {
+				interfacePaths := []string{}
+				interfacePaths = append(interfacePaths, writeNetworkDevice("fake-eth0", "fake-static-mac-address", true))
+				interfacePaths = append(interfacePaths, writeNetworkDevice("fake-eth1", "fake-dhcp-mac-address", true))
+				fs.SetGlob("/sys/class/net/*", interfacePaths)
+
+				interfaceAddrsProvider.GetInterfaceAddresses = []boship.InterfaceAddress{
+					boship.NewSimpleInterfaceAddress("fake-eth0", "1.2.3.4"),
+					boship.NewSimpleInterfaceAddress("fake-eth1", "5.6.7.8"),
+				}
+
 				dhcpNetwork.Preconfigured = true
 				staticNetwork.Preconfigured = true
 				networks = boshsettings.Networks{
@@ -387,7 +397,7 @@ nameserver 9.9.9.9
 				err := netManager.SetupNetworking(networks, nil)
 				Expect(err).ToNot(HaveOccurred())
 
-				Expect(len(cmdRunner.RunCommands)).To(Equal(1))
+				Expect(len(cmdRunner.RunCommands)).To(Equal(6))
 				Expect(cmdRunner.RunCommands[0]).To(Equal([]string{"resolvconf", "-u"}))
 			})
 		})

--- a/settings/service.go
+++ b/settings/service.go
@@ -123,6 +123,10 @@ func (s *settingsService) GetSettings() Settings {
 	}
 	s.settingsMutex.Unlock()
 
+	if settingsCopy.Networks.HasInterfaceAlias() {
+		return settingsCopy
+	}
+
 	for networkName, network := range settingsCopy.Networks {
 		if !network.IsDHCP() {
 			continue


### PR DESCRIPTION
This PR worked on configuring DNS servers for preconfigured networks.

We merged PR 151: https://github.com/cloudfoundry/bosh-agent/pull/151#issuecomment-381711516 and modified this code https://github.com/cloudfoundry/bosh-agent/blob/c74db775183f3e0e68254279e649b802bd4bf63f/platform/net/ubuntu_net_manager.go#L100-L103
It skipped configuring network alias interfaces and caused empty virtual interfaces. We should continue to configure networked after writing DNS entries. 

@mikexuu Please help to view about network configs.