### PR TITLE
Need to wipe off both partitions and devices

### DIFF
--- a/platform/disk/ephemeral_device_partitioner_test.go
+++ b/platform/disk/ephemeral_device_partitioner_test.go
@@ -84,9 +84,10 @@ var _ = Describe("EphemeralDevicePartitioner", func() {
 				err := partitioner.Partition(devicePath, partitions)
 				Expect(err).ToNot(HaveOccurred())
 
-				Expect(len(fakeCmdRunner.RunCommands)).To(Equal(12))
+				Expect(len(fakeCmdRunner.RunCommands)).To(Equal(13))
 
 				Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"parted", "-m", "/dev/edx", "unit", "B", "print"}))
+				Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"blkid"}))
 				Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"parted", "-s", "/dev/edx", "unit", "B", "mkpart", "fake-agent-id-0", "1048576", "8590983167"}))
 				Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"parted", "-s", "/dev/edx", "unit", "B", "mkpart", "fake-agent-id-1", "8590983168", "17180917759"}))
 				Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"partprobe", "/dev/edx"}))
@@ -103,6 +104,13 @@ var _ = Describe("EphemeralDevicePartitioner", func() {
 							Stdout: `BYT;
 /dev/edx:221190815744B:xvd:512:512:gpt:Xen Virtual Block Device;
 1:512B:2048576B:199680B:linux-swap(v1):fake-agent-id-0:;
+`},
+					)
+					fakeCmdRunner.AddCmdResult(
+						"blkid",
+						fakesys.FakeCmdResult{
+							Stdout: `/dev/xvda1: UUID="96dbf75b-3d78-4990-81e6-b8a5ce7c36f6" TYPE="ext4" PARTUUID="00057b93-01"
+/dev/edx1: UUID="ae5f3f45-4f48-48ec-b3bd-c218b92e4a47" TYPE="swap" PARTLABEL="old-agent-id-0" PARTUUID="b5c66318-d96d-45c6-aebc-4b96823923a4"
 `},
 					)
 					fakeCmdRunner.AddCmdResult(
@@ -137,10 +145,12 @@ var _ = Describe("EphemeralDevicePartitioner", func() {
 					err := partitioner.Partition(devicePath, partitions)
 					Expect(err).ToNot(HaveOccurred())
 
-					Expect(len(fakeCmdRunner.RunCommands)).To(Equal(12))
+					Expect(len(fakeCmdRunner.RunCommands)).To(Equal(14))
 
 					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"parted", "-m", "/dev/edx", "unit", "B", "print"}))
-					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"wipefs", "-a", "/dev/edx"}))
+					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"blkid"}))
+					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"wipefs", "-af", "/dev/edx1"}))
+					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"wipefs", "-af", "/dev/edx"}))
 					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"parted", "-s", "/dev/edx", "unit", "B", "mkpart", "fake-agent-id-0", "1048576", "17180917759"}))
 					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"parted", "-s", "/dev/edx", "unit", "B", "mkpart", "fake-agent-id-1", "17180917760", "25770852351"}))
 					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"partprobe", "/dev/edx"}))
@@ -158,6 +168,14 @@ var _ = Describe("EphemeralDevicePartitioner", func() {
 /dev/edx:221190815744B:xvd:512:512:msdos:Xen Virtual Block Device:;
 1:512B:8406236159B:8406235648B:linux-swap(v1)::;
 2:8406236160B:107372805119B:98966568960B:ext4::;
+`},
+					)
+					fakeCmdRunner.AddCmdResult(
+						"blkid",
+						fakesys.FakeCmdResult{
+							Stdout: `/dev/xvda1: UUID="96dbf75b-3d78-4990-81e6-b8a5ce7c36f6" TYPE="ext4" PARTUUID="00057b93-01"
+/dev/edx1: UUID="ae5f3f45-4f48-48ec-b3bd-c218b92e4a47" TYPE="swap" PARTLABEL="old-agent-id-0" PARTUUID="b5c66318-d96d-45c6-aebc-4b96823923a4"
+/dev/edx2: UUID="144bfa2c-73fd-4665-bf1f-b740648b6b59" TYPE="ext4" PARTLABEL="old-agent-id-1" PARTUUID="024fe371-91a3-4835-af4e-c9182702cbb6"
 `},
 					)
 					fakeCmdRunner.AddCmdResult(
@@ -193,10 +211,13 @@ var _ = Describe("EphemeralDevicePartitioner", func() {
 					err := partitioner.Partition(devicePath, partitions)
 					Expect(err).ToNot(HaveOccurred())
 
-					Expect(len(fakeCmdRunner.RunCommands)).To(Equal(12))
+					Expect(len(fakeCmdRunner.RunCommands)).To(Equal(15))
 
 					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"parted", "-m", "/dev/edx", "unit", "B", "print"}))
-					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"wipefs", "-a", "/dev/edx"}))
+					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"blkid"}))
+					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"wipefs", "-af", "/dev/edx1"}))
+					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"wipefs", "-af", "/dev/edx2"}))
+					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"wipefs", "-af", "/dev/edx"}))
 					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"parted", "-s", "/dev/edx", "unit", "B", "mkpart", "fake-agent-id-0", "1048576", "8590983167"}))
 					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"parted", "-s", "/dev/edx", "unit", "B", "mkpart", "fake-agent-id-1", "8590983168", "17180917759"}))
 					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"partprobe", "/dev/edx"}))
@@ -251,6 +272,14 @@ var _ = Describe("EphemeralDevicePartitioner", func() {
 `},
 					)
 					fakeCmdRunner.AddCmdResult(
+						"blkid",
+						fakesys.FakeCmdResult{
+							Stdout: `/dev/xvda1: UUID="96dbf75b-3d78-4990-81e6-b8a5ce7c36f6" TYPE="ext4" PARTUUID="00057b93-01"
+/dev/edx1: UUID="ae5f3f45-4f48-48ec-b3bd-c218b92e4a47" TYPE="swap" PARTLABEL="old-agent-id-0" PARTUUID="b5c66318-d96d-45c6-aebc-4b96823923a4"
+/dev/edx2: UUID="144bfa2c-73fd-4665-bf1f-b740648b6b59" TYPE="ext4" PARTLABEL="old-agent-id-1" PARTUUID="024fe371-91a3-4835-af4e-c9182702cbb6"
+`},
+					)
+					fakeCmdRunner.AddCmdResult(
 						"parted -m /dev/edx unit B print",
 						fakesys.FakeCmdResult{
 							Stdout: `BYT;
@@ -282,10 +311,12 @@ var _ = Describe("EphemeralDevicePartitioner", func() {
 					err := partitioner.Partition(devicePath, partitions)
 					Expect(err).ToNot(HaveOccurred())
 
-					Expect(len(fakeCmdRunner.RunCommands)).To(Equal(12))
+					Expect(len(fakeCmdRunner.RunCommands)).To(Equal(15))
 
 					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"parted", "-m", "/dev/edx", "unit", "B", "print"}))
-					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"wipefs", "-a", "/dev/edx"}))
+					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"wipefs", "-af", "/dev/edx"}))
+					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"wipefs", "-af", "/dev/edx1"}))
+					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"wipefs", "-af", "/dev/edx2"}))
 					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"parted", "-s", "/dev/edx", "unit", "B", "mkpart", "fake-agent-id-0", "1048576", "8590983167"}))
 					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"parted", "-s", "/dev/edx", "unit", "B", "mkpart", "fake-agent-id-1", "8590983168", "17180917759"}))
 					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"partprobe", "/dev/edx"}))
@@ -329,7 +360,7 @@ var _ = Describe("EphemeralDevicePartitioner", func() {
 				)
 				for i := 0; i < 20; i++ {
 					fakeCmdRunner.AddCmdResult(
-						"wipefs -a /dev/edx",
+						"wipefs -af /dev/edx",
 						fakesys.FakeCmdResult{Stdout: "", ExitStatus: 2, Error: errors.New("fake-cmd-error")},
 					)
 				}
@@ -349,7 +380,7 @@ var _ = Describe("EphemeralDevicePartitioner", func() {
 				err := partitioner.Partition(devicePath, partitions)
 				Expect(err).To(HaveOccurred())
 
-				Expect(len(fakeCmdRunner.RunCommands)).To(Equal(22))
+				Expect(len(fakeCmdRunner.RunCommands)).To(Equal(23))
 				Expect(err.Error()).To(ContainSubstring("Removing existing partitions"))
 			})
 		})


### PR DESCRIPTION
The original PR is https://github.com/cloudfoundry/bosh-agent/pull/190, but we found after OS reload, the ephemeral disk is not re-formatted, because it only wipes off the device, but doesn't wipe off partitions. This PR is very important to our IBM Cloud, the disk is not cleaned up  after stemcell upgrade, which caused many problems in our cf deployments. Please help review this PR. Thanks.

/cc @dpb587 @maximilien 