### PR TITLE
Fix double-resize persistent disk on vSphere

### DIFF
--- a/platform/disk/ephemeral_device_partitioner_test.go
+++ b/platform/disk/ephemeral_device_partitioner_test.go
@@ -84,7 +84,7 @@ var _ = Describe("EphemeralDevicePartitioner", func() {
 				err := partitioner.Partition(devicePath, partitions)
 				Expect(err).ToNot(HaveOccurred())
 
-				Expect(len(fakeCmdRunner.RunCommands)).To(Equal(12))
+				Expect(len(fakeCmdRunner.RunCommands)).To(Equal(13))
 
 				Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"parted", "-m", "/dev/edx", "unit", "B", "print"}))
 				Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"parted", "-s", "/dev/edx", "unit", "B", "mkpart", "fake-agent-id-0", "1048576", "8590983167"}))
@@ -137,7 +137,7 @@ var _ = Describe("EphemeralDevicePartitioner", func() {
 					err := partitioner.Partition(devicePath, partitions)
 					Expect(err).ToNot(HaveOccurred())
 
-					Expect(len(fakeCmdRunner.RunCommands)).To(Equal(12))
+					Expect(len(fakeCmdRunner.RunCommands)).To(Equal(13))
 
 					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"parted", "-m", "/dev/edx", "unit", "B", "print"}))
 					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"wipefs", "-a", "/dev/edx"}))
@@ -193,7 +193,7 @@ var _ = Describe("EphemeralDevicePartitioner", func() {
 					err := partitioner.Partition(devicePath, partitions)
 					Expect(err).ToNot(HaveOccurred())
 
-					Expect(len(fakeCmdRunner.RunCommands)).To(Equal(12))
+					Expect(len(fakeCmdRunner.RunCommands)).To(Equal(13))
 
 					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"parted", "-m", "/dev/edx", "unit", "B", "print"}))
 					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"wipefs", "-a", "/dev/edx"}))
@@ -282,7 +282,7 @@ var _ = Describe("EphemeralDevicePartitioner", func() {
 					err := partitioner.Partition(devicePath, partitions)
 					Expect(err).ToNot(HaveOccurred())
 
-					Expect(len(fakeCmdRunner.RunCommands)).To(Equal(12))
+					Expect(len(fakeCmdRunner.RunCommands)).To(Equal(13))
 
 					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"parted", "-m", "/dev/edx", "unit", "B", "print"}))
 					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"wipefs", "-a", "/dev/edx"}))

--- a/platform/disk/parted_partitioner.go
+++ b/platform/disk/parted_partitioner.go
@@ -35,6 +35,12 @@ func NewPartedPartitioner(logger boshlog.Logger, cmdRunner boshsys.CmdRunner, ti
 }
 
 func (p partedPartitioner) Partition(devicePath string, desiredPartitions []Partition) error {
+	_, _, _, err := p.cmdRunner.RunCommand("partprobe", devicePath)
+	if err != nil {
+		p.logger.Error(p.logTag, "Failed to probe existing parition: %s", err)
+		return bosherr.WrapErrorf(err, "Re-reading partition table for `%s'", devicePath)
+	}
+
 	existingPartitions, deviceFullSizeInBytes, err := p.GetPartitions(devicePath)
 	if err != nil {
 		return bosherr.WrapErrorf(err, "Getting existing partitions of `%s'", devicePath)

--- a/platform/disk/parted_partitioner_test.go
+++ b/platform/disk/parted_partitioner_test.go
@@ -80,6 +80,7 @@ var _ = Describe("PartedPartitioner", func() {
 					Expect(err).ToNot(HaveOccurred())
 
 					Expect(fakeCmdRunner.RunCommands).To(Equal([][]string{
+						[]string{"partprobe", "/dev/sda"},
 						[]string{"parted", "-m", "/dev/sda", "unit", "B", "print"},
 						[]string{"parted", "-s", "/dev/sda", "mklabel", "gpt"},
 						[]string{"parted", "-m", "/dev/sda", "unit", "B", "print"},
@@ -141,6 +142,7 @@ var _ = Describe("PartedPartitioner", func() {
 					Expect(err).ToNot(HaveOccurred())
 
 					Expect(fakeCmdRunner.RunCommands).To(Equal([][]string{
+						[]string{"partprobe", "/dev/sda"},
 						[]string{"parted", "-m", "/dev/sda", "unit", "B", "print"},
 						[]string{"parted", "-s", "/dev/sda", "mklabel", "gpt"},
 						[]string{"parted", "-m", "/dev/sda", "unit", "B", "print"},
@@ -191,6 +193,7 @@ var _ = Describe("PartedPartitioner", func() {
 					Expect(err).ToNot(HaveOccurred())
 
 					Expect(fakeCmdRunner.RunCommands).To(Equal([][]string{
+						[]string{"partprobe", "/dev/sda"},
 						[]string{"parted", "-m", "/dev/sda", "unit", "B", "print"},
 						[]string{"udevadm", "settle"},
 						[]string{"parted", "-s", "/dev/sda", "unit", "B", "mkpart", "bosh-partition-0", "1048576", "8590983167"},
@@ -243,6 +246,7 @@ var _ = Describe("PartedPartitioner", func() {
 						Expect(err).ToNot(HaveOccurred())
 
 						Expect(fakeCmdRunner.RunCommands).To(Equal([][]string{
+							[]string{"partprobe", "/dev/sda"},
 							[]string{"parted", "-m", "/dev/sda", "unit", "B", "print"},
 							[]string{"udevadm", "settle"},
 							[]string{"parted", "-s", "/dev/sda", "unit", "B", "mkpart", "bosh-partition-0", "1048576", "8590983167"},
@@ -292,6 +296,7 @@ var _ = Describe("PartedPartitioner", func() {
 						Expect(err.Error()).To(Equal("'/dev/sda' contains a partition created by bosh. No partitioning is allowed."))
 
 						Expect(fakeCmdRunner.RunCommands).To(Equal([][]string{
+							[]string{"partprobe", "/dev/sda"},
 							[]string{"parted", "-m", "/dev/sda", "unit", "B", "print"},
 							[]string{"udevadm", "settle"},
 						}))
@@ -330,6 +335,7 @@ var _ = Describe("PartedPartitioner", func() {
 					Expect(err).ToNot(HaveOccurred())
 
 					Expect(fakeCmdRunner.RunCommands).To(Equal([][]string{
+						[]string{"partprobe", "/dev/sdf"},
 						[]string{"parted", "-m", "/dev/sdf", "unit", "B", "print"},
 						[]string{"udevadm", "settle"},
 						[]string{"parted", "-s", "/dev/sdf", "unit", "B", "mkpart", "bosh-partition-0", "1048576", "3146062495743"},
@@ -368,6 +374,7 @@ var _ = Describe("PartedPartitioner", func() {
 					err := partitioner.Partition("/dev/sdf", partitions)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(fakeCmdRunner.RunCommands).To(Equal([][]string{
+						[]string{"partprobe", "/dev/sdf"},
 						[]string{"parted", "-m", "/dev/sdf", "unit", "B", "print"},
 						[]string{"udevadm", "settle"},
 						[]string{"parted", "-s", "/dev/sdf", "unit", "B", "mkpart", "bosh-partition-0", "1048576", "3146062495743"},
@@ -415,6 +422,7 @@ var _ = Describe("PartedPartitioner", func() {
 					Expect(err).ToNot(HaveOccurred())
 
 					Expect(fakeCmdRunner.RunCommands).To(Equal([][]string{
+						[]string{"partprobe", "/dev/sda"},
 						[]string{"parted", "-m", "/dev/sda", "unit", "B", "print"},
 						[]string{"udevadm", "settle"},
 						[]string{"parted", "-s", "/dev/sda", "unit", "B", "mkpart", "bosh-partition-0", "1048576", "8590983167"},
@@ -452,6 +460,7 @@ var _ = Describe("PartedPartitioner", func() {
 
 					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"parted", "-m", "/dev/sda", "unit", "B", "print"}))
 					Expect(fakeCmdRunner.RunCommands).To(Equal([][]string{
+						[]string{"partprobe", "/dev/sda"},
 						[]string{"parted", "-m", "/dev/sda", "unit", "B", "print"},
 						[]string{"udevadm", "settle"},
 					}))
@@ -481,6 +490,7 @@ var _ = Describe("PartedPartitioner", func() {
 
 					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"parted", "-m", "/dev/sda", "unit", "B", "print"}))
 					Expect(fakeCmdRunner.RunCommands).To(Equal([][]string{
+						[]string{"partprobe", "/dev/sda"},
 						[]string{"parted", "-m", "/dev/sda", "unit", "B", "print"},
 						[]string{"udevadm", "settle"},
 					}))
@@ -509,6 +519,7 @@ var _ = Describe("PartedPartitioner", func() {
 
 					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"parted", "-m", "/dev/sda", "unit", "B", "print"}))
 					Expect(fakeCmdRunner.RunCommands).To(Equal([][]string{
+						[]string{"partprobe", "/dev/sda"},
 						[]string{"parted", "-m", "/dev/sda", "unit", "B", "print"},
 						[]string{"udevadm", "settle"},
 					}))
@@ -538,6 +549,7 @@ var _ = Describe("PartedPartitioner", func() {
 							Expect(err).ToNot(HaveOccurred())
 
 							Expect(fakeCmdRunner.RunCommands).To(Equal([][]string{
+								[]string{"partprobe", "/dev/sdf"},
 								[]string{"parted", "-m", "/dev/sdf", "unit", "B", "print"},
 								[]string{"udevadm", "settle"},
 							}))
@@ -568,6 +580,7 @@ var _ = Describe("PartedPartitioner", func() {
 
 					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"parted", "-m", "/dev/sdf", "unit", "B", "print"}))
 					Expect(fakeCmdRunner.RunCommands).To(Equal([][]string{
+						[]string{"partprobe", "/dev/sdf"},
 						[]string{"parted", "-m", "/dev/sdf", "unit", "B", "print"},
 						[]string{"udevadm", "settle"},
 					}))
@@ -576,6 +589,31 @@ var _ = Describe("PartedPartitioner", func() {
 		})
 
 		Context("when getting existing partitions returns an error", func() {
+			Context("when re-reading partition table fails", func() {
+				BeforeEach(func() {
+					fakeCmdRunner.AddCmdResult(
+						"partprobe /dev/sda",
+						fakesys.FakeCmdResult{
+							Stdout: "Some weird error", ExitStatus: 1, Error: errors.New("Some weird error")},
+					)
+				})
+
+				It("throw an error", func() {
+					partitions := []Partition{
+						{SizeInBytes: 8589934592}, // (8GiB)
+						{SizeInBytes: 8589934592}, // (8GiB)
+					}
+
+					err := partitioner.Partition("/dev/sda", partitions)
+					Expect(err).To(HaveOccurred())
+
+					Expect(err.Error()).To(ContainSubstring("Re-reading partition table for `/dev/sda': Some weird error"))
+					Expect(fakeCmdRunner.RunCommands).To(Equal([][]string{
+						[]string{"partprobe", "/dev/sda"},
+					}))
+				})
+			})
+
 			Context("when the first call to parted print fails", func() {
 				BeforeEach(func() {
 					fakeCmdRunner.AddCmdResult(
@@ -596,6 +634,7 @@ var _ = Describe("PartedPartitioner", func() {
 
 					Expect(err.Error()).To(ContainSubstring("Getting existing partitions of `/dev/sda': Running parted print: Some weird error"))
 					Expect(fakeCmdRunner.RunCommands).To(Equal([][]string{
+						[]string{"partprobe", "/dev/sda"},
 						[]string{"parted", "-m", "/dev/sda", "unit", "B", "print"},
 						[]string{"udevadm", "settle"},
 					}))
@@ -625,6 +664,7 @@ var _ = Describe("PartedPartitioner", func() {
 
 					Expect(err.Error()).To(ContainSubstring("Getting existing partitions of `/dev/sda': Running parted print: Parted making label: Some weird error"))
 					Expect(fakeCmdRunner.RunCommands).To(Equal([][]string{
+						[]string{"partprobe", "/dev/sda"},
 						[]string{"parted", "-m", "/dev/sda", "unit", "B", "print"},
 						[]string{"parted", "-s", "/dev/sda", "mklabel", "gpt"},
 						[]string{"udevadm", "settle"},
@@ -659,6 +699,7 @@ var _ = Describe("PartedPartitioner", func() {
 
 					Expect(err.Error()).To(ContainSubstring("Getting existing partitions of `/dev/sda': Running parted print: Some weird error"))
 					Expect(fakeCmdRunner.RunCommands).To(Equal([][]string{
+						[]string{"partprobe", "/dev/sda"},
 						[]string{"parted", "-m", "/dev/sda", "unit", "B", "print"},
 						[]string{"parted", "-s", "/dev/sda", "mklabel", "gpt"},
 						[]string{"parted", "-m", "/dev/sda", "unit", "B", "print"},


### PR DESCRIPTION
When extending the size of a persistent disk _for the second time_ on vSphere, the operation fails with "...Creating partition using parted...". This commit addresses that error.

Our fix is to strategically run `partprobe`, which "informs the operating system kernel of partition table changes".

We believe the cause of this error is the manner in which vSphere detaches disks from VMs, which differ from the manner in which other IaaSes, specifically GCP, detach disks. vSphere does not signal to the OS that the disk has been removed, and the memory of the disk "lingers".

For example, running `lsblk -a` after the first resize (say from 1GB → 2GB), the new (larger) disk shows up as `/dev/sdd` and the old (smaller) disk shows up as `/dev/sdc`. This stands in sharp contrast to GCP, where the new (larger)
disk shows up as `/dev/sdc`, and the old (smaller) disk is not to be found.

Note that after the first resize, all is good on vSphere: `/dev/sdd1` is mounted on `/var/vcap/store` (on GCP it's `/dev/sdc1` that's mounted on `/var/vcap/store`). It's when the second resize (say from 2GB → 3GB) is done that everything breaks down on vSphere: the new 3GB disk is connected as `/dev/sdc`, but as far as the kernel is concerned `/dev/sdc` is not the new 3GB disk but the original 1GB disk with the original partition table, and the `bosh-agent` errors saying the disk is too small.

Fixes, on `bosh deploy`:
```
Task 28327 | 20:05:31 | L executing post-stop: app/cad4e5cd-cf79-4af1-9d50-2393109227a8 (0) (canary) (00:03:29)
                     L Error: Action Failed get_task: Task 36a76be2-0c67-4c07-78d7-bb6d44e71344 result: Mounting persistent disk: Partitioning disk: Partitioning disk `/dev/sdc': Creating partition using parted: Running command: 'parted -s /dev/sdc unit B mkpart bosh-partition-0 1048576 2146435071', stdout: '', stderr: 'Warning: Not all of the space available to /dev/sdc appears to be used, you can fix the GPT to use all of the space (an extra 2097152 blocks) or continue with the current setting?
Error: You requested a partition from 1048576B to 2146434560B (sectors 2048..4192255).
The closest location we can manage is 1048576B to 1073724416B (sectors 2048..2097118).
```

### Please Note

- We're looking for guidance about which branch to submit this PR to. We're submitting against develop, but we suspect it should be backported to branch `2.268.x`
- We tested this fix by applying it as a patch to the `2.268.16` tag and deploying three persistent disk resizes in a row.
- We ran the unit tests, but were unable to run the integrations tests.

/cc @jpalermo who did much of the initial investigation
