### PR TITLE
Fix Windows cert manager backups when there are duplicate certs

### DIFF
--- a/platform/cert/windows_cert_manager.go
+++ b/platform/cert/windows_cert_manager.go
@@ -40,7 +40,7 @@ func (c *windowsCertManager) createBackup() error {
 		_, _, _, err := c.runner.RunCommand(
 			"powershell",
 			"-Command",
-			fmt.Sprintf("Get-ChildItem %s | Export-Certificate -Type SST -FilePath %s", rootCertStore, c.backupPath),
+			fmt.Sprintf("Get-ChildItem %s | Select -Unique | Export-Certificate -Type SST -FilePath %s", rootCertStore, c.backupPath),
 		)
 		if err != nil {
 			return err


### PR DESCRIPTION
https://stackoverflow.com/questions/55484185/object-or-property-already-exists-error-when-trying-to-export-certificate-from-r

Not sure why I am getting duplicate certs in my cert store. I have installed a private candidate KB from Microsoft, so I think that might have done something. The error I was seeing from compilation VMs without this fix was:

```
Error: Action Failed get_task: Task 1727f2f8-775a-4b78-7d6b-ef9622cc04be result: Running command: 'powershell -Command Get-ChildItem Cert:\LocalMachine\Root | Export-Certificate -Type SST -FilePath \var\vcap\data\tmp/rootCertBackup.sst', stdout: '', stderr: 'Export-Certificate : The object or property already exists. (Exception from HRESULT: 0x80092005)
At line:1 char:41
+ ... hine\Root | Export-Certificate -Type SST -FilePath \var\vcap\data\tmp ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Export-Certificate], COMException
    + FullyQualifiedErrorId : System.Runtime.InteropServices.COMException,Microsoft.CertificateServices.Commands.Expor
   tCertificateCommand
```
