### PR TITLE
Enable UseMTU in systemd networking configuration

### DIFF
--- a/platform/net/ubuntu_net_manager.go
+++ b/platform/net/ubuntu_net_manager.go
@@ -604,6 +604,7 @@ func (net UbuntuNetManager) writeDynamicInterfaceConfiguration(config DHCPInterf
 	// DHCP Section
 	dhcpSection := &ini.Section{Name: "DHCP"}
 	dhcpSection.AddKey("UseDomains", "yes")
+	dhcpSection.AddKey("UseMTU", "yes")
 	file.AppendSection(dhcpSection)
 
 	// Route Sections

--- a/platform/net/ubuntu_net_manager_test.go
+++ b/platform/net/ubuntu_net_manager_test.go
@@ -742,6 +742,7 @@ DNS=8.8.8.8
 
 [DHCP]
 UseDomains=yes
+UseMTU=yes
 
 [Route]
 Destination=10.0.0.0/8
@@ -1113,6 +1114,7 @@ DNS=9.9.9.9
 
 [DHCP]
 UseDomains=yes
+UseMTU=yes
 
 `))
 


### PR DESCRIPTION
Without UseMTU, systemd will not properly use the MTU
value that is received over DHCP on Ubuntu Bionic.
The change should be compatible with previous stemcells,
since apparently the default behavior of systemd-networkd
was changed between Xenial and Bionic.

Diff of the relevant man page section (Xenial and Bionic stemcells):

> UseMTU=
>     When true, the interface maximum transmission unit from the DHCP server will be used on the current link. {+If MTUBytes= is set, then this setting is ignored.+} Defaults to [-true.-]{+false.+}
