### PR TITLE
Fix iscsiadm compatibility for xenial.

### DIFF
--- a/infrastructure/devicepathresolver/iscsi_device_path_resolver.go
+++ b/infrastructure/devicepathresolver/iscsi_device_path_resolver.go
@@ -166,6 +166,17 @@ func (ispr iscsiDevicePathResolver) connectTarget(iSCSISettings boshsettings.ISC
 		return bosherr.WrapError(err, fmt.Sprintf("Could not discovery lun against portal %s", iSCSISettings.Target))
 	}
 
+	hasBeenLoggedin, err := ispr.openiscsi.IsLoggedin()
+	if err != nil {
+		return bosherr.WrapError(err, "Could not check all sessions")
+	}
+	if hasBeenLoggedin {
+		err = ispr.openiscsi.Logout()
+		if err != nil {
+			return bosherr.WrapError(err, "Could not logout all sessions")
+		}
+	}
+
 	err = ispr.openiscsi.Login()
 	if err != nil {
 		return bosherr.WrapError(err, "Could not login all sessions")

--- a/platform/openiscsi/concrete_open_iscsi_admin_test.go
+++ b/platform/openiscsi/concrete_open_iscsi_admin_test.go
@@ -178,6 +178,44 @@ node.conn[0].iscsi.MaxRecvDataSegmentLength = 65536
 		})
 	})
 
+	Describe("IsLoggedin", func() {
+		var (
+			target string
+		)
+		BeforeEach(func() {
+			target = "11.11.22.22"
+		})
+
+		It("returns true when has active sessions", func() {
+			runner.AddCmdResult(
+				"iscsiadm -m session",
+				fakesys.FakeCmdResult{Stdout: "tcp: [29] 11.11.22.22:1111,2222 iqn.icssi.icssivendor:dc0101"},
+			)
+			hasBeenLoggedin, err := iscsiAdm.IsLoggedin()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(hasBeenLoggedin).To(BeTrue())
+		})
+
+		It("returns false when No active sessions", func() {
+			runner.AddCmdResult(
+				"iscsiadm -m session",
+				fakesys.FakeCmdResult{Stderr: "No active sessions.", ExitStatus: 21},
+			)
+			hasBeenLoggedin, err := iscsiAdm.IsLoggedin()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(hasBeenLoggedin).To(BeFalse())
+		})
+
+		It("returns error when No active sessions", func() {
+			runner.AddCmdResult(
+				"iscsiadm -m session",
+				fakesys.FakeCmdResult{Error: errors.New("fake-cmd-error")},
+			)
+			_, err := iscsiAdm.IsLoggedin()
+			Expect(err.Error()).To(ContainSubstring("fake-cmd-error"))
+		})
+	})
+
 	Describe("Login", func() {
 		It("iscsiadm login successfully", func() {
 			err := iscsiAdm.Login()

--- a/platform/openiscsi/fakes/fake_open_iscsi.go
+++ b/platform/openiscsi/fakes/fake_open_iscsi.go
@@ -59,6 +59,17 @@ type FakeOpenIscsi struct {
 	discoveryReturnsOnCall map[int]struct {
 		result1 error
 	}
+	IsLoggedinStub        func() (bool, error)
+	isLoggedinMutex       sync.RWMutex
+	isLoggedinArgsForCall []struct{}
+	isLoggedinReturns     struct {
+		result1 bool
+		result2 error
+	}
+	isLoggedinReturnsOnCall map[int]struct {
+		result1 bool
+		result2 error
+	}
 	LoginStub        func() (err error)
 	loginMutex       sync.RWMutex
 	loginArgsForCall []struct{}
@@ -299,6 +310,49 @@ func (fake *FakeOpenIscsi) DiscoveryReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
+func (fake *FakeOpenIscsi) IsLoggedin() (bool, error) {
+	fake.isLoggedinMutex.Lock()
+	ret, specificReturn := fake.isLoggedinReturnsOnCall[len(fake.isLoggedinArgsForCall)]
+	fake.isLoggedinArgsForCall = append(fake.isLoggedinArgsForCall, struct{}{})
+	fake.recordInvocation("IsLoggedin", []interface{}{})
+	fake.isLoggedinMutex.Unlock()
+	if fake.IsLoggedinStub != nil {
+		return fake.IsLoggedinStub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.isLoggedinReturns.result1, fake.isLoggedinReturns.result2
+}
+
+func (fake *FakeOpenIscsi) IsLoggedinCallCount() int {
+	fake.isLoggedinMutex.RLock()
+	defer fake.isLoggedinMutex.RUnlock()
+	return len(fake.isLoggedinArgsForCall)
+}
+
+func (fake *FakeOpenIscsi) IsLoggedinReturns(result1 bool, result2 error) {
+	fake.IsLoggedinStub = nil
+	fake.isLoggedinReturns = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeOpenIscsi) IsLoggedinReturnsOnCall(i int, result1 bool, result2 error) {
+	fake.IsLoggedinStub = nil
+	if fake.isLoggedinReturnsOnCall == nil {
+		fake.isLoggedinReturnsOnCall = make(map[int]struct {
+			result1 bool
+			result2 error
+		})
+	}
+	fake.isLoggedinReturnsOnCall[i] = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeOpenIscsi) Login() (err error) {
 	fake.loginMutex.Lock()
 	ret, specificReturn := fake.loginReturnsOnCall[len(fake.loginArgsForCall)]
@@ -392,6 +446,8 @@ func (fake *FakeOpenIscsi) Invocations() map[string][][]interface{} {
 	defer fake.restartMutex.RUnlock()
 	fake.discoveryMutex.RLock()
 	defer fake.discoveryMutex.RUnlock()
+	fake.isLoggedinMutex.RLock()
+	defer fake.isLoggedinMutex.RUnlock()
 	fake.loginMutex.RLock()
 	defer fake.loginMutex.RUnlock()
 	fake.logoutMutex.RLock()

--- a/platform/openiscsi/open_iscsi_interface.go
+++ b/platform/openiscsi/open_iscsi_interface.go
@@ -8,6 +8,7 @@ type OpenIscsi interface {
 	Stop() (err error)
 	Restart() (err error)
 	Discovery(ipAddress string) (err error)
+	IsLoggedin() (bool, error)
 	Login() (err error)
 	Logout() (err error)
 }


### PR DESCRIPTION
This PR worked on iscsiadm compatibility for xenial:

When using xenial, iscsiadm command returns error more explicit such as login when session already present:

```
/etc/iscsi# iscsiadm -m node -l
Logging in to [iface: default, target: iqn.1992-08.com.netapp:stflon0201, portal: 10.1.222.171,3260] (multiple)
Logging in to [iface: default, target: iqn.1992-08.com.netapp:stflon0201, portal: 10.1.222.172,3260] (multiple)
Login to [iface: default, target: iqn.1992-08.com.netapp:stflon0201, portal: 10.1.222.171,3260] successful.
Login to [iface: default, target: iqn.1992-08.com.netapp:stflon0201, portal: 10.1.222.172,3260] successful.
/etc/iscsi# iscsiadm -m node -l
iscsiadm: default: 1 session requested, but 1 already present.
iscsiadm: default: 1 session requested, but 1 already present.
iscsiadm: Could not log into all portals
```

So bosh-agent need log out session before re-login for xenial. 