### PR TITLE
Enhancement for encryption of persistent disk

### DIFF
--- a/agent/action/list_disk.go
+++ b/agent/action/list_disk.go
@@ -61,11 +61,11 @@ func (a ListDiskAction) Run() (interface{}, error) {
 		if err != nil {
 			return nil, bosherr.WrapErrorf(err, "Checking whether device %+v is mounted", diskSettings)
 		}
-                isMountedExternally, err := a.platform.IsPersistentDiskMountedExternally(diskSettings)
-                if err != nil {
+		isMountedExternally, err := a.platform.IsPersistentDiskMountedExternally(diskSettings)
+		if err != nil {
 			return nil, bosherr.WrapErrorf(err, "Checking whether device %+v is mounted externally", diskSettings)
 		}
-		if isMounted || (!isMounted && isMountedExternally) {
+		if (isMounted || isMountedExternally) {
 			if _, present := usedIDs[diskID]; !present {
 				diskIDs = append(diskIDs, diskID)
 				usedIDs[diskID] = true

--- a/agent/action/list_disk.go
+++ b/agent/action/list_disk.go
@@ -61,8 +61,11 @@ func (a ListDiskAction) Run() (interface{}, error) {
 		if err != nil {
 			return nil, bosherr.WrapErrorf(err, "Checking whether device %+v is mounted", diskSettings)
 		}
-
-		if isMounted {
+                isMountedExternally, err := a.platform.IsPersistentDiskMountedExternally(diskSettings)
+                if err != nil {
+			return nil, bosherr.WrapErrorf(err, "Checking whether device %+v is mounted externally", diskSettings)
+		}
+		if isMounted || (!isMounted && isMountedExternally) {
 			if _, present := usedIDs[diskID]; !present {
 				diskIDs = append(diskIDs, diskID)
 				usedIDs[diskID] = true

--- a/platform/disk/diskfakes/fake_mounter.go
+++ b/platform/disk/diskfakes/fake_mounter.go
@@ -157,6 +157,10 @@ func (fake *FakeMounter) IsMountPoint(arg1 string) (string, bool, error) {
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
+func (fake *FakeMounter) IsCryptLuks(arg1 string) ( bool, error) {
+	return false, nil
+}
+
 func (fake *FakeMounter) IsMountPointCallCount() int {
 	fake.isMountPointMutex.RLock()
 	defer fake.isMountPointMutex.RUnlock()

--- a/platform/disk/formatter_interface.go
+++ b/platform/disk/formatter_interface.go
@@ -6,6 +6,7 @@ const (
 	FileSystemSwap    FileSystemType = "swap"
 	FileSystemExt4    FileSystemType = "ext4"
 	FileSystemXFS     FileSystemType = "xfs"
+	FileSystemLUKS    FileSystemType = "crypto_LUKS"
 	FileSystemDefault FileSystemType = ""
 )
 

--- a/platform/disk/linux_bind_mounter.go
+++ b/platform/disk/linux_bind_mounter.go
@@ -48,6 +48,10 @@ func (m linuxBindMounter) IsMountPoint(path string) (string, bool, error) {
 	return m.delegateMounter.IsMountPoint(path)
 }
 
+func (m linuxBindMounter) IsCryptLuks(arg1 string) ( bool, error) {
+	return false, nil
+}
+
 func (m linuxBindMounter) IsMounted(partitionOrMountPoint string) (bool, error) {
 	return m.delegateMounter.IsMounted(partitionOrMountPoint)
 }

--- a/platform/disk/linux_formatter.go
+++ b/platform/disk/linux_formatter.go
@@ -30,7 +30,7 @@ func (f linuxFormatter) Format(partitionPath string, fsType FileSystemType) (err
 			return
 		}
 		// swap is not user-configured, so we're not concerned about reformatting
-	} else if existingFsType == FileSystemExt4 || existingFsType == FileSystemXFS {
+	} else if existingFsType == FileSystemExt4 || existingFsType == FileSystemXFS || existingFsType == FileSystemLUKS {
 		// never reformat if it is already formatted in a supported format
 		return
 	}

--- a/platform/disk/linux_mounter.go
+++ b/platform/disk/linux_mounter.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"os/exec"
 
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 	boshsys "github.com/cloudfoundry/bosh-utils/system"
@@ -145,6 +146,15 @@ func (m linuxMounter) IsMountPoint(path string) (string, bool, error) {
 	}
 
 	return "", false, nil
+}
+
+func (m linuxMounter) IsCryptLuks(partitionOrMountPoint string) (bool, error) {
+	out, _ := exec.Command("sh","-c","lsblk -f | grep crypto_LUKS | wc -l").Output()
+	result := string(out)
+	if strings.TrimRight(result, "\n") == "1" {
+		return true, nil
+	}
+	return false, nil
 }
 
 func (m linuxMounter) IsMounted(partitionOrMountPoint string) (bool, error) {

--- a/platform/disk/linux_mounter.go
+++ b/platform/disk/linux_mounter.go
@@ -2,9 +2,9 @@ package disk
 
 import (
 	"fmt"
+	"os/exec"
 	"strings"
 	"time"
-	"os/exec"
 
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 	boshsys "github.com/cloudfoundry/bosh-utils/system"
@@ -149,7 +149,10 @@ func (m linuxMounter) IsMountPoint(path string) (string, bool, error) {
 }
 
 func (m linuxMounter) IsCryptLuks(partitionOrMountPoint string) (bool, error) {
-	out, _ := exec.Command("sh","-c","lsblk -f | grep crypto_LUKS | wc -l").Output()
+	out, err := exec.Command("sh", "-c", "lsblk -f | grep crypto_LUKS | wc -l").Output()
+	if err != nil {
+		return false, bosherr.WrapError(err, "Running lsblk command")
+	}
 	result := string(out)
 	if strings.TrimRight(result, "\n") == "1" {
 		return true, nil

--- a/platform/disk/mounter_interface.go
+++ b/platform/disk/mounter_interface.go
@@ -15,5 +15,6 @@ type Mounter interface {
 	SwapOn(partitionPath string) (err error)
 
 	IsMountPoint(path string) (parititionPath string, result bool, err error)
+	IsCryptLuks(path string) (result bool, err error)
 	IsMounted(devicePathOrMountPoint string) (result bool, err error)
 }

--- a/platform/disk/parted_partitioner.go
+++ b/platform/disk/parted_partitioner.go
@@ -2,10 +2,10 @@ package disk
 
 import (
 	"fmt"
+	"os/exec"
 	"regexp"
 	"strconv"
 	"strings"
-	"os/exec"
 
 	"code.cloudfoundry.org/clock"
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
@@ -158,7 +158,10 @@ func (p partedPartitioner) GetPartitions(devicePath string) (partitions []Existi
 			return partitions, deviceFullSizeInBytes, bosherr.WrapErrorf(err, "Parsing existing partitions")
 		}
 
-		out, _ := exec.Command("sh","-c","lsblk -f | grep crypto_LUKS | wc -l").Output()
+		out, err := exec.Command("sh", "-c", "lsblk -f | grep crypto_LUKS | wc -l").Output()
+		if err != nil {
+			return partitions, deviceFullSizeInBytes, bosherr.WrapErrorf(err, "Running lsblk command")
+		}
 		result := string(out)
 
 		partitionType := PartitionTypeUnknown

--- a/platform/disk/parted_partitioner.go
+++ b/platform/disk/parted_partitioner.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"os/exec"
 
 	"code.cloudfoundry.org/clock"
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
@@ -157,8 +158,11 @@ func (p partedPartitioner) GetPartitions(devicePath string) (partitions []Existi
 			return partitions, deviceFullSizeInBytes, bosherr.WrapErrorf(err, "Parsing existing partitions")
 		}
 
+		out, _ := exec.Command("sh","-c","lsblk -f | grep crypto_LUKS | wc -l").Output()
+		result := string(out)
+
 		partitionType := PartitionTypeUnknown
-		if partitionInfo[4] == "ext4" || partitionInfo[4] == "xfs" {
+		if partitionInfo[4] == "ext4" || partitionInfo[4] == "xfs" || strings.TrimRight(result, "\n") == "1" {
 			partitionType = PartitionTypeLinux
 		} else if partitionInfo[4] == "linux-swap(v1)" {
 			partitionType = PartitionTypeSwap

--- a/platform/dummy_platform.go
+++ b/platform/dummy_platform.go
@@ -393,6 +393,10 @@ func (p dummyPlatform) IsPersistentDiskMounted(diskSettings boshsettings.DiskSet
 	return true, nil
 }
 
+func (p dummyPlatform) IsPersistentDiskMountedExternally(diskSettings boshsettings.DiskSettings) ( bool,  error) {
+	return false, nil
+}
+
 func (p dummyPlatform) IsPersistentDiskMountable(diskSettings boshsettings.DiskSettings) (bool, error) {
 	var formattedDisks []formattedDisk
 	formattedDisksPath := filepath.Join(p.dirProvider.BoshDir(), "formatted_disks.json")

--- a/platform/platform_interface.go
+++ b/platform/platform_interface.go
@@ -76,6 +76,7 @@ type Platform interface {
 	GetEphemeralDiskPath(diskSettings boshsettings.DiskSettings) string
 	IsMountPoint(path string) (partitionPath string, result bool, err error)
 	IsPersistentDiskMounted(diskSettings boshsettings.DiskSettings) (result bool, err error)
+	IsPersistentDiskMountedExternally(diskSettings boshsettings.DiskSettings) (result bool, err error)
 	IsPersistentDiskMountable(diskSettings boshsettings.DiskSettings) (bool, error)
 	AssociateDisk(name string, settings boshsettings.DiskSettings) error
 

--- a/platform/platformfakes/fake_platform.go
+++ b/platform/platformfakes/fake_platform.go
@@ -2115,6 +2115,10 @@ func (fake *FakePlatform) IsPersistentDiskMounted(arg1 settings.DiskSettings) (b
 	return fakeReturns.result1, fakeReturns.result2
 }
 
+func (fake *FakePlatform) IsPersistentDiskMountedExternally(arg1 settings.DiskSettings) ( bool,  error) {
+	return false, nil
+}
+
 func (fake *FakePlatform) IsPersistentDiskMountedCallCount() int {
 	fake.isPersistentDiskMountedMutex.RLock()
 	defer fake.isPersistentDiskMountedMutex.RUnlock()

--- a/platform/windows_platform.go
+++ b/platform/windows_platform.go
@@ -567,6 +567,10 @@ func (p WindowsPlatform) IsPersistentDiskMounted(diskSettings boshsettings.DiskS
 	return true, nil
 }
 
+func (p WindowsPlatform) IsPersistentDiskMountedExternally(diskSettings boshsettings.DiskSettings) ( bool,  error) {
+	return false, nil
+}
+
 func (p WindowsPlatform) IsPersistentDiskMountable(diskSettings boshsettings.DiskSettings) (bool, error) {
 	return true, nil
 }


### PR DESCRIPTION
This pull request includes the changes required to support usage and management of the encrypted disk in the bosh environment. Since the mount has to be done differently when the persistent disk is encrypted which needs encryption keys as well, so therefore it has to be handled externally (during deployment of encryption job) and not by the bosh-agent.
Seeing issues for scenarios like redeployment of vms or deletion/creation of vm having the same disk volume where bosh was trying to mount the already encrypted disk which now has fs type as crypto_LUKS instead of ext4/xfs.

Currently in bosh-agent code there is a method which returns cid to bosh director if the disk is mounted correctly. Since bosh is not able to mount the encrypted disk correctly in the above mentioned scenrio, therefore it is returning nil to the director, where AgentDiskOutOfSync check  compares the cid stored within the director to the one received by the agent which are now different in this case and therfore it raises exception saying "instance has invalid disks: agent reports 'nil' while director record shows vol-xxxx".

To fix this issue, the code change is done entirely on the bosh-agent side where it checks if the partition format type is crypto_LUKS through lsblk command (as suggested last in previous pull request), then don't try to mount the partition which will be done by the job later on and the variable IsMountedExternally is set to true in this case.
One more filesystem type is added i.e crypto_LUKS apart from ext4 and xfs and now even at the time of formatting the disk this new fs type is also checked along with other fs types. If the disk is already formatted with crypto_LUKS type, it shouldn't be formatted again.

We tried to make this code change generic enough by implementing it through interface level in such a way that anyone who wants to handle mounting of partition externally can leverage this implementation.

Co-authored-by: Maksim Yankovskiy <myankovskiy@zettaset.com>
Co-authored-by: Deepak Shetty <dshetty@zettaset.com>
Co-authored-by: Brian Metzger <bmetzger@zettaset.com>