### PR TITLE
Revert "Fix blackhole route parsing"

### DIFF
--- a/platform/net/routes_searcher_unix.go
+++ b/platform/net/routes_searcher_unix.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
-	boshlog "github.com/cloudfoundry/bosh-utils/logger"
 	boshsys "github.com/cloudfoundry/bosh-utils/system"
 )
 
@@ -15,23 +14,16 @@ import (
 // which routes in a same format on Ubuntu and CentOS
 type cmdRoutesSearcher struct {
 	runner boshsys.CmdRunner
-	logger boshlog.Logger
 }
 
-func NewRoutesSearcher(logger boshlog.Logger, runner boshsys.CmdRunner, _ InterfaceManager) RoutesSearcher {
-	return cmdRoutesSearcher{
-		runner: runner,
-		logger: logger,
-	}
+func NewRoutesSearcher(runner boshsys.CmdRunner, _ InterfaceManager) RoutesSearcher {
+	return cmdRoutesSearcher{runner}
 }
 
-func parseRoute(ipString string) (Route, error) {
+func parseRoute(ipString string) Route {
 	var r = regexp.MustCompile(`(?P<destination>[a-z0-9.]+)(/[0-9]+)?( via (?P<gateway>[0-9.]+))? dev (?P<interfaceName>[a-z0-9]+)`)
 
 	match := r.FindStringSubmatch(ipString)
-	if len(match) == 0 {
-		return Route{}, bosherr.Error("unexpected route")
-	}
 	matches := make(map[string]string)
 	for i, name := range r.SubexpNames() {
 		matches[name] = match[i]
@@ -50,7 +42,7 @@ func parseRoute(ipString string) (Route, error) {
 		Destination:   destination,
 		Gateway:       gateway,
 		InterfaceName: matches["interfaceName"],
-	}, nil
+	}
 }
 
 func (s cmdRoutesSearcher) SearchRoutes() ([]Route, error) {
@@ -65,12 +57,7 @@ func (s cmdRoutesSearcher) SearchRoutes() ([]Route, error) {
 		if len(routeEntry) == 0 {
 			continue
 		}
-		route, err := parseRoute(routeEntry)
-		if err != nil {
-			s.logger.Warn("SearchRoutes", "parseRoute error for route '%s': %s", routeEntry, err.Error())
-			continue
-		}
-		routes = append(routes, route)
+		routes = append(routes, parseRoute(routeEntry))
 	}
 
 	return routes, nil

--- a/platform/net/routes_searcher_unix_test.go
+++ b/platform/net/routes_searcher_unix_test.go
@@ -9,7 +9,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	. "github.com/cloudfoundry/bosh-agent/platform/net"
-	"github.com/cloudfoundry/bosh-utils/logger/loggerfakes"
 	fakesys "github.com/cloudfoundry/bosh-utils/system/fakes"
 )
 
@@ -21,7 +20,7 @@ var _ = Describe("cmdRoutesSeacher", func() {
 
 	BeforeEach(func() {
 		runner = fakesys.NewFakeCmdRunner()
-		searcher = NewRoutesSearcher(&loggerfakes.FakeLogger{}, runner, nil)
+		searcher = NewRoutesSearcher(runner, nil)
 	})
 
 	Describe("SearchRoutes", func() {
@@ -31,25 +30,6 @@ var _ = Describe("cmdRoutesSeacher", func() {
 					Stdout: `172.16.79.0/24 dev eth0 proto kernel scope link metric 100
 169.254.0.0/16 dev eth0 proto link metric 1000
 default via 172.16.79.1 dev eth0 proto dhcp metric 100
-`,
-				})
-
-				routes, err := searcher.SearchRoutes()
-				Expect(err).ToNot(HaveOccurred())
-				Expect(runner.RunCommandsQuietly[0]).To(Equal([]string{"ip", "r"}))
-				Expect(routes).To(Equal([]Route{
-					Route{Destination: "172.16.79.0", Gateway: "0.0.0.0", InterfaceName: "eth0"},
-					Route{Destination: "169.254.0.0", Gateway: "0.0.0.0", InterfaceName: "eth0"},
-					Route{Destination: "0.0.0.0", Gateway: "172.16.79.1", InterfaceName: "eth0"},
-				}))
-			})
-
-			It("ignores unexpected blackhole routes information", func() {
-				runner.AddCmdResult("ip r", fakesys.FakeCmdResult{
-					Stdout: `172.16.79.0/24 dev eth0 proto kernel scope link metric 100
-169.254.0.0/16 dev eth0 proto link metric 1000
-default via 172.16.79.1 dev eth0 proto dhcp metric 100
-blackhole 10.200.115.192/26  proto bird
 `,
 				})
 

--- a/platform/provider.go
+++ b/platform/provider.go
@@ -100,7 +100,7 @@ func NewProvider(logger boshlog.Logger, dirProvider boshdirs.Provider, statsColl
 
 	interfaceManager := boshnet.NewInterfaceManager()
 
-	routesSearcher := boshnet.NewRoutesSearcher(logger, runner, interfaceManager)
+	routesSearcher := boshnet.NewRoutesSearcher(runner, interfaceManager)
 	defaultNetworkResolver := boshnet.NewDefaultNetworkResolver(routesSearcher, ipResolver)
 
 	monitRetryable := NewMonitRetryable(runner)


### PR DESCRIPTION
Reverts cloudfoundry/bosh-agent#231

Original PR was targeting wrong branch.