### PR TITLE
Repartition ephemeral disk when OS reload

### DIFF
--- a/platform/bootstrap_state.go
+++ b/platform/bootstrap_state.go
@@ -14,7 +14,8 @@ type BootstrapState struct {
 }
 
 type LinuxState struct {
-	HostsConfigured bool `json:"hosts_configured"`
+	HostsConfigured          bool `json:"hosts_configured"`
+	EphemeralDiskPartitioned bool `json:"ephemeral_disk_partitioned,omitempty"`
 }
 
 func NewBootstrapState(fs boshsys.FileSystem, path string) (*BootstrapState, error) {

--- a/platform/bootstrap_state_test.go
+++ b/platform/bootstrap_state_test.go
@@ -6,7 +6,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	platform "github.com/cloudfoundry/bosh-agent/platform"
+	"github.com/cloudfoundry/bosh-agent/platform"
 	fakesys "github.com/cloudfoundry/bosh-utils/system/fakes"
 )
 
@@ -46,6 +46,16 @@ var _ = Describe("State", func() {
 			Expect(string(contents)).To(Equal(`{"Linux":{"hosts_configured":true}}`))
 		})
 
+		It("saves the state file with the ephemeral_disk_partitioned passed in", func() {
+			s.Linux = platform.LinuxState{HostsConfigured: true, EphemeralDiskPartitioned: true}
+			s.SaveState()
+
+			contents, readerr := fs.ReadFile(path)
+
+			Expect(readerr).ToNot(HaveOccurred())
+			Expect(string(contents)).To(Equal(`{"Linux":{"hosts_configured":true,"ephemeral_disk_partitioned":true}}`))
+		})
+
 		It("returns an error when it can't write the file", func() {
 			s.Linux = platform.LinuxState{HostsConfigured: true}
 			fs.WriteFileError = errors.New("ENXIO: disk failed")
@@ -69,6 +79,7 @@ var _ = Describe("State", func() {
 				s, err = platform.NewBootstrapState(fs, path)
 
 				Expect(s.Linux.HostsConfigured).To(BeFalse())
+				Expect(s.Linux.EphemeralDiskPartitioned).To(BeFalse())
 			})
 		})
 
@@ -77,6 +88,7 @@ var _ = Describe("State", func() {
 				s, err = platform.NewBootstrapState(fs, "")
 
 				Expect(s.Linux.HostsConfigured).To(BeFalse())
+				Expect(s.Linux.EphemeralDiskPartitioned).To(BeFalse())
 			})
 		})
 

--- a/platform/disk/linux_disk_manager.go
+++ b/platform/disk/linux_disk_manager.go
@@ -36,6 +36,7 @@ func NewLinuxDiskManager(
 	runner boshsys.CmdRunner,
 	fs boshsys.FileSystem,
 	opts LinuxDiskManagerOpts,
+	ephemeralPartitioned bool,
 ) Manager {
 	var mounter Mounter
 	var mountsSearcher MountsSearcher
@@ -61,7 +62,7 @@ func NewLinuxDiskManager(
 	var ephemeralPartitioner, persistentPartitioner Partitioner
 
 	diskUtil := NewUtil(runner, mounter, fs, logger)
-	partedPartitioner := NewPartedPartitioner(logger, runner, clock.NewClock())
+	partedPartitioner := NewPartedPartitioner(logger, runner, clock.NewClock(), ephemeralPartitioned)
 	sfDiskPartitioner := NewSfdiskPartitioner(logger, runner, clock.NewClock())
 
 	switch opts.PartitionerType {

--- a/platform/disk/parted_partitioner_test.go
+++ b/platform/disk/parted_partitioner_test.go
@@ -40,6 +40,8 @@ func scrubPartitionNames(commands [][]string) [][]string {
 
 var _ = Describe("PartedPartitioner", func() {
 	var (
+		ephemeralDiskPartitioned bool
+
 		fakeCmdRunner *fakesys.FakeCmdRunner
 		partitioner   Partitioner
 		fakeclock     *fakeboshaction.FakeClock
@@ -47,10 +49,12 @@ var _ = Describe("PartedPartitioner", func() {
 	)
 
 	BeforeEach(func() {
+		ephemeralDiskPartitioned = false
+
 		logger = boshlog.NewLogger(boshlog.LevelNone)
 		fakeCmdRunner = fakesys.NewFakeCmdRunner()
 		fakeclock = &fakeboshaction.FakeClock{}
-		partitioner = NewPartedPartitioner(logger, fakeCmdRunner, fakeclock)
+		partitioner = NewPartedPartitioner(logger, fakeCmdRunner, fakeclock, ephemeralDiskPartitioned)
 	})
 
 	Describe("Partition", func() {
@@ -219,7 +223,7 @@ var _ = Describe("PartedPartitioner", func() {
 						)
 					})
 
-					It("does NOT partition the disk, and returns an error", func() {
+					It("does NOT partition the disk, and returns an error when ephemeralDiskPartitioned is set to true", func() {
 						partitions := []Partition{
 							{SizeInBytes: 8589934592}, // (8GiB)
 							{SizeInBytes: 8589934592}, // (8GiB)
@@ -240,12 +244,97 @@ var _ = Describe("PartedPartitioner", func() {
 						// 17180917760 - 0 - 1 = 17180917759
 						// second start=8590983168, end=17180917759, size=8589934592
 
+						ephemeralDiskPartitioned = true
+						partitioner = NewPartedPartitioner(logger, fakeCmdRunner, fakeclock, ephemeralDiskPartitioned)
+
 						err := partitioner.Partition("/dev/sda", partitions)
 						Expect(err.Error()).To(Equal("'/dev/sda' contains a partition created by bosh. No partitioning is allowed."))
 
 						Expect(len(fakeCmdRunner.RunCommands)).To(Equal(1))
 						scrubbedCommands := scrubPartitionNames(fakeCmdRunner.RunCommands)
 						Expect(scrubbedCommands).To(ContainElement([]string{"parted", "-m", "/dev/sda", "unit", "B", "print"}))
+					})
+
+					It("Repartition the disk when ephemeralDiskPartitioned is set to false", func() {
+						partitions := []Partition{
+							{SizeInBytes: 8589934592}, // (8GiB)
+							{SizeInBytes: 8589934592}, // (8GiB)
+						}
+
+						err := partitioner.Partition("/dev/sda", partitions)
+						Expect(err).To(BeNil())
+
+						Expect(len(fakeCmdRunner.RunCommands)).To(Equal(8))
+						scrubbedCommands := scrubPartitionNames(fakeCmdRunner.RunCommands)
+						Expect(scrubbedCommands).To(ContainElement([]string{"parted", "-m", "/dev/sda", "unit", "B", "print"}))
+						Expect(scrubbedCommands).To(ContainElement([]string{"parted", "/dev/sda", "rm", "1"}))
+						Expect(scrubbedCommands).To(ContainElement([]string{"parted", "-s", "/dev/sda", "unit", "B", "mkpart", "bosh-partition-x", "1048576", "8590983167"}))
+						Expect(scrubbedCommands).To(ContainElement([]string{"parted", "-s", "/dev/sda", "unit", "B", "mkpart", "bosh-partition-x", "8590983168", "17180917759"}))
+						Expect(scrubbedCommands).To(ContainElement([]string{"partprobe", "/dev/sda"}))
+						Expect(scrubbedCommands).To(ContainElement([]string{"udevadm", "settle"}))
+					})
+
+					It("Repartition the first disk and set ephemeralDiskPartitioned to true when ephemeralDiskPartitioned is set to false", func() {
+						fakeCmdRunner.AddCmdResult(
+							"parted -m /dev/sda unit B print",
+							fakesys.FakeCmdResult{
+								Stdout: `BYT;
+/dev/xvdf:221190815744B:xvd:512:512:gpt:Xen Virtual Block Device;
+1:512B:2048576B:199680B:ext4:bosh-partition-0:;
+`},
+						)
+
+						partitions := []Partition{
+							{SizeInBytes: 8589934592}, // (8GiB)
+							{SizeInBytes: 8589934592}, // (8GiB)
+						}
+
+						err := partitioner.Partition("/dev/sda", partitions)
+						Expect(err).To(BeNil())
+
+						Expect(len(fakeCmdRunner.RunCommands)).To(Equal(8))
+						scrubbedCommands := scrubPartitionNames(fakeCmdRunner.RunCommands)
+
+						err = partitioner.Partition("/dev/sda", partitions)
+						Expect(err.Error()).To(Equal("'/dev/sda' contains a partition created by bosh. No partitioning is allowed."))
+						Expect(len(fakeCmdRunner.RunCommands)).To(Equal(9))
+						scrubbedCommands = scrubPartitionNames(fakeCmdRunner.RunCommands)
+						Expect(scrubbedCommands).To(ContainElement([]string{"parted", "-m", "/dev/sda", "unit", "B", "print"}))
+						Expect(scrubbedCommands).To(ContainElement([]string{"parted", "/dev/sda", "rm", "1"}))
+						Expect(scrubbedCommands).To(ContainElement([]string{"parted", "-s", "/dev/sda", "unit", "B", "mkpart", "bosh-partition-x", "1048576", "8590983167"}))
+						Expect(scrubbedCommands).To(ContainElement([]string{"parted", "-s", "/dev/sda", "unit", "B", "mkpart", "bosh-partition-x", "8590983168", "17180917759"}))
+						Expect(scrubbedCommands).To(ContainElement([]string{"partprobe", "/dev/sda"}))
+						Expect(scrubbedCommands).To(ContainElement([]string{"udevadm", "settle"}))
+					})
+
+					It("Return error when removing when ephemeralDiskPartitioned is set to false", func() {
+						partitions := []Partition{
+							{SizeInBytes: 8589934592}, // (8GiB)
+							{SizeInBytes: 8589934592}, // (8GiB)
+						}
+
+						fakeCmdRunner.AddCmdResult(
+							"parted /dev/sda rm 1",
+							fakesys.FakeCmdResult{
+								Error: errors.New("fake-cmd-error"),
+							},
+						)
+						fakeCmdRunner.AddCmdResult(
+							"parted /dev/sda rm 1",
+							fakesys.FakeCmdResult{},
+						)
+
+						err := partitioner.Partition("/dev/sda", partitions)
+						Expect(err).To(BeNil())
+
+						Expect(len(fakeCmdRunner.RunCommands)).To(Equal(9))
+						scrubbedCommands := scrubPartitionNames(fakeCmdRunner.RunCommands)
+						Expect(scrubbedCommands).To(ContainElement([]string{"parted", "-m", "/dev/sda", "unit", "B", "print"}))
+						Expect(scrubbedCommands).To(ContainElement([]string{"parted", "/dev/sda", "rm", "1"}))
+						Expect(scrubbedCommands).To(ContainElement([]string{"parted", "-s", "/dev/sda", "unit", "B", "mkpart", "bosh-partition-x", "1048576", "8590983167"}))
+						Expect(scrubbedCommands).To(ContainElement([]string{"parted", "-s", "/dev/sda", "unit", "B", "mkpart", "bosh-partition-x", "8590983168", "17180917759"}))
+						Expect(scrubbedCommands).To(ContainElement([]string{"partprobe", "/dev/sda"}))
+						Expect(scrubbedCommands).To(ContainElement([]string{"udevadm", "settle"}))
 					})
 				})
 

--- a/platform/linux_platform.go
+++ b/platform/linux_platform.go
@@ -1467,8 +1467,22 @@ func (p linux) partitionDisk(availableSize uint64, desiredSwapSizeInBytes *uint6
 		dataPartitionPath = p.partitionPath(partitionPath, partitionStartCount+1)
 	}
 
-	p.logger.Info(logTag, "Partitioning `%s' with %s", partitionPath, partitions)
-	err = partitioner.Partition(partitionPath, partitions)
+	if !p.state.Linux.EphemeralDiskPartitioned {
+		p.logger.Info(logTag, "Partitioning `%s' with %s", partitionPath, partitions)
+		err = partitioner.Partition(partitionPath, partitions)
+
+		// Only set EphemeralDiskPartitioned to true when ScrubEphemeralDisk is set to true
+		if p.options.ScrubEphemeralDisk {
+			p.logger.Info(logTag, "Setting EphemeralDiskPartitioned to true")
+			p.state.Linux.EphemeralDiskPartitioned = true
+			err = p.state.SaveState()
+			if err != nil {
+				p.logger.Warn(logTag, "Setting EphemeralDiskPartitioned to true: %s", err.Error())
+			}
+		}
+	} else {
+		p.logger.Info(logTag, "Skipping to partition `%s'", partitionPath)
+	}
 
 	return swapPartitionPath, dataPartitionPath, err
 }

--- a/platform/provider.go
+++ b/platform/provider.go
@@ -58,7 +58,7 @@ func NewProvider(logger boshlog.Logger, dirProvider boshdirs.Provider, statsColl
 
 	auditLogger.StartLogging()
 
-	linuxDiskManager := boshdisk.NewLinuxDiskManager(logger, runner, fs, diskManagerOpts)
+	linuxDiskManager := boshdisk.NewLinuxDiskManager(logger, runner, fs, diskManagerOpts, bootstrapState.Linux.EphemeralDiskPartitioned)
 	udev := boshudev.NewConcreteUdevDevice(runner, logger)
 	linuxCdrom := boshcdrom.NewLinuxCdrom("/dev/sr0", udev, runner)
 	linuxCdutil := boshcdrom.NewCdUtil(dirProvider.SettingsDir(), fs, linuxCdrom, logger)


### PR DESCRIPTION
Hi,

This PR focused on repartition ephemeral disk and was originated from https://github.com/cloudfoundry/bosh-agent/issues/184

1. When OS reload, agent will repartition the ephemeral disk and set `ephemeral_disk_partitioned` to true.

2. When OS reboot or agent restart, agent will check `ephemeral_disk_partitioned` field and skip repartitioning if it is true.


/cc @mattcui @dpb587  Please help to review