### PR TITLE
Add AWS IMDSv2 support

### DIFF
--- a/infrastructure/http_metadata_service.go
+++ b/infrastructure/http_metadata_service.go
@@ -355,12 +355,17 @@ func (ms HTTPMetadataService) getToken()(token string, err error) {
 		}
 	}()
 
+	if resp.StatusCode != 200 {
+		return "", nil
+	}
+
 	bytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return "", bosherr.WrapError(err, "Reading instance id response body")
 	}
 
 	return string(bytes), nil
+
 }
 
 func createRetryClient(delay time.Duration, logger boshlog.Logger) *httpclient.HTTPClient {

--- a/infrastructure/instance_metadata_settings_source.go
+++ b/infrastructure/instance_metadata_settings_source.go
@@ -42,7 +42,7 @@ func NewInstanceMetadataSettingsSource(
 		logTag: logTag,
 		// The HTTPMetadataService provides more functionality than we need (like custom DNS), so we
 		// pass zero values to the New function and only use its GetValueAtPath method.
-		metadataService: NewHTTPMetadataService(metadataHost, metadataHeaders, "", "", "", nil, platform, logger),
+		metadataService: NewHTTPMetadataService(metadataHost, metadataHeaders, "", "", "", "", nil, platform, logger),
 	}
 }
 

--- a/infrastructure/settings_source_factory.go
+++ b/infrastructure/settings_source_factory.go
@@ -34,6 +34,7 @@ type HTTPSourceOptions struct {
 	UserDataPath   string
 	InstanceIDPath string
 	SSHKeysPath    string
+	TokenPath      string
 }
 
 func (o HTTPSourceOptions) sourceOptionsInterface() {}
@@ -115,6 +116,7 @@ func (f SettingsSourceFactory) buildWithRegistry() (boshsettings.Source, error) 
 				typedOpts.UserDataPath,
 				typedOpts.InstanceIDPath,
 				typedOpts.SSHKeysPath,
+				typedOpts.TokenPath,
 				resolver,
 				f.platform,
 				f.logger,


### PR DESCRIPTION
Adds support for a new tokenPath field in agent.json

When this field is present, the agent will make a PUT request to that path to fetch a token before each AWS Instance Metadata Service call, and will include that token in a header when calling IMDS.

When the tokenPath is not specified, the agent behaves as before and uses IMDSv1.

It should also fall back to IMDSv1 if IMDSv2 is not available in the region. We're not sure if this exists, but we ran into similar problems recently with availability of gp3 disks in some regions.

This functionality being used is dependent on an update to the `agent.json` in the bosh linux stemcell builder which will be coming soon.