### PR TITLE
agentclient/http: fix retry format string

### DIFF
--- a/agentclient/http/agent_client.go
+++ b/agentclient/http/agent_client.go
@@ -224,8 +224,7 @@ func (c *AgentClient) SendAsyncTaskMessage(method string, arguments []interface{
 			sendErrors++
 			shouldRetry := sendErrors <= c.toleratedErrorCount
 			err = bosherr.WrapError(err, "Sending 'get_task' to the agent")
-			msg := fmt.Sprintf("Error occured sending get_task. Error retry %d of %d", sendErrors, c.toleratedErrorCount)
-			c.logger.Debug(c.logTag, msg, err)
+			c.logger.Debug(c.logTag, "Error occured sending get_task. Error retry %d of %d: %s", sendErrors, c.toleratedErrorCount, err.Error())
 			return shouldRetry, err
 		}
 		sendErrors = 0


### PR DESCRIPTION
The format string was correct in the context of the informational line
but didn't have a placeholder for the error message added in the next
line.

Adding a '%s' to the first line would work but would confuse static
analysis tools which would detect it as a placeholder-to-argument
mismatch. Inlining everything results in a longer but overall simpler
line.

**Before**
```
[httpAgentClient] 2018/08/28 13:04:34 DEBUG - Error occured sending get_task. Error retry 1 of 10%!(EXTRA errors.ComplexError=Sending 'get_task' to the agent: Agent responded with error: Action Failed get_task: Task 42cfd353-5d4e-41ab-7adb-ea0894c13e74 result: Extracting method arguments from payload: Unmarshalling action argument: No digest algorithm found. Supported algorithms: sha1, sha256, sha512)
```

**After**
```
[httpAgentClient] 2018/08/29 09:31:51 DEBUG - Error occured sending get_task. Error retry 3 of 10: Sending 'get_task' to the agent: Agent responded with error: Action Failed get_task: Task 8f94f1c3-006d-496e-639b-5071d2cf2e86 result: Extracting method arguments from payload: Unmarshalling action argument: No digest algorithm found. Supported algorithms: sha1, sha256, sha512
```