### PR TITLE
Fix device discovery through iSCSI for SoftLayer

### DIFF
--- a/infrastructure/devicepathresolver/iscsi_device_path_resolver.go
+++ b/infrastructure/devicepathresolver/iscsi_device_path_resolver.go
@@ -76,7 +76,10 @@ func (ispr iscsiDevicePathResolver) GetRealDevicePath(diskSettings boshsettings.
 		return "", false, bosherr.WrapError(err, "More than 2 persistent disks attached")
 	}
 
-	if lastDiskID == diskSettings.ID && len(existingPaths) > 0 {
+	alreadySeen := lastDiskID == diskSettings.ID
+	brandNew := lastDiskID == ""
+	isPartitionned := len(existingPaths) > 0
+	if (alreadySeen || brandNew) && isPartitionned {
 		ispr.logger.Info(ispr.logTag, "Found existing path '%s'", existingPaths[0])
 		return existingPaths[0], false, nil
 	}
@@ -143,9 +146,15 @@ func (ispr iscsiDevicePathResolver) getDevicePaths(devices []string, shouldExist
 	var paths []string
 
 	for _, device := range devices {
-		exist := partitionRegexp.MatchString(device)
-		if exist == shouldExist {
-			matchedPath := path.Join("/dev/mapper", strings.Split(strings.Fields(device)[0], "-")[0])
+		fields := strings.Fields(device)
+		if len(fields) == 0 {
+			ispr.logger.Warn(ispr.logTag, "unexpected device in dmsetup output: '%+v'", device)
+			continue
+		}
+		deviceName := fields[0]
+		firstPartitionExists := partitionRegexp.MatchString(deviceName)
+		if firstPartitionExists == shouldExist {
+			matchedPath := path.Join("/dev/mapper", strings.Split(deviceName, "-")[0])
 			ispr.logger.Debug(ispr.logTag, "path in device list: '%+v'", matchedPath)
 			paths = append(paths, matchedPath)
 		}
@@ -226,17 +235,15 @@ func (ispr iscsiDevicePathResolver) getDevicePathAfterConnectTarget(existingPath
 
 func (ispr iscsiDevicePathResolver) lastMountedCid() (string, error) {
 	managedDiskSettingsPath := filepath.Join(ispr.dirProvider.BoshDir(), "managed_disk_settings.json")
-	var lastMountedCid string
 
-	if ispr.fs.FileExists(managedDiskSettingsPath) {
-		contents, err := ispr.fs.ReadFile(managedDiskSettingsPath)
-		if err != nil {
-			return "", bosherr.WrapError(err, "Reading managed_disk_settings.json")
-		}
-		lastMountedCid = string(contents)
-
-		return lastMountedCid, nil
+	if !ispr.fs.FileExists(managedDiskSettingsPath) {
+		return "", nil
 	}
 
-	return "", nil
+	contents, err := ispr.fs.ReadFile(managedDiskSettingsPath)
+	if err != nil {
+		return "", bosherr.WrapError(err, "Reading managed_disk_settings.json")
+	}
+
+	return string(contents), nil
 }

--- a/infrastructure/devicepathresolver/iscsi_device_path_resolver_test.go
+++ b/infrastructure/devicepathresolver/iscsi_device_path_resolver_test.go
@@ -149,7 +149,8 @@ var _ = Describe("iscsiDevicePathResolver", func() {
 			Context("when the device has never been mounted previously", func() {
 				BeforeEach(func() {
 					// ...that has never been mounted previously...
-					fs.RemoveAll(managedDiskSettingsPath)
+					err := fs.RemoveAll(managedDiskSettingsPath)
+					Expect(err).ToNot(HaveOccurred())
 				})
 
 				Context("when the device is not yet partitioned", func() {


### PR DESCRIPTION
iSCSI device discovery could not be called a second time after disk partioning,
since code was refactored for IaaS-native disk resize.
Here we modify slightly the algorithm so that a never-mounted but
already-partitioned disk doesn't trigger any unnecessary iSCSI restart.

Fixes #252.

While working on this fix, I've reviewed other strategy classes implementing the `DevicePathResolver` interface. Conclusion is that only the iSCSI strategy is dependant on whether the disk device is partitioned or not, which leads to different results when called before or after partitioning.