### PR TITLE
Fix blackhole route parsing

### DIFF
--- a/platform/net/routes_searcher_unix.go
+++ b/platform/net/routes_searcher_unix.go
@@ -67,7 +67,7 @@ func (s cmdRoutesSearcher) SearchRoutes() ([]Route, error) {
 		}
 		route, err := parseRoute(routeEntry)
 		if err != nil {
-			s.logger.Warn("SearchRoutes", "parseRoute error: %s", err.Error())
+			s.logger.Warn("SearchRoutes", "parseRoute error for route '%s': %s", routeEntry, err.Error())
 			continue
 		}
 		routes = append(routes, route)

--- a/platform/net/routes_searcher_unix_test.go
+++ b/platform/net/routes_searcher_unix_test.go
@@ -43,6 +43,25 @@ default via 172.16.79.1 dev eth0 proto dhcp metric 100
 				}))
 			})
 
+			It("ignores unexpected blackhole routes information", func() {
+				runner.AddCmdResult("ip r", fakesys.FakeCmdResult{
+					Stdout: `172.16.79.0/24 dev eth0 proto kernel scope link metric 100
+169.254.0.0/16 dev eth0 proto link metric 1000
+default via 172.16.79.1 dev eth0 proto dhcp metric 100
+blackhole 10.200.115.192/26  proto bird
+`,
+				})
+
+				routes, err := searcher.SearchRoutes()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(runner.RunCommandsQuietly[0]).To(Equal([]string{"ip", "r"}))
+				Expect(routes).To(Equal([]Route{
+					Route{Destination: "172.16.79.0", Gateway: "0.0.0.0", InterfaceName: "eth0"},
+					Route{Destination: "169.254.0.0", Gateway: "0.0.0.0", InterfaceName: "eth0"},
+					Route{Destination: "0.0.0.0", Gateway: "172.16.79.1", InterfaceName: "eth0"},
+				}))
+			})
+
 			It("ignores empty lines", func() {
 				runner.AddCmdResult("ip r", fakesys.FakeCmdResult{
 					Stdout: `

--- a/platform/net/routes_searcher_unix_test.go
+++ b/platform/net/routes_searcher_unix_test.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	. "github.com/cloudfoundry/bosh-agent/platform/net"
+	"github.com/cloudfoundry/bosh-utils/logger/loggerfakes"
 	fakesys "github.com/cloudfoundry/bosh-utils/system/fakes"
 )
 
@@ -20,7 +21,7 @@ var _ = Describe("cmdRoutesSeacher", func() {
 
 	BeforeEach(func() {
 		runner = fakesys.NewFakeCmdRunner()
-		searcher = NewRoutesSearcher(runner, nil)
+		searcher = NewRoutesSearcher(&loggerfakes.FakeLogger{}, runner, nil)
 	})
 
 	Describe("SearchRoutes", func() {

--- a/platform/provider.go
+++ b/platform/provider.go
@@ -100,7 +100,7 @@ func NewProvider(logger boshlog.Logger, dirProvider boshdirs.Provider, statsColl
 
 	interfaceManager := boshnet.NewInterfaceManager()
 
-	routesSearcher := boshnet.NewRoutesSearcher(runner, interfaceManager)
+	routesSearcher := boshnet.NewRoutesSearcher(logger, runner, interfaceManager)
 	defaultNetworkResolver := boshnet.NewDefaultNetworkResolver(routesSearcher, ipResolver)
 
 	monitRetryable := NewMonitRetryable(runner)


### PR DESCRIPTION
In this fix, perform checking before consuming the route parsing results to avoid [panic issue](https://github.com/cloudfoundry/bosh-agent/issues/230).