### PR TITLE
Make fly exec to not ignore bosh-agent binary

### DIFF
--- a/bin/repack-stemcell/run.sh
+++ b/bin/repack-stemcell/run.sh
@@ -10,6 +10,10 @@ cd "${bin}"/../..
 
 mv out/bosh-agent bin/bosh-agent # necessary so that fly -x can be used
 
+git add -f bin/bosh-agent
+
 time fly -t production execute -p -i agent-src=. -o stemcell=out/ -c ./bin/repack-stemcell/task.yml
+
+git reset bin/bosh-agent
 
 ls -la out/stemcell.tgz


### PR DESCRIPTION
Currently, when running the repack-stemcell script the concourse one-off ignores the just created bosh-agent binary. 

We temporarily added the bosh-agent binary to the git index to ensure it is being picked by concourse as input resource. Alternatively the concourse CLI provides a flag `fly execute --include-ignored` which will take everything ignored by git. However, we thought there might be credentials you do not want to be uploaded to concourse.

Any thoughts from your side?
 
Co-authored-by: Florian Nachtigall <florian.nachtigall@sap.com>