### PR TITLE
Have vitals check for mount points (fixes #245)

### DIFF
--- a/agent/bootstrap_test.go
+++ b/agent/bootstrap_test.go
@@ -1116,7 +1116,7 @@ var _ = Describe("bootstrap", func() {
 
 				sigarCollector := boshsigar.NewSigarStatsCollector(&sigar.ConcreteSigar{})
 
-				vitalsService := boshvitals.NewService(sigarCollector, dirProvider)
+				vitalsService := boshvitals.NewService(sigarCollector, dirProvider, mounter)
 
 				ipResolver := boship.NewResolver(boship.NetworkInterfaceToAddrsFunc)
 

--- a/platform/dummy_platform.go
+++ b/platform/dummy_platform.go
@@ -69,7 +69,7 @@ func NewDummyPlatform(
 		copier:             boshcmd.NewGenericCpCopier(fs, logger),
 		dirProvider:        dirProvider,
 		devicePathResolver: devicePathResolver,
-		vitalsService:      boshvitals.NewService(collector, dirProvider),
+		vitalsService:      boshvitals.NewService(collector, dirProvider, nil),
 		certManager:        boshcert.NewDummyCertManager(fs, cmdRunner, 0, logger),
 		logger:             logger,
 		auditLogger:        auditLogger,

--- a/platform/linux_platform_test.go
+++ b/platform/linux_platform_test.go
@@ -80,7 +80,6 @@ var _ = Describe("LinuxPlatform", func() {
 		cdutil = fakecdrom.NewFakeCDUtil()
 		compressor = boshcmd.NewTarballCompressor(cmdRunner, fs)
 		copier = boshcmd.NewGenericCpCopier(fs, logger)
-		vitalsService = boshvitals.NewService(collector, dirProvider)
 		netManager = &fakenet.FakeManager{}
 		certManager = new(certfakes.FakeManager)
 		monitRetryStrategy = fakeretry.NewFakeRetryStrategy()
@@ -122,6 +121,8 @@ var _ = Describe("LinuxPlatform", func() {
 
 		diskUtil = fakedisk.NewFakeDiskUtil()
 		diskManager.GetUtilReturns(diskUtil)
+
+		vitalsService = boshvitals.NewService(collector, dirProvider, mounter)
 	})
 
 	JustBeforeEach(func() {

--- a/platform/provider.go
+++ b/platform/provider.go
@@ -72,7 +72,7 @@ func NewProvider(logger boshlog.Logger, dirProvider boshdirs.Provider, statsColl
 	// Kick of stats collection as soon as possible
 	statsCollector.StartCollecting(SigarStatsCollectionInterval, nil)
 
-	vitalsService := boshvitals.NewService(statsCollector, dirProvider)
+	vitalsService := boshvitals.NewService(statsCollector, dirProvider, linuxDiskManager.GetMounter())
 
 	ipResolver := boship.NewResolver(boship.NetworkInterfaceToAddrsFunc)
 

--- a/platform/vitals/service_test.go
+++ b/platform/vitals/service_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"github.com/cloudfoundry/bosh-agent/platform/disk/diskfakes"
 	boshstats "github.com/cloudfoundry/bosh-agent/platform/stats"
 	fakestats "github.com/cloudfoundry/bosh-agent/platform/stats/fakes"
 	. "github.com/cloudfoundry/bosh-agent/platform/vitals"
@@ -16,55 +17,63 @@ import (
 
 const Windows = runtime.GOOS == "windows"
 
-func buildVitalsService() (statsCollector *fakestats.FakeCollector, service Service) {
-	dirProvider := boshdirs.NewProvider("/fake/base/dir")
-	statsCollector = &fakestats.FakeCollector{
-		CPULoad: boshstats.CPULoad{
-			One:     0.2,
-			Five:    4.55,
-			Fifteen: 1.123,
-		},
-		StartCollectingCPUStats: boshstats.CPUStats{
-			User:  56,
-			Sys:   10,
-			Wait:  1,
-			Total: 100,
-		},
-		MemStats: boshstats.Usage{
-			Used:  700 * 1024,
-			Total: 1000 * 1024,
-		},
-		SwapStats: boshstats.Usage{
-			Used:  600 * 1024,
-			Total: 1000 * 1024,
-		},
-		UptimeStats: boshstats.UptimeStats{
-			Secs: 5,
-		},
-		DiskStats: map[string]boshstats.DiskStats{
-			"/": boshstats.DiskStats{
-				DiskUsage:  boshstats.Usage{Used: 100, Total: 200},
-				InodeUsage: boshstats.Usage{Used: 50, Total: 500},
-			},
-			dirProvider.DataDir(): boshstats.DiskStats{
-				DiskUsage:  boshstats.Usage{Used: 15, Total: 20},
-				InodeUsage: boshstats.Usage{Used: 10, Total: 50},
-			},
-			dirProvider.StoreDir(): boshstats.DiskStats{
-				DiskUsage:  boshstats.Usage{Used: 2, Total: 2},
-				InodeUsage: boshstats.Usage{Used: 3, Total: 4},
-			},
-		},
-	}
-
-	service = NewService(statsCollector, dirProvider)
-	statsCollector.StartCollecting(1*time.Millisecond, nil)
-	return
-}
-
 var _ = Describe("Vitals service", func() {
-	It("vitals construction", func() {
-		_, service := buildVitalsService()
+	var (
+		dirProvider    boshdirs.Provider
+		statsCollector *fakestats.FakeCollector
+		mounter        *diskfakes.FakeMounter
+		service        Service
+	)
+
+	BeforeEach(func() {
+		dirProvider = boshdirs.NewProvider("/fake/base/dir")
+		statsCollector = &fakestats.FakeCollector{
+			CPULoad: boshstats.CPULoad{
+				One:     0.2,
+				Five:    4.55,
+				Fifteen: 1.123,
+			},
+			StartCollectingCPUStats: boshstats.CPUStats{
+				User:  56,
+				Sys:   10,
+				Wait:  1,
+				Total: 100,
+			},
+			MemStats: boshstats.Usage{
+				Used:  700 * 1024,
+				Total: 1000 * 1024,
+			},
+			SwapStats: boshstats.Usage{
+				Used:  600 * 1024,
+				Total: 1000 * 1024,
+			},
+			UptimeStats: boshstats.UptimeStats{
+				Secs: 5,
+			},
+			DiskStats: map[string]boshstats.DiskStats{
+				"/": {
+					DiskUsage:  boshstats.Usage{Used: 100, Total: 200},
+					InodeUsage: boshstats.Usage{Used: 50, Total: 500},
+				},
+				dirProvider.DataDir(): {
+					DiskUsage:  boshstats.Usage{Used: 15, Total: 20},
+					InodeUsage: boshstats.Usage{Used: 10, Total: 50},
+				},
+				dirProvider.StoreDir(): {
+					DiskUsage:  boshstats.Usage{Used: 2, Total: 2},
+					InodeUsage: boshstats.Usage{Used: 3, Total: 4},
+				},
+			},
+		}
+
+		mounter = &diskfakes.FakeMounter{}
+		mounter.IsMountPointReturns("/dev/fake-partition-device", true, nil)
+
+		service = NewService(statsCollector, dirProvider, mounter)
+		statsCollector.StartCollecting(1*time.Millisecond, nil)
+	})
+
+	It("constructs vitals properly", func() {
 		vitals, err := service.Get()
 
 		expectedVitals := map[string]interface{}{
@@ -107,31 +116,55 @@ var _ = Describe("Vitals service", func() {
 
 		Expect(err).ToNot(HaveOccurred())
 
+		Expect(mounter.IsMountPointCallCount()).To(Equal(3))
+
 		boshassert.MatchesJSONMap(GinkgoT(), vitals, expectedVitals)
 	})
 
-	It("getting vitals when missing disks", func() {
+	Context("when missing stats for ephemeral and peristent disk", func() {
+		BeforeEach(func() {
+			statsCollector.DiskStats = map[string]boshstats.DiskStats{
+				"/": {
+					DiskUsage:  boshstats.Usage{Used: 100, Total: 200},
+					InodeUsage: boshstats.Usage{Used: 50, Total: 500},
+				},
+			}
+		})
 
-		statsCollector, service := buildVitalsService()
-		statsCollector.DiskStats = map[string]boshstats.DiskStats{
-			"/": boshstats.DiskStats{
-				DiskUsage:  boshstats.Usage{Used: 100, Total: 200},
-				InodeUsage: boshstats.Usage{Used: 50, Total: 500},
-			},
-		}
+		It("returns vitals for root disk only", func() {
+			vitals, err := service.Get()
+			Expect(err).ToNot(HaveOccurred())
 
-		vitals, err := service.Get()
-		Expect(err).ToNot(HaveOccurred())
-
-		boshassert.LacksJSONKey(GinkgoT(), vitals.Disk, "ephemeral")
-		boshassert.LacksJSONKey(GinkgoT(), vitals.Disk, "persistent")
+			boshassert.LacksJSONKey(GinkgoT(), vitals.Disk, "ephemeral")
+			boshassert.LacksJSONKey(GinkgoT(), vitals.Disk, "persistent")
+		})
 	})
-	It("get getting vitals on system disk error", func() {
 
-		statsCollector, service := buildVitalsService()
-		statsCollector.DiskStats = map[string]boshstats.DiskStats{}
+	Context("when missing stats for system disk", func() {
+		BeforeEach(func() {
+			statsCollector.DiskStats = map[string]boshstats.DiskStats{}
+		})
 
-		_, err := service.Get()
-		Expect(err).To(HaveOccurred())
+		It("returns an error", func() {
+			_, err := service.Get()
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Context("when no persistent disk is mounted", func() {
+		BeforeEach(func() {
+			mounter.IsMountPointStub = func(path string) (partitionPath string, isMountPoint bool, err error) {
+				partitionPath = "/dev/fake-partition-device"
+				isMountPoint = (path != "/fake/base/dir/store")
+				return
+			}
+		})
+
+		It("does not return vitals for persistent disk", func() {
+			vitals, err := service.Get()
+
+			Expect(err).NotTo(HaveOccurred())
+			boshassert.LacksJSONKey(GinkgoT(), vitals.Disk, "persistent")
+		})
 	})
 })

--- a/platform/windows_platform.go
+++ b/platform/windows_platform.go
@@ -89,7 +89,7 @@ func NewWindowsPlatform(
 		dirProvider:            dirProvider,
 		netManager:             netManager,
 		devicePathResolver:     devicePathResolver,
-		vitalsService:          boshvitals.NewService(collector, dirProvider),
+		vitalsService:          boshvitals.NewService(collector, dirProvider, nil),
 		certManager:            certManager,
 		options:                options,
 		defaultNetworkResolver: defaultNetworkResolver,


### PR DESCRIPTION
This PR fixes #245, introducing a call to `IsMountPoint()` in order to exclude from vitals the existing directories where no disk is actually mounted.
The problem is a bit tricky because Windows and dummy platforms don't have any disk mounter. The proposed solution here, is based on an optional `diskMounter` dependency in the vitals service, that can be `nil`.
Unit tests for the vitals service have also been refactored a bit, in order to be clearer and adopt standard easy-to-read structure.
Cheers