### PR TITLE
Reduce duplicated code for writeresolvConf func

### DIFF
--- a/platform/net/ubuntu_net_manager.go
+++ b/platform/net/ubuntu_net_manager.go
@@ -3,7 +3,6 @@ package net
 import (
 	"bytes"
 	"path"
-	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
@@ -456,30 +455,6 @@ func (net UbuntuNetManager) writeResolvConf(networks boshsettings.Networks) erro
 		if err != nil {
 			return bosherr.WrapError(err, "Writing to /etc/resolvconf/resolv.conf.d/base")
 		}
-	} else {
-		// For the first time before resolv.conf is symlinked to /run/...
-		// inherit possibly configured resolv.conf
-
-		targetPath, err := net.fs.ReadAndFollowLink("/etc/resolv.conf")
-		if err != nil {
-			return bosherr.WrapError(err, "Reading /etc/resolv.conf symlink")
-		}
-
-		expectedPath, err := filepath.Abs("/etc/resolv.conf")
-		if err != nil {
-			return bosherr.WrapError(err, "Resolving path to native OS")
-		}
-		if targetPath == expectedPath {
-			err := net.fs.CopyFile("/etc/resolv.conf", "/etc/resolvconf/resolv.conf.d/base")
-			if err != nil {
-				return bosherr.WrapError(err, "Copying /etc/resolv.conf for backwards compat")
-			}
-		}
-	}
-
-	err = net.fs.Symlink("/run/resolvconf/resolv.conf", "/etc/resolv.conf")
-	if err != nil {
-		return bosherr.WrapError(err, "Setting up /etc/resolv.conf symlink")
 	}
 
 	_, _, _, err = net.cmdRunner.RunCommand("resolvconf", "-u")

--- a/platform/net/ubuntu_net_manager_test.go
+++ b/platform/net/ubuntu_net_manager_test.go
@@ -3,7 +3,6 @@ package net_test
 import (
 	"errors"
 	"fmt"
-	"path/filepath"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -294,16 +293,6 @@ nameserver 9.9.9.9
 					}
 				})
 
-				Context("when could not read link /etc/resolv.conf", func() {
-					It("fails reporting error", func() {
-						fs.ReadAndFollowLinkError = errors.New("fake-read-link-error")
-
-						err := netManager.SetupNetworking(networks, nil)
-						Expect(err).To(HaveOccurred())
-						Expect(err.Error()).To(ContainSubstring("Reading /etc/resolv.conf symlink"))
-					})
-				})
-
 				Context("when /etc/resolv.conf is no symlink", func() {
 					BeforeEach(func() {
 						err := fs.Symlink("/etc/resolv.conf", "/etc/resolv.conf")
@@ -313,47 +302,6 @@ nameserver 9.9.9.9
 						Expect(err).ToNot(HaveOccurred())
 					})
 
-					It("copies /etc/resolv.conf to .../resolv.conf.d/base", func() {
-						err := netManager.SetupNetworking(networks, nil)
-						Expect(err).ToNot(HaveOccurred())
-
-						contents, err := fs.ReadFile("/etc/resolvconf/resolv.conf.d/base")
-						Expect(err).ToNot(HaveOccurred())
-						Expect(string(contents)).To(Equal("fake-content"))
-					})
-
-					Context("when copying fails", func() {
-						It("fails reporting the error", func() {
-							fs.CopyFileError = errors.New("fake-copy-error")
-
-							err := netManager.SetupNetworking(networks, nil)
-							Expect(err).To(HaveOccurred())
-							Expect(err.Error()).To(ContainSubstring("Copying /etc/resolv.conf for backwards compat"))
-						})
-					})
-				})
-			})
-
-			It("forces /etc/resolv.conf to be a symlink", func() {
-				err := netManager.SetupNetworking(networks, nil)
-				Expect(err).ToNot(HaveOccurred())
-				linkContents, err := fs.Readlink("/etc/resolv.conf")
-				Expect(err).ToNot(HaveOccurred())
-
-				expectedContents, err := filepath.Abs("/run/resolvconf/resolv.conf")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(linkContents).To(Equal(expectedContents))
-			})
-
-			Context("when symlink command fails", func() {
-				BeforeEach(func() {
-					fs.SymlinkError = errors.New("fake-symlink-error")
-				})
-
-				It("fails reporting error", func() {
-					err := netManager.SetupNetworking(networks, nil)
-					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("Setting up /etc/resolv.conf symlink"))
 				})
 			})
 


### PR DESCRIPTION
`writeresolvConf` func had duplicated code about `etc/resolv.conf` symbolic link which `resolvcof`  package already covered. This PR reduced duplicated code.


Best,

@edwardstudy, IBM

/cc @mattcui @dpb587-pivotal 