### PR TITLE
Prevent logging of reading records.json

### DIFF
--- a/agent/action/state/sync_dns_state.go
+++ b/agent/action/state/sync_dns_state.go
@@ -65,7 +65,7 @@ func (s SyncDNSState) NeedsUpdate(newVersion uint64) bool {
 }
 
 func (s SyncDNSState) loadVersion() (uint64, error) {
-	contents, err := s.fs.ReadFile(s.path)
+	contents, err := s.fs.ReadFileWithOpts(s.path, boshsys.ReadOpts{Quiet: true})
 	if err != nil {
 		return 0, bosherr.WrapError(err, "reading state file")
 	}

--- a/agent/action/sync_dns.go
+++ b/agent/action/sync_dns.go
@@ -15,6 +15,7 @@ import (
 	boshcrypto "github.com/cloudfoundry/bosh-utils/crypto"
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 	boshlog "github.com/cloudfoundry/bosh-utils/logger"
+	boshsystem "github.com/cloudfoundry/bosh-utils/system"
 	boshuuid "github.com/cloudfoundry/bosh-utils/uuid"
 )
 
@@ -79,7 +80,7 @@ func (a SyncDNS) Run(blobID string, multiDigest boshcrypto.MultipleDigest, versi
 		}
 	}()
 
-	contents, err := fs.ReadFile(filePath)
+	contents, err := fs.ReadFileWithOpts(filePath, boshsystem.ReadOpts{Quiet: true})
 	if err != nil {
 		return "", bosherr.WrapErrorf(err, "reading %s from blobstore", filePath)
 	}

--- a/agent/action/sync_dns.go
+++ b/agent/action/sync_dns.go
@@ -15,7 +15,6 @@ import (
 	boshcrypto "github.com/cloudfoundry/bosh-utils/crypto"
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 	boshlog "github.com/cloudfoundry/bosh-utils/logger"
-	boshsystem "github.com/cloudfoundry/bosh-utils/system"
 	boshuuid "github.com/cloudfoundry/bosh-utils/uuid"
 )
 
@@ -80,7 +79,7 @@ func (a SyncDNS) Run(blobID string, multiDigest boshcrypto.MultipleDigest, versi
 		}
 	}()
 
-	contents, err := fs.ReadFileWithOpts(filePath, boshsystem.ReadOpts{Quiet: true})
+	contents, err := fs.ReadFile(filePath)
 	if err != nil {
 		return "", bosherr.WrapErrorf(err, "reading %s from blobstore", filePath)
 	}


### PR DESCRIPTION
* whenever agent received sync_dns action, it logged the content of the
records.json.
* In the case where an update of the dns records is needed on the VM, the file content is logged 3 times.
* With a large number of VMs managed by BOSH this led to frequent log rotations
making logs unusable. (With more than 1,000 VMs, agent logs got
lost after 15 minutes)

[#164371973](https://www.pivotaltracker.com/story/show/164371973)

Co-authored-by: David Ansari <david.ansari@sap.com>