### PR TITLE
add cookie support for monit as new monit versions need one

### DIFF
--- a/jobsupervisor/monit/http_client.go
+++ b/jobsupervisor/monit/http_client.go
@@ -190,14 +190,14 @@ func (c httpClient) validateResponse(response *http.Response) error {
 }
 
 func (c httpClient) makeRequest(client HTTPClient, target url.URL, method, requestBody string) (*http.Response, error) {
-	c.logger.Debug("http-client", "Monit request: url='%s' body='%s'", target.String(), requestBody)
 
 	for _, cookie := range c.jar.Cookies(&target) {
 		if cookie.Name == "securityToken" {
+			c.logger.Debug("http-client", "Adding cookie (name='%v') found in jar", cookie.Name)
 			requestBody = fmt.Sprintf("%v&securityToken=%v", requestBody, url.QueryEscape(cookie.Value))
 		}
 	}
-
+	c.logger.Debug("http-client", "Monit request: url='%s' body='%s'", target.String(), requestBody)
 	request, err := http.NewRequest(method, target.String(), strings.NewReader(requestBody))
 	if err != nil {
 		return nil, err
@@ -207,5 +207,6 @@ func (c httpClient) makeRequest(client HTTPClient, target url.URL, method, reque
 
 	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
+	c.logger.Debug("full request: %v", fmt.Sprintf("%v", request))
 	return client.Do(request)
 }

--- a/jobsupervisor/monit/http_client.go
+++ b/jobsupervisor/monit/http_client.go
@@ -4,6 +4,7 @@ import (
 	"encoding/xml"
 	"io/ioutil"
 	"net/http"
+	"net/http/cookiejar"
 	"net/url"
 	"path"
 	"strings"
@@ -29,6 +30,7 @@ type httpClient struct {
 	username        string
 	password        string
 	logger          boshlog.Logger
+	cookieJar       cookiejar.Jar
 }
 
 // NewHTTPClient creates a new monit client
@@ -41,6 +43,10 @@ func NewHTTPClient(
 	longClient HTTPClient,
 	logger boshlog.Logger,
 ) Client {
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		bosherr.Errorf("Error creating CookieJar: %s", err)
+	}
 	return httpClient{
 		host:            host,
 		username:        username,
@@ -50,6 +56,7 @@ func NewHTTPClient(
 		unmonitorClient: longClient,
 		statusClient:    shortClient,
 		logger:          logger,
+		cookieJar:       *jar,
 	}
 }
 

--- a/jobsupervisor/monit/http_client.go
+++ b/jobsupervisor/monit/http_client.go
@@ -4,7 +4,6 @@ import (
 	"encoding/xml"
 	"io/ioutil"
 	"net/http"
-	"net/http/cookiejar"
 	"net/url"
 	"path"
 	"strings"
@@ -30,7 +29,6 @@ type httpClient struct {
 	username        string
 	password        string
 	logger          boshlog.Logger
-	cookieJar       cookiejar.Jar
 }
 
 // NewHTTPClient creates a new monit client
@@ -43,10 +41,6 @@ func NewHTTPClient(
 	longClient HTTPClient,
 	logger boshlog.Logger,
 ) Client {
-	jar, err := cookiejar.New(nil)
-	if err != nil {
-		bosherr.Errorf("Error creating CookieJar: %s", err)
-	}
 	return httpClient{
 		host:            host,
 		username:        username,
@@ -56,7 +50,6 @@ func NewHTTPClient(
 		unmonitorClient: longClient,
 		statusClient:    shortClient,
 		logger:          logger,
-		cookieJar:       *jar,
 	}
 }
 
@@ -90,8 +83,6 @@ func (c httpClient) StartService(serviceName string) error {
 }
 
 func (c httpClient) StopService(serviceName string) error {
-	var response *http.Response
-
 	response, err := c.makeRequest(c.stopClient, c.monitURL(serviceName), "POST", "action=stop")
 	if err != nil {
 		return bosherr.WrapErrorf(err, "Sending stop request for service '%s'", serviceName)

--- a/jobsupervisor/monit/http_client_test.go
+++ b/jobsupervisor/monit/http_client_test.go
@@ -132,7 +132,7 @@ var _ = Describe("httpClient", func() {
 				Expect(r.URL.Path).To(Equal("/test-service"))
 				Expect(r.PostFormValue("action")).To(Equal("unmonitor"))
 				Expect(r.Header.Get("Content-Type")).To(Equal("application/x-www-form-urlencoded"))
-
+				w.Header().Set("securitytoken", "testvalue")
 				expectedAuthEncoded := base64.URLEncoding.EncodeToString([]byte("fake-user:fake-pass"))
 				Expect(r.Header.Get("Authorization")).To(Equal(fmt.Sprintf("Basic %s", expectedAuthEncoded)))
 			})
@@ -215,7 +215,12 @@ var _ = Describe("httpClient", func() {
 
 			shortClient.DoReturns(&http.Response{
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(bytes.NewBufferString(string(readFixture(statusWithMultipleServiceFixturePath)))),
+				Header: http.Header{
+					"securitytoken": []string{
+						"test",
+					},
+				},
+				Body: ioutil.NopCloser(bytes.NewBufferString(string(readFixture(statusWithMultipleServiceFixturePath)))),
 			}, nil)
 
 			status, err := client.Status()
@@ -267,7 +272,7 @@ func newFakeClient(shortClient, longClient HTTPClient) Client {
 	logger := boshlog.NewLogger(boshlog.LevelNone)
 	jar, err := cookiejar.New(nil)
 	if err != nil {
-		return nil
+		bosherr.Errorf("Error creating CookieJar: %s", err)
 	}
 	return NewHTTPClient(
 		"agent.example.com",

--- a/jobsupervisor/monit/http_client_test.go
+++ b/jobsupervisor/monit/http_client_test.go
@@ -72,7 +72,7 @@ var _ = Describe("httpClient", func() {
 
 			content, err := ioutil.ReadAll(req.Body)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(string(content)).To(Equal("action=start"))
+			Expect(string(content)).To(ContainSubstring("action=start"))
 		})
 	})
 
@@ -118,7 +118,7 @@ var _ = Describe("httpClient", func() {
 
 			content, err := ioutil.ReadAll(req.Body)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(string(content)).To(Equal("action=stop"))
+			Expect(string(content)).To(ContainSubstring("action=stop"))
 		})
 	})
 
@@ -165,7 +165,7 @@ var _ = Describe("httpClient", func() {
 
 			content, err := ioutil.ReadAll(req.Body)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(string(content)).To(Equal("action=unmonitor"))
+			Expect(string(content)).To(ContainSubstring("action=unmonitor"))
 		})
 	})
 

--- a/jobsupervisor/monit/http_client_test.go
+++ b/jobsupervisor/monit/http_client_test.go
@@ -259,12 +259,16 @@ func newRealClient(url string) Client {
 		&http.Client{Jar: jar},
 		&http.Client{Jar: jar},
 		logger,
+		jar,
 	)
 }
 
 func newFakeClient(shortClient, longClient HTTPClient) Client {
 	logger := boshlog.NewLogger(boshlog.LevelNone)
-
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		return nil
+	}
 	return NewHTTPClient(
 		"agent.example.com",
 		"fake-user",
@@ -272,5 +276,6 @@ func newFakeClient(shortClient, longClient HTTPClient) Client {
 		shortClient,
 		longClient,
 		logger,
+		jar,
 	)
 }

--- a/jobsupervisor/monit/monit_retry_client.go
+++ b/jobsupervisor/monit/monit_retry_client.go
@@ -34,6 +34,7 @@ func NewMonitRetryClient(
 }
 
 func (r *monitRetryClient) Do(req *http.Request) (*http.Response, error) {
+
 	requestRetryable := httpclient.NewRequestRetryable(req, r.delegate, r.logger, nil)
 	timeService := clock.NewClock()
 	retryStrategy := NewMonitRetryStrategy(

--- a/jobsupervisor/monit/provider.go
+++ b/jobsupervisor/monit/provider.go
@@ -27,6 +27,7 @@ type clientProvider struct {
 	logger          boshlog.Logger
 	shortHTTPClient HTTPClient
 	longHTTPClient  HTTPClient
+	jar             cookiejar.Jar
 }
 
 func NewProvider(platform boshplatform.Platform, logger boshlog.Logger) ClientProvider {
@@ -56,6 +57,7 @@ func NewProvider(platform boshplatform.Platform, logger boshlog.Logger) ClientPr
 		logger:          logger,
 		shortHTTPClient: shortHTTPClient,
 		longHTTPClient:  longHTTPClient,
+		jar:             *jar,
 	}
 }
 
@@ -72,5 +74,6 @@ func (p clientProvider) Get() (client Client, err error) {
 		p.shortHTTPClient,
 		p.longHTTPClient,
 		p.logger,
+		&p.jar,
 	), nil
 }

--- a/jobsupervisor/monit/provider.go
+++ b/jobsupervisor/monit/provider.go
@@ -27,7 +27,7 @@ type clientProvider struct {
 	logger          boshlog.Logger
 	shortHTTPClient HTTPClient
 	longHTTPClient  HTTPClient
-	jar             cookiejar.Jar
+	jar             *cookiejar.Jar
 }
 
 func NewProvider(platform boshplatform.Platform, logger boshlog.Logger) ClientProvider {
@@ -43,7 +43,7 @@ func NewProvider(platform boshplatform.Platform, logger boshlog.Logger) ClientPr
 		retryDelay,
 		logger,
 	)
-
+	httpClient = &http.Client{Jar: jar}
 	longHTTPClient := NewMonitRetryClient(
 		httpClient,
 		longRetryStrategyAttempts,
@@ -57,7 +57,7 @@ func NewProvider(platform boshplatform.Platform, logger boshlog.Logger) ClientPr
 		logger:          logger,
 		shortHTTPClient: shortHTTPClient,
 		longHTTPClient:  longHTTPClient,
-		jar:             *jar,
+		jar:             jar,
 	}
 }
 
@@ -66,7 +66,6 @@ func (p clientProvider) Get() (client Client, err error) {
 	if err != nil {
 		return nil, bosherr.WrapError(err, "Getting monit credentials")
 	}
-
 	return NewHTTPClient(
 		monitHost,
 		monitUser,
@@ -74,6 +73,6 @@ func (p clientProvider) Get() (client Client, err error) {
 		p.shortHTTPClient,
 		p.longHTTPClient,
 		p.logger,
-		&p.jar,
+		p.jar,
 	), nil
 }

--- a/jobsupervisor/monit/provider.go
+++ b/jobsupervisor/monit/provider.go
@@ -2,6 +2,7 @@ package monit
 
 import (
 	"net/http"
+	"net/http/cookiejar"
 	"time"
 
 	boshplatform "github.com/cloudfoundry/bosh-agent/platform"
@@ -29,8 +30,12 @@ type clientProvider struct {
 }
 
 func NewProvider(platform boshplatform.Platform, logger boshlog.Logger) ClientProvider {
-	httpClient := http.DefaultClient
 
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		panic(err)
+	}
+	httpClient := &http.Client{Jar: jar}
 	shortHTTPClient := httpclient.NewRetryClient(
 		httpClient,
 		shortRetryStrategyAttempts,

--- a/jobsupervisor/monit/provider_test.go
+++ b/jobsupervisor/monit/provider_test.go
@@ -2,6 +2,7 @@ package monit_test
 
 import (
 	"net/http"
+	"net/http/cookiejar"
 	"time"
 
 	. "github.com/cloudfoundry/bosh-agent/jobsupervisor/monit"
@@ -25,8 +26,11 @@ var _ = Describe("clientProvider", func() {
 
 		client, err := NewProvider(platform, logger).Get()
 		Expect(err).ToNot(HaveOccurred())
-
-		httpClient := http.DefaultClient
+		jar, err := cookiejar.New(nil)
+		if err != nil {
+			panic(err)
+		}
+		httpClient := &http.Client{Jar: jar}
 
 		shortHTTPClient := httpclient.NewRetryClient(httpClient, 20, 1*time.Second, logger)
 		longHTTPClient := NewMonitRetryClient(httpClient, 300, 20, 1*time.Second, logger)

--- a/jobsupervisor/monit/provider_test.go
+++ b/jobsupervisor/monit/provider_test.go
@@ -42,6 +42,7 @@ var _ = Describe("clientProvider", func() {
 			shortHTTPClient,
 			longHTTPClient,
 			logger,
+			jar,
 		)
 		Expect(client).To(Equal(expectedClient))
 	})

--- a/jobsupervisor/monit/status_test.go
+++ b/jobsupervisor/monit/status_test.go
@@ -30,6 +30,7 @@ var _ = Describe("status", func() {
 
 			logger := boshlog.NewLogger(boshlog.LevelNone)
 			jar, err := cookiejar.New(nil)
+			Expect(err).To(BeNil())
 
 			httpClient := &http.Client{
 				Jar: jar,
@@ -81,6 +82,7 @@ var _ = Describe("status", func() {
 
 			logger := boshlog.NewLogger(boshlog.LevelNone)
 			jar, err := cookiejar.New(nil)
+			Expect(err).To(BeNil())
 			httpClient := &http.Client{
 				Jar: jar,
 			}

--- a/jobsupervisor/monit/status_test.go
+++ b/jobsupervisor/monit/status_test.go
@@ -44,14 +44,14 @@ var _ = Describe("status", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			expectedServices := []Service{
-				Service{Monitored: false, Name: "unmonitored-start-pending", Status: "unknown", Pending: true},
-				Service{Monitored: true, Name: "initializing", Status: "starting", Pending: false},
-				Service{Monitored: true, Name: "running", Status: "running", Pending: false},
-				Service{Monitored: true, Name: "running-stop-pending", Status: "running", Pending: true},
-				Service{Monitored: false, Name: "unmonitored-stop-pending", Status: "unknown", Pending: true},
-				Service{Monitored: false, Name: "unmonitored", Status: "unknown", Pending: false},
-				Service{Monitored: false, Name: "stopped", Status: "unknown", Pending: false},
-				Service{Monitored: true, Name: "failing", Status: "failing", Pending: false},
+				{Monitored: false, Name: "unmonitored-start-pending", Status: "unknown", Pending: true},
+				{Monitored: true, Name: "initializing", Status: "starting", Pending: false},
+				{Monitored: true, Name: "running", Status: "running", Pending: false},
+				{Monitored: true, Name: "running-stop-pending", Status: "running", Pending: true},
+				{Monitored: false, Name: "unmonitored-stop-pending", Status: "unknown", Pending: true},
+				{Monitored: false, Name: "unmonitored", Status: "unknown", Pending: false},
+				{Monitored: false, Name: "stopped", Status: "unknown", Pending: false},
+				{Monitored: true, Name: "failing", Status: "failing", Pending: false},
 			}
 
 			services := status.ServicesInGroup("vcap")
@@ -91,7 +91,7 @@ var _ = Describe("status", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			expectedServices := []Service{
-				Service{
+				{
 					Name:                 "dummy",
 					Monitored:            true,
 					Errored:              false,

--- a/jobsupervisor/monit/status_test.go
+++ b/jobsupervisor/monit/status_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"net/http"
+	"net/http/cookiejar"
 	"net/http/httptest"
 
 	. "github.com/onsi/ginkgo"
@@ -28,8 +29,11 @@ var _ = Describe("status", func() {
 			defer ts.Close()
 
 			logger := boshlog.NewLogger(boshlog.LevelNone)
+			jar, err := cookiejar.New(nil)
 
-			httpClient := http.DefaultClient
+			httpClient := &http.Client{
+				Jar: jar,
+			}
 
 			client := NewHTTPClient(
 				ts.Listener.Addr().String(),
@@ -38,6 +42,7 @@ var _ = Describe("status", func() {
 				httpClient,
 				httpClient,
 				logger,
+				jar,
 			)
 
 			status, err := client.Status()
@@ -75,8 +80,10 @@ var _ = Describe("status", func() {
 			defer ts.Close()
 
 			logger := boshlog.NewLogger(boshlog.LevelNone)
-
-			httpClient := http.DefaultClient
+			jar, err := cookiejar.New(nil)
+			httpClient := &http.Client{
+				Jar: jar,
+			}
 
 			client := NewHTTPClient(
 				ts.Listener.Addr().String(),
@@ -85,6 +92,7 @@ var _ = Describe("status", func() {
 				httpClient,
 				httpClient,
 				logger,
+				jar,
 			)
 
 			status, err := client.Status()

--- a/jobsupervisor/monit_job_supervisor_test.go
+++ b/jobsupervisor/monit_job_supervisor_test.go
@@ -291,6 +291,7 @@ var _ = Describe("monitJobSupervisor", func() {
 				&http.Client{Jar: jar},
 				&http.Client{Jar: jar},
 				logger,
+				jar,
 			)
 
 			monit := NewMonitJobSupervisor(
@@ -499,6 +500,7 @@ var _ = Describe("monitJobSupervisor", func() {
 					&http.Client{Jar: jar},
 					&http.Client{Jar: jar},
 					logger,
+					jar,
 				)
 
 				monit := NewMonitJobSupervisor(
@@ -556,6 +558,7 @@ var _ = Describe("monitJobSupervisor", func() {
 					&http.Client{Jar: jar},
 					&http.Client{Jar: jar},
 					logger,
+					jar,
 				)
 
 				monit := NewMonitJobSupervisor(


### PR DESCRIPTION
with impish we are introducing a new monit version 5.29.0 

monit => 5.20 adds a CSRF check.
by adding a cookiejar we solve this issue
https://www.mmonit.com/documentation/http-api/Authentication

tested backwards compatibility on a bionic stemcell line which uses monit 5.2.5