### PR TITLE
Fix nil deference error when no service is available

### DIFF
--- a/infrastructure/multi_source_metadata_service_test.go
+++ b/infrastructure/multi_source_metadata_service_test.go
@@ -49,6 +49,13 @@ func describeMultiSourceMetadataService() {
 			metadataService = NewMultiSourceMetadataService(service1, service2)
 		})
 
+		Describe("IsAvailable", func() {
+			It("is true", func() {
+				availablity := metadataService.IsAvailable()
+				Expect(availablity).To(BeTrue())
+			})
+		})
+
 		Describe("GetPublicKey", func() {
 			It("returns public key from the available service", func() {
 				publicKey, err := metadataService.GetPublicKey()
@@ -120,6 +127,13 @@ func describeMultiSourceMetadataService() {
 			metadataService = NewMultiSourceMetadataService(service1, service2)
 		})
 
+		Describe("IsAvailable", func() {
+			It("is true", func() {
+				availablity := metadataService.IsAvailable()
+				Expect(availablity).To(BeTrue())
+			})
+		})
+
 		Describe("GetPublicKey", func() {
 			It("returns public key from the available service", func() {
 				publicKey, err := metadataService.GetPublicKey()
@@ -157,6 +171,68 @@ func describeMultiSourceMetadataService() {
 				networks, err := metadataService.GetNetworks()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(networks).To(Equal(boshsettings.Networks{"net-2": boshsettings.Network{}}))
+			})
+		})
+	})
+
+	Context("when no service is available", func() {
+		BeforeEach(func() {
+			service1.Available = false
+			metadataService = NewMultiSourceMetadataService(service1)
+		})
+
+		Describe("IsAvailable", func() {
+			It("is false", func() {
+				availablity := metadataService.IsAvailable()
+				Expect(availablity).To(BeFalse())
+			})
+		})
+
+		Describe("GetPublicKey", func() {
+			It("returns an error", func() {
+				_, err := metadataService.GetPublicKey()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("services not available"))
+			})
+		})
+
+		Describe("GetInstanceID", func() {
+			It("returns an error getting the instance ID", func() {
+				_, err := metadataService.GetInstanceID()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("services not available"))
+			})
+		})
+
+		Describe("GetServerName", func() {
+			It("returns an error getting the server name", func() {
+				_, err := metadataService.GetServerName()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("services not available"))
+			})
+		})
+
+		Describe("GetRegistryEndpoint", func() {
+			It("returns an error getting the registry endpoint", func() {
+				_, err := metadataService.GetRegistryEndpoint()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("services not available"))
+			})
+		})
+
+		Describe("GetNetworks", func() {
+			It("returns an error getting the networks", func() {
+				_, err := metadataService.GetNetworks()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("services not available"))
+			})
+		})
+
+		Describe("GetSettings", func() {
+			It("returns an error getting the settings", func() {
+				_, err := metadataService.GetSettings()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("services not available"))
 			})
 		})
 	})


### PR DESCRIPTION
## Why This PR
When the bosh agent is initially starting on a VM, it seems that a race condition can occur where the `agent.json` will point to `ConfigDriveMetadataService` and a `FileMetadataService`, but neither the referenced drive nor the referenced file exist yet on the VM, and we get a nil pointer dereference error. The agent will eventually recover once the files/drive exist, but until then it makes for some nasty agent logs to read through, and led my team and I astray while we were trying to debug a different issue. 

## Error Log
```2019-03-21_22:41:44.27019 [main] 2019/03/21 22:41:44 DEBUG - Starting agent
2019-03-21_22:41:44.28267 [File System] 2019/03/21 22:41:44 DEBUG - Reading file /var/vcap/bosh/agent.json
2019-03-21_22:41:44.31884 [File System] 2019/03/21 22:41:44 DEBUG - Read content
2019-03-21_22:41:44.31885 ********************
2019-03-21_22:41:44.31886 {
2019-03-21_22:41:44.31886   "Platform": {
2019-03-21_22:41:44.31886     "Linux": {
2019-03-21_22:41:44.31886       "CreatePartitionIfNoEphemeralDisk": true,
2019-03-21_22:41:44.31886       "DevicePathResolutionType": "scsi",
2019-03-21_22:41:44.31887       "PartitionerType": "parted"
2019-03-21_22:41:44.31887     }
2019-03-21_22:41:44.31887   },
2019-03-21_22:41:44.31887   "Infrastructure": {
2019-03-21_22:41:44.31887     "Settings": {
2019-03-21_22:41:44.31888       "Sources": [
2019-03-21_22:41:44.31888         {
2019-03-21_22:41:44.31888           "Type": "ConfigDrive",
2019-03-21_22:41:44.31888           "DiskPaths": [
2019-03-21_22:41:44.31888             "/dev/disk/by-label/azure_cfg_dsk",
2019-03-21_22:41:44.31888             "/dev/disk/by-label/AZURE_CFG_DSK"
2019-03-21_22:41:44.31889           ],
2019-03-21_22:41:44.31889           "MetaDataPath": "configs/MetaData",
2019-03-21_22:41:44.31889           "UserDataPath": "configs/UserData"
2019-03-21_22:41:44.31889         },
2019-03-21_22:41:44.31889         {
2019-03-21_22:41:44.31890           "Type": "File",
2019-03-21_22:41:44.31890           "MetaDataPath": "",
2019-03-21_22:41:44.31890           "UserDataPath": "/var/lib/waagent/CustomData",
2019-03-21_22:41:44.31890           "SettingsPath": "/var/lib/waagent/CustomData"
2019-03-21_22:41:44.31890         }
2019-03-21_22:41:44.31890       ],
2019-03-21_22:41:44.31891       "UseServerName": true,
2019-03-21_22:41:44.31891       "UseRegistry": true
2019-03-21_22:41:44.31891     }
2019-03-21_22:41:44.31891   }
2019-03-21_22:41:44.31891 }
2019-03-21_22:41:44.31891
2019-03-21_22:41:44.31892 ********************
2019-03-21_22:41:44.33865 [File System] 2019/03/21 22:41:44 DEBUG - Reading file /var/vcap/bosh/etc/stemcell_version
2019-03-21_22:41:44.36079 [File System] 2019/03/21 22:41:44 DEBUG - Read content
2019-03-21_22:41:44.36080 ********************
2019-03-21_22:41:44.36080 170.9
2019-03-21_22:41:44.36080 ********************
2019-03-21_22:41:44.36082 [File System] 2019/03/21 22:41:44 DEBUG - Reading file /var/vcap/bosh/etc/stemcell_git_sha1
2019-03-21_22:41:44.39043 [File System] 2019/03/21 22:41:44 DEBUG - Read content
2019-03-21_22:41:44.39044 ********************
2019-03-21_22:41:44.39044 e7f09e054b4e958bc2450013cd35c7cb0cd29bf3
2019-03-21_22:41:44.39044 ********************
2019-03-21_22:41:44.39050 [App] 2019/03/21 22:41:44 INFO - Running on stemcell version '170.9' (git: e7f09e054b4e958bc2450013cd35c7cb0cd29bf3)
2019-03-21_22:41:44.39051 [File System] 2019/03/21 22:41:44 DEBUG - Checking if file exists /var/vcap/bosh/agent_state.json
2019-03-21_22:41:44.39051 [File System] 2019/03/21 22:41:44 DEBUG - Stat '/var/vcap/bosh/agent_state.json'
2019-03-21_22:41:44.40891 [Cmd Runner] 2019/03/21 22:41:44 DEBUG - Running command 'bosh-agent-rc'
2019-03-21_22:41:44.46459 [unlimitedRetryStrategy] 2019/03/21 22:41:44 DEBUG - Making attempt #0
2019-03-21_22:41:44.47335 panic: runtime error: invalid memory address or nil pointer dereference
2019-03-21_22:41:44.47336 [signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x8a5b25]
2019-03-21_22:41:44.47336
2019-03-21_22:41:44.47336 goroutine 9 [running]:
2019-03-21_22:41:44.61617 github.com/cloudfoundry/bosh-agent/infrastructure.(*MultiSourceMetadataService).GetPublicKey(0xc00018a4b0, 0xc00000dd60, 0xaeff00, 0xc00001e6e0, 0xaf56c0)
2019-03-21_22:41:44.61628       /tmp/build/9674af12/gopath/src/github.com/cloudfoundry/bosh-agent/infrastructure/multi_source_metadata_service.go:17 +0x35
2019-03-21_22:41:44.61628 github.com/cloudfoundry/bosh-agent/infrastructure.ComplexSettingsSource.PublicSSHKeyForUsername(0xaf53c0, 0xc00018a4b0, 0xaeb660, 0xc00005ae40, 0xa3a7dd, 0x15, 0xaf7080, 0xc000162060, 0xa2d5a5, 0x4, ...)
2019-03-21_22:41:44.61629       /tmp/build/9674af12/gopath/src/github.com/cloudfoundry/bosh-agent/infrastructure/complex_settings_source.go:31 +0x31
2019-03-21_22:41:44.61659 github.com/cloudfoundry/bosh-agent/settings.(*settingsService).PublicSSHKeyForUsername(0xc0000a5680, 0xa2d5a5, 0x4, 0x0, 0xafbee0, 0x954cc0, 0x0)
2019-03-21_22:41:44.61660       /tmp/build/9674af12/gopath/src/github.com/cloudfoundry/bosh-agent/settings/service.go:71 +0x4e
2019-03-21_22:41:44.61660 github.com/cloudfoundry/bosh-agent/agent.bootstrap.Run(0xafba60, 0xc000021c40, 0xaff680, 0xc0000b4780, 0xa315e1, 0x9, 0xaf5c00, 0xc0000a5680, 0xaf1c20, 0xc00000de20, ...)
2019-03-21_22:41:44.61660       /tmp/build/9674af12/gopath/src/github.com/cloudfoundry/bosh-agent/agent/bootstrap.go:56 +0x1b0
2019-03-21_22:41:44.61660 github.com/cloudfoundry/bosh-agent/app.(*app).Setup(0xc000176000, 0x0, 0x0, 0x7ffe9d270f22, 0x6, 0xa315e1, 0x9, 0xa2de8b, 0x5, 0x7ffe9d270f2c, ...)
2019-03-21_22:41:44.61661       /tmp/build/9674af12/gopath/src/github.com/cloudfoundry/bosh-agent/app/app.go:120 +0xea3
2019-03-21_22:41:44.61661 main.runAgent.func1(0xaf7080, 0xc000162060, 0x0, 0x0, 0x7ffe9d270f22, 0x6, 0xa315e1, 0x9, 0xa2de8b, 0x5, ...)
2019-03-21_22:41:44.61661       /tmp/build/9674af12/gopath/src/github.com/cloudfoundry/bosh-agent/main/agent.go:35 +0x239
2019-03-21_22:41:44.61661 created by main.runAgent
2019-03-21_22:41:44.61661       /tmp/build/9674af12/gopath/src/github.com/cloudfoundry/bosh-agent/main/agent.go:23 +0xb9
2019-03-21_22:41:44.63589 [main] 2019/03/21 22:41:44 DEBUG - Starting agent
```