### PR TITLE
Use a defined type rather for script options

### DIFF
--- a/agent/action/run_script_test.go
+++ b/agent/action/run_script_test.go
@@ -2,6 +2,7 @@ package action_test
 
 import (
 	"errors"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -18,7 +19,7 @@ var _ = Describe("RunScript", func() {
 		fakeJobScriptProvider *scriptfakes.FakeJobScriptProvider
 		specService           *fakeapplyspec.FakeV1Service
 		action                RunScriptAction
-		options               map[string]interface{}
+		options               RunScriptOptions
 	)
 
 	BeforeEach(func() {
@@ -27,9 +28,10 @@ var _ = Describe("RunScript", func() {
 		specService.Spec.RenderedTemplatesArchiveSpec = &applyspec.RenderedTemplatesArchiveSpec{}
 		logger := boshlog.NewLogger(boshlog.LevelNone)
 		action = NewRunScript(fakeJobScriptProvider, specService, logger)
-		options = make(map[string]interface{})
-		options["env"] = map[string]string{
-			"FOO": "foo",
+		options = RunScriptOptions{
+			Env: map[string]string{
+				"FOO": "foo",
+			},
 		}
 	})
 


### PR DESCRIPTION
This change updates `run_script` to take use a structured object for
options rather than an genreic map. This change should be both backwards
compatible and forwards compatible due to the unmarshalling behavior of
JSON in Golang. Adding fields to the options struct will be additive
changes and will not break older directors.

[#164262374](https://www.pivotaltracker.com/story/show/164262374)