### PR TITLE
Enable specification of a second mbus password

### DIFF
--- a/bin/test-bosh-integration
+++ b/bin/test-bosh-integration
@@ -19,7 +19,7 @@ else
   )
 fi
 
-cd $base/tmp/bosh
+cd $base/tmp/bosh/src
 
 echo -e "\n Installing BOSH dependencies..."
 bundle install
@@ -29,4 +29,4 @@ rm -rf go/src/github.com/cloudfoundry/bosh-agent
 ln -s $base go/src/github.com/cloudfoundry/bosh-agent
 
 echo -e "\n Running integration tests..."
-bundle exec rake spec:integration
+bundle exec rake spec:integration:gocli

--- a/mbus/handler_provider.go
+++ b/mbus/handler_provider.go
@@ -42,6 +42,7 @@ func (p HandlerProvider) Get(
 	}
 
 	mbusURL, err := url.Parse(p.settingsService.GetSettings().GetMbusURL())
+	alternativePassword := p.settingsService.GetSettings().GetAlternativeMbusPassword()
 	if err != nil {
 		err = bosherr.WrapError(err, "Parsing handler URL")
 		return
@@ -53,7 +54,7 @@ func (p HandlerProvider) Get(
 		handler = NewNatsHandler(p.settingsService, natsClient, p.logger, platform)
 	case "https":
 		mbusKeyPair := p.settingsService.GetSettings().Env.Bosh.Mbus.Cert
-		handler = NewHTTPSHandler(mbusURL, mbusKeyPair, blobManager, p.logger, p.auditLogger)
+		handler = NewHTTPSHandler(mbusURL, alternativePassword, mbusKeyPair, blobManager, p.logger, p.auditLogger)
 	default:
 		err = bosherr.Errorf("Message Bus Handler with scheme %s could not be found", mbusURL.Scheme)
 	}

--- a/mbus/handler_provider_test.go
+++ b/mbus/handler_provider_test.go
@@ -55,7 +55,7 @@ var _ = Describe("HandlerProvider", func() {
 			settingsService.Settings.Mbus = "https://foo:bar@lol"
 			handler, err := provider.Get(platform, blobManager)
 			Expect(err).ToNot(HaveOccurred())
-			expectedHandler := NewHTTPSHandler(mbusURL, settings.CertKeyPair{}, blobManager, logger, auditLogger)
+			expectedHandler := NewHTTPSHandler(mbusURL, "", settings.CertKeyPair{}, blobManager, logger, auditLogger)
 			httpsHandler, ok := handler.(HTTPSHandler)
 			Expect(ok).To(BeTrue())
 			Expect(httpsHandler).To(Equal(expectedHandler))
@@ -68,10 +68,12 @@ var _ = Describe("HandlerProvider", func() {
 			settingsService.Settings.Mbus = "https://foo:bar@lol"
 			settingsService.Settings.Env.Bosh.Mbus.Cert.Certificate = "certificate-pem-block"
 			settingsService.Settings.Env.Bosh.Mbus.Cert.PrivateKey = "private-key-pem-block"
+			settingsService.Settings.Env.Bosh.Mbus.AlternativePassword = "fake-alt-password"
 
 			handler, err := provider.Get(platform, blobManager)
 			expectedHandler := NewHTTPSHandler(
 				mbusURL,
+				"fake-alt-password",
 				settingsService.Settings.Env.Bosh.Mbus.Cert,
 				blobManager,
 				logger,

--- a/mbus/https_handler.go
+++ b/mbus/https_handler.go
@@ -29,6 +29,7 @@ type HTTPSHandler struct {
 
 func NewHTTPSHandler(
 	parsedURL *url.URL,
+	alternativePassword string,
 	keyPair settings.CertKeyPair,
 	blobManager boshagentblobstore.BlobManagerInterface,
 	logger boshlog.Logger,
@@ -38,7 +39,7 @@ func NewHTTPSHandler(
 		parsedURL:   parsedURL,
 		logger:      logger,
 		blobManager: blobManager,
-		dispatcher:  NewHTTPSDispatcher(parsedURL, keyPair, logger),
+		dispatcher:  NewHTTPSDispatcher(parsedURL, alternativePassword, keyPair, logger),
 		auditLogger: auditLogger,
 	}
 }

--- a/mbus/https_handler_test.go
+++ b/mbus/https_handler_test.go
@@ -23,12 +23,13 @@ import (
 
 var _ = Describe("HTTPSHandler", func() {
 	var (
-		serverURL       string
-		tmpdir          string
-		handler         HTTPSHandler
-		receivedRequest boshhandler.Request
-		httpClient      http.Client
-		blobManager     boshagentblobstore.BlobManagerInterface
+		serverURL           string
+		alternativePassword string
+		tmpdir              string
+		handler             HTTPSHandler
+		receivedRequest     boshhandler.Request
+		httpClient          http.Client
+		blobManager         boshagentblobstore.BlobManagerInterface
 	)
 
 	BeforeEach(func() {
@@ -65,7 +66,7 @@ var _ = Describe("HTTPSHandler", func() {
 
 			mbusURL, _ := url.Parse(serverURL)
 			logger := boshlog.NewWriterLogger(boshlog.LevelDebug, GinkgoWriter)
-			handler = NewHTTPSHandler(mbusURL, mbusKeyPair, blobManager, logger, fakes.NewFakeAuditLogger())
+			handler = NewHTTPSHandler(mbusURL, alternativePassword, mbusKeyPair, blobManager, logger, fakes.NewFakeAuditLogger())
 
 			go handler.Start(func(req boshhandler.Request) (resp boshhandler.Response) {
 				receivedRequest = req

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -155,6 +155,9 @@ func (s Settings) GetMbusURL() string {
 	return s.Mbus
 }
 
+func (s Settings) GetAlternativeMbusPassword() string {
+	return s.Env.Bosh.Mbus.AlternativePassword
+}
 func (s Settings) GetBlobstore() Blobstore {
 	if len(s.Env.Bosh.Blobstores) > 0 {
 		return s.Env.Bosh.Blobstores[0]
@@ -292,8 +295,9 @@ type AgentSettings struct {
 }
 
 type MBus struct {
-	Cert CertKeyPair `json:"cert"`
-	URLs []string    `json:"urls"`
+	Cert                CertKeyPair `json:"cert"`
+	URLs                []string    `json:"urls"`
+	AlternativePassword string      `json:"alternative_password"`
 }
 
 type CertKeyPair struct {

--- a/settings/settings_test.go
+++ b/settings/settings_test.go
@@ -910,7 +910,8 @@ var _ = Describe("Settings", func() {
 			"cert": {
 				"private_key": "fake-private-key-pem",
 				"certificate": "fake-certificate-pem"
-      }
+      },
+			"alternative_password": "fake-alt-password"
     }
   }
 }`
@@ -925,6 +926,11 @@ var _ = Describe("Settings", func() {
 			Expect(*env.GetSwapSizeInBytes()).To(Equal(uint64(2048 * 1024 * 1024)))
 			Expect(*env.GetSwapSizeInBytes()).To(Equal(uint64(2048 * 1024 * 1024)))
 			Expect(*env.GetSwapSizeInBytes()).To(Equal(uint64(2048 * 1024 * 1024)))
+
+			settings := Settings{
+				Env: env,
+			}
+			Expect(settings.GetAlternativeMbusPassword()).To(Equal("fake-alt-password"))
 		})
 
 		It("can enable ipv6", func() {


### PR DESCRIPTION
* allow configuration of a second password in agent settings (env/bosh/mbus/alternative_password)
* both passwords are valid for login
* Necessary for rotation of mbus_bootstrap_password without skipping
drain scripts in create_env

[#161682954](https://www.pivotaltracker.com/story/show/161682954)

Co-authored-by: Manuel Dewald <m.dewald@sap.com>