### PR TITLE
Added support for resizing root disks which are of XFS file system types

### DIFF
--- a/platform/disk/fakes/fake_formatter.go
+++ b/platform/disk/fakes/fake_formatter.go
@@ -5,10 +5,17 @@ import (
 )
 
 type FakeFormatter struct {
+	GetFileSystemType    map[string]boshdisk.FileSystemType
 	FormatCalled         bool
 	FormatPartitionPaths []string
 	FormatFsTypes        []boshdisk.FileSystemType
 	FormatError          error
+}
+
+func NewFakeFormatter() *FakeFormatter {
+	return &FakeFormatter{
+		GetFileSystemType: make(map[string]boshdisk.FileSystemType),
+	}
 }
 
 func (p *FakeFormatter) Format(partitionPath string, fsType boshdisk.FileSystemType) (err error) {
@@ -19,4 +26,11 @@ func (p *FakeFormatter) Format(partitionPath string, fsType boshdisk.FileSystemT
 	p.FormatPartitionPaths = append(p.FormatPartitionPaths, partitionPath)
 	p.FormatFsTypes = append(p.FormatFsTypes, fsType)
 	return
+}
+
+func (p *FakeFormatter) GetPartitionFormatType(partitionPath string) (boshdisk.FileSystemType, error) {
+	if p.FormatError != nil {
+		return "", p.FormatError
+	}
+	return p.GetFileSystemType[partitionPath], nil
 }

--- a/platform/disk/formatter_interface.go
+++ b/platform/disk/formatter_interface.go
@@ -3,12 +3,15 @@ package disk
 type FileSystemType string
 
 const (
-	FileSystemSwap    FileSystemType = "swap"
-	FileSystemExt4    FileSystemType = "ext4"
-	FileSystemXFS     FileSystemType = "xfs"
-	FileSystemDefault FileSystemType = ""
+	FileSystemSwap             FileSystemType = "swap"
+	FileSystemExt4             FileSystemType = "ext4"
+	FileSystemXFS              FileSystemType = "xfs"
+	FileSystemDefault          FileSystemType = ""
+	FileSystemExtResizeUtility                = "resize2fs"
+	FileSystemXFSResizeUtility                = "xfs_growfs"
 )
 
 type Formatter interface {
 	Format(partitionPath string, fsType FileSystemType) (err error)
+	GetPartitionFormatType(string) (FileSystemType, error)
 }

--- a/platform/disk/linux_formatter.go
+++ b/platform/disk/linux_formatter.go
@@ -1,10 +1,11 @@
 package disk
 
 import (
-	bosherr "github.com/cloudfoundry/bosh-utils/errors"
-	boshsys "github.com/cloudfoundry/bosh-utils/system"
 	"regexp"
 	"strings"
+
+	bosherr "github.com/cloudfoundry/bosh-utils/errors"
+	boshsys "github.com/cloudfoundry/bosh-utils/system"
 )
 
 type linuxFormatter struct {
@@ -20,7 +21,7 @@ func NewLinuxFormatter(runner boshsys.CmdRunner, fs boshsys.FileSystem) Formatte
 }
 
 func (f linuxFormatter) Format(partitionPath string, fsType FileSystemType) (err error) {
-	existingFsType, err := f.getPartitionFormatType(partitionPath)
+	existingFsType, err := f.GetPartitionFormatType(partitionPath)
 	if err != nil {
 		return bosherr.WrapError(err, "Checking filesystem format of partition")
 	}
@@ -72,7 +73,7 @@ func (f linuxFormatter) makeFileSystemExt4(partitionPath string) error {
 	return err
 }
 
-func (f linuxFormatter) getPartitionFormatType(partitionPath string) (FileSystemType, error) {
+func (f linuxFormatter) GetPartitionFormatType(partitionPath string) (FileSystemType, error) {
 	stdout, stderr, exitStatus, err := f.runner.RunCommand("blkid", "-p", partitionPath)
 
 	if err != nil {


### PR DESCRIPTION
The 'resiz2fs' command that is currently being used in setting up the root disk does not work for xfs filesystems. This PR adds the capability to check for the file system type of the root disk and then call the appropriate command - 'xfs_growfs' for XFS file systems and 'resize2fs' for EXT file systems.