### PR TITLE
platform/disk: Reread partitions for block device

### DIFF
--- a/platform/disk/linux_disk_manager.go
+++ b/platform/disk/linux_disk_manager.go
@@ -74,7 +74,7 @@ func NewLinuxDiskManager(
 		persistentPartitioner = sfDiskPartitioner
 	case "":
 		ephemeralPartitioner = sfDiskPartitioner
-		persistentPartitioner = NewPersistentDevicePartitioner(sfDiskPartitioner, partedPartitioner, diskUtil, logger)
+		persistentPartitioner = NewPersistentDevicePartitioner(sfDiskPartitioner, partedPartitioner, diskUtil, logger, runner)
 	default:
 		panic(fmt.Sprintf("Unknown partitioner type '%s'", opts.PartitionerType))
 	}

--- a/platform/disk/linux_disk_manager_test.go
+++ b/platform/disk/linux_disk_manager_test.go
@@ -96,6 +96,7 @@ var _ = Describe("NewLinuxDiskManager", func() {
 				disk.NewPartedPartitioner(logger, runner, clock.NewClock()),
 				disk.NewUtil(runner, mounter, fs, logger),
 				logger,
+				runner,
 			)))
 		})
 

--- a/platform/disk/persistent_device_partitioner_test.go
+++ b/platform/disk/persistent_device_partitioner_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cloudfoundry/bosh-agent/platform/disk"
 	"github.com/cloudfoundry/bosh-agent/platform/disk/fakes"
 	"github.com/cloudfoundry/bosh-utils/logger"
+	fakesys "github.com/cloudfoundry/bosh-utils/system/fakes"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -16,6 +17,7 @@ var _ = Describe("PersistentDevicePartitioner", func() {
 		sfDiskPartitioner *fakes.FakePartitioner
 		partedPartitioner *fakes.FakePartitioner
 		diskUtil          *fakes.FakeDiskUtil
+		runner            *fakesys.FakeCmdRunner
 
 		devicePath string
 		partitions []disk.Partition
@@ -38,8 +40,9 @@ var _ = Describe("PersistentDevicePartitioner", func() {
 		sfDiskPartitioner = fakes.NewFakePartitioner()
 		partedPartitioner = fakes.NewFakePartitioner()
 		diskUtil = fakes.NewFakeDiskUtil()
+		runner = fakesys.NewFakeCmdRunner()
 
-		partitioner = disk.NewPersistentDevicePartitioner(sfDiskPartitioner, partedPartitioner, diskUtil, logger)
+		partitioner = disk.NewPersistentDevicePartitioner(sfDiskPartitioner, partedPartitioner, diskUtil, logger, runner)
 	})
 
 	Describe("Partition", func() {


### PR DESCRIPTION
Fixes an issue when block device size is not detected properly due to stale information in kernel.

Links:
- https://github.com/cloudfoundry/bosh-agent/issues/198