### PR TITLE
Mount ephemeral disk with project quota enabled

### DIFF
--- a/platform/disk/linux_formatter.go
+++ b/platform/disk/linux_formatter.go
@@ -65,9 +65,9 @@ func (f linuxFormatter) Format(partitionPath string, fsType FileSystemType) (err
 func (f linuxFormatter) makeFileSystemExt4(partitionPath string) error {
 	var err error
 	if f.fs.FileExists("/sys/fs/ext4/features/lazy_itable_init") {
-		_, _, _, err = f.runner.RunCommand("mke2fs", "-t", string(FileSystemExt4), "-j", "-E", "lazy_itable_init=1", partitionPath)
+		_, _, _, err = f.runner.RunCommand("mke2fs", "-t", string(FileSystemExt4), "-O", "quota,project", "-j", "-E", "lazy_itable_init=1", partitionPath)
 	} else {
-		_, _, _, err = f.runner.RunCommand("mke2fs", "-t", string(FileSystemExt4), "-j", partitionPath)
+		_, _, _, err = f.runner.RunCommand("mke2fs", "-t", string(FileSystemExt4), "-O", "quota,project", "-j", partitionPath)
 	}
 	return err
 }

--- a/platform/linux_platform.go
+++ b/platform/linux_platform.go
@@ -655,7 +655,7 @@ func (p linux) SetupEphemeralDiskWithPath(realPath string, desiredSwapSizeInByte
 	}
 
 	p.logger.Info(logTag, "Mounting `%s' (canonical path: %s) at `%s'", dataPartitionPath, canonicalDataPartitionPath, mountPoint)
-	err = p.diskManager.GetMounter().Mount(canonicalDataPartitionPath, mountPoint)
+	err = p.diskManager.GetMounter().Mount(canonicalDataPartitionPath, mountPoint, "noatime,prjquota")
 	if err != nil {
 		return bosherr.WrapError(err, "Mounting data partition")
 	}


### PR DESCRIPTION
Hi Bosh Team,

We (Garden Team) would like to use project quotas on ext4 filesystems on diego cells in CF, so that we can more easily and reliably enforce disk quotas for app containers. This draft PR is by no means merge-ready. We would like to use it as a basis for discussion on how to achieve that together.

### What are project quotas?
Project quotas is a relatively new ext4 feature available since kernel version 4.5 and e2fs-tools 1.43 (although it is probably better to use a newer version such as 1.44.5). Generally speaking it provides a way to limit the size of directories (a.k.a projects) on ext4 volumes formatted and mounted with specific options.

### Why do we need them?
CF limits the amount of disk that apps can use, so that a rogue app cannot use up all the disk on the diego cell. Currently Garden achieves this by using an exotic mix of filesystems. Namely, the ephemeral dis is ext4 (without project quotas enabled), so we have to create a loop device, format it as xfs with project quotas and mount it on `/var/vcap/data/grootfs/store`. This setup causes lots of pain for us, for example the sparse file that backs the loop device up can grow to exhaust the complete ephemeral disk and we have lots of code to try to prevent this. We have also seen lots of reports of file system lockups and we believe that they might be connected to that complex file systems setup. If ephemeral disks had project quotas enabled we would not have to do all those hoops.

### What would the impact be?
We had an [exploration story](https://www.pivotaltracker.com/story/show/166286184) in our backlog to measure the performance impact of enabling project quotas on ext4 file systems. [TL;DR](https://www.pivotaltracker.com/story/show/166286184/comments/203953559), we concluded that there is about 20% slowdown on creating and deleting large files that cannot make use of RAM caching. For small files the performance impact is neglectable. We therefore believe that enabling project quotas on diego cells would not be a problem because: 
* Applications/Services which use lots of disk IO would either use persistent databases, or persistent disks. In other words, they would not be using the ephemeral volume to perform their disk IO
* For the rest of the processes running on the diego cell (such as bosh jobs) disk IO should be quite minimal and therefore covered by the RAM cache, so we believe that there would not be a big impact.

### What is missing in this PR
e2fs-progs that are bundled into stemcells as of today are outdated and do not support ext4 project quotas. Could you suggest how solve that? Can we bump the e2fs-progs package, or should we distribute an up-to-date binary and use it on the bosh-agent instead?

In this PR we enable project quotas for ephemeral disk for all bosh vms. We realise that bosh is a generic tool, so probably project quotas should be enabled conditionally. We do not know how to implement that and would appreciate your input a lot. Any feedback from your side is also very welcome!
