### PR TITLE
Simplify NicSettingsTemplate

### DIFF
--- a/platform/net/windows_net_manager.go
+++ b/platform/net/windows_net_manager.go
@@ -86,8 +86,7 @@ foreach($interface in $interfaces) {
 `
 
 	NicSettingsTemplate = `
-$connectionName=(get-wmiobject win32_networkadapter | where-object {$_.MacAddress -eq '%s'}).netconnectionid
-netsh interface ip set address $connectionName static %s %s %s
+netsh interface ip set address %q static %s %s %s
 `
 )
 
@@ -210,7 +209,7 @@ func (net WindowsNetManager) setupInterfaces(staticConfigs []StaticInterfaceConf
 			gateway = conf.Gateway
 		}
 
-		content := fmt.Sprintf(NicSettingsTemplate, conf.Mac, conf.Address, conf.Netmask, gateway)
+		content := fmt.Sprintf(NicSettingsTemplate, conf.Name, conf.Address, conf.Netmask, gateway)
 
 		_, _, _, err := net.runner.RunCommand("powershell", "-Command", content)
 		if err != nil {

--- a/platform/net/windows_net_manager_test.go
+++ b/platform/net/windows_net_manager_test.go
@@ -123,10 +123,11 @@ var _ = Describe("WindowsNetManager", func() {
 			err := setupNetworking(boshsettings.Networks{"net1": network1, "net2": network2, "vip": vip})
 			Expect(err).ToNot(HaveOccurred())
 
+
 			Expect(runner.RunCommands).To(
-				ContainElement([]string{"powershell", "-Command", fmt.Sprintf(NicSettingsTemplate, network1.Mac, network1.IP, network1.Netmask, network1.Gateway)}))
+				ContainElement([]string{"powershell", "-Command", fmt.Sprintf(NicSettingsTemplate, macAddressDetector.macs[network1.Mac], network1.IP, network1.Netmask, network1.Gateway)}))
 			Expect(runner.RunCommands).To(
-				ContainElement([]string{"powershell", "-Command", fmt.Sprintf(NicSettingsTemplate, network2.Mac, network2.IP, network2.Netmask, "")}))
+				ContainElement([]string{"powershell", "-Command", fmt.Sprintf(NicSettingsTemplate, macAddressDetector.macs[network2.Mac], network2.IP, network2.Netmask, "")}))
 		})
 
 		It("ignores VIP networks", func() {
@@ -138,7 +139,7 @@ var _ = Describe("WindowsNetManager", func() {
 		It("returns an error when configuring fails", func() {
 			setUpMACs(macAddressDetector, network1)
 			runner.AddCmdResult(
-				"powershell -Command "+fmt.Sprintf(NicSettingsTemplate, network1.Mac, network1.IP, network1.Netmask, network1.Gateway),
+				"powershell -Command "+fmt.Sprintf(NicSettingsTemplate, macAddressDetector.macs[network1.Mac], network1.IP, network1.Netmask, network1.Gateway),
 				fakesys.FakeCmdResult{Error: errors.New("fake-err")},
 			)
 


### PR DESCRIPTION
We were running into a problem where after creating an HNS Network we were getting two network adapters returned for the same MAC address.

This was then causing the `netsh interface ip set` line of the NicSettingsTemplate powershell script to fail since it was combining the two names.

We tried this change out with a 2019 stemcell. It fixed our problem and seemed to otherwise work fine.

@ashwin-venkatesh 