### PR TITLE
This moves /var/opt to /var/vcap/data/root_opt

### DIFF
--- a/agent/bootstrap.go
+++ b/agent/bootstrap.go
@@ -124,6 +124,10 @@ func (boot bootstrap) Run() (err error) {
 		return bosherr.WrapError(err, "Setting up log dir")
 	}
 
+	if err = boot.platform.SetupOptDir(); err != nil {
+		return bosherr.WrapError(err, "Setting up opt dir")
+	}
+
 	if err = boot.platform.SetTimeWithNtpServers(settings.GetNtpServers()); err != nil {
 		return bosherr.WrapError(err, "Setting up NTP servers")
 	}

--- a/agent/bootstrap_test.go
+++ b/agent/bootstrap_test.go
@@ -431,6 +431,7 @@ var _ = Describe("bootstrap", func() {
 			Expect(platform.SetupTmpDirCallCount()).To(Equal(1))
 			Expect(platform.SetupHomeDirCallCount()).To(Equal(1))
 			Expect(platform.SetupLogDirCallCount()).To(Equal(1))
+			Expect(platform.SetupOptDirCallCount()).To(Equal(1))
 			Expect(platform.SetupLoggingAndAuditingCallCount()).To(Equal(1))
 		})
 

--- a/integration/test_environment.go
+++ b/integration/test_environment.go
@@ -174,6 +174,11 @@ func (t *TestEnvironment) CleanupDataDir() error {
 		return err
 	}
 
+	err = t.DetachDevice("/var/opt")
+	if err != nil {
+		return err
+	}
+
 	err = t.DetachDevice("/var/vcap/data")
 	if err != nil {
 		return err
@@ -205,6 +210,21 @@ func (t *TestEnvironment) CleanupDataDir() error {
 	}
 
 	_, err = t.RunCommand("sudo chown root:syslog /var/log")
+	if err != nil {
+		return err
+	}
+
+	_, err = t.RunCommand("sudo mkdir -p /var/opt")
+	if err != nil {
+		return err
+	}
+
+	_, err = t.RunCommand("sudo chmod 775 /var/opt")
+	if err != nil {
+		return err
+	}
+
+	_, err = t.RunCommand("sudo chown root:root /var/opt")
 	if err != nil {
 		return err
 	}

--- a/platform/dummy_platform.go
+++ b/platform/dummy_platform.go
@@ -245,6 +245,10 @@ func (p dummyPlatform) SetupLogDir() error {
 	return nil
 }
 
+func (p dummyPlatform) SetupOptDir() error {
+	return nil
+}
+
 func (p dummyPlatform) SetupSharedMemory() error {
 	return nil
 }

--- a/platform/linux_platform.go
+++ b/platform/linux_platform.go
@@ -1068,6 +1068,9 @@ func (p linux) SetupOptDir() error {
 
 	boshRootOptDirPath := path.Join(p.dirProvider.DataDir(), "root_opt")
 	err := p.fs.MkdirAll(boshRootOptDirPath, userRootOptDirPermissions)
+	if err != nil {
+		return bosherr.WrapError(err, "Creating root opt dir")
+	}
 
 	_, _, _, err = p.cmdRunner.RunCommand("chown", "root:root", boshRootOptDirPath)
 	if err != nil {

--- a/platform/linux_platform.go
+++ b/platform/linux_platform.go
@@ -40,6 +40,7 @@ const (
 	userBaseDirPermissions    = os.FileMode(0755)
 	disksDirPermissions       = os.FileMode(0755)
 	userRootLogDirPermissions = os.FileMode(0775)
+	userRootOptDirPermissions = os.FileMode(0755)
 	tmpDirPermissions         = os.FileMode(0755) // 0755 to make sure that vcap user can use new temp dir
 	blobsDirPermissions       = os.FileMode(0700)
 
@@ -1060,6 +1061,25 @@ func (p linux) SetupLogDir() error {
 	}
 
 	return nil
+}
+
+func (p linux) SetupOptDir() error {
+	optDir := "/var/opt"
+
+	boshRootOptDirPath := path.Join(p.dirProvider.DataDir(), "root_opt")
+	err := p.fs.MkdirAll(boshRootOptDirPath, userRootOptDirPermissions)
+
+	_, _, _, err = p.cmdRunner.RunCommand("chown", "root:root", boshRootOptDirPath)
+	if err != nil {
+		return bosherr.WrapError(err, "Chowning root opt dir")
+	}
+
+	err = p.bindMountDir(boshRootOptDirPath, optDir)
+	if err != nil {
+		return err
+	}
+
+	return err
 }
 
 func (p linux) ensureFile(path, owner, mode string) error {

--- a/platform/platform_interface.go
+++ b/platform/platform_interface.go
@@ -68,6 +68,7 @@ type Platform interface {
 	SetupRuntimeConfiguration() (err error)
 	SetupLogDir() (err error)
 	SetupLoggingAndAuditing() (err error)
+	SetupOptDir() (err error)
 	SetupRecordsJSONPermission(path string) error
 
 	// Disk management

--- a/platform/platformfakes/fake_platform.go
+++ b/platform/platformfakes/fake_platform.go
@@ -571,6 +571,16 @@ type FakePlatform struct {
 	setupNetworkingReturnsOnCall map[int]struct {
 		result1 error
 	}
+	SetupOptDirStub        func() error
+	setupOptDirMutex       sync.RWMutex
+	setupOptDirArgsForCall []struct {
+	}
+	setupOptDirReturns struct {
+		result1 error
+	}
+	setupOptDirReturnsOnCall map[int]struct {
+		result1 error
+	}
 	SetupRawEphemeralDisksStub        func([]settings.DiskSettings) error
 	setupRawEphemeralDisksMutex       sync.RWMutex
 	setupRawEphemeralDisksArgsForCall []struct {
@@ -3569,6 +3579,59 @@ func (fake *FakePlatform) SetupNetworkingReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
+func (fake *FakePlatform) SetupOptDir() error {
+	fake.setupOptDirMutex.Lock()
+	ret, specificReturn := fake.setupOptDirReturnsOnCall[len(fake.setupOptDirArgsForCall)]
+	fake.setupOptDirArgsForCall = append(fake.setupOptDirArgsForCall, struct {
+	}{})
+	stub := fake.SetupOptDirStub
+	fakeReturns := fake.setupOptDirReturns
+	fake.recordInvocation("SetupOptDir", []interface{}{})
+	fake.setupOptDirMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakePlatform) SetupOptDirCallCount() int {
+	fake.setupOptDirMutex.RLock()
+	defer fake.setupOptDirMutex.RUnlock()
+	return len(fake.setupOptDirArgsForCall)
+}
+
+func (fake *FakePlatform) SetupOptDirCalls(stub func() error) {
+	fake.setupOptDirMutex.Lock()
+	defer fake.setupOptDirMutex.Unlock()
+	fake.SetupOptDirStub = stub
+}
+
+func (fake *FakePlatform) SetupOptDirReturns(result1 error) {
+	fake.setupOptDirMutex.Lock()
+	defer fake.setupOptDirMutex.Unlock()
+	fake.SetupOptDirStub = nil
+	fake.setupOptDirReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakePlatform) SetupOptDirReturnsOnCall(i int, result1 error) {
+	fake.setupOptDirMutex.Lock()
+	defer fake.setupOptDirMutex.Unlock()
+	fake.SetupOptDirStub = nil
+	if fake.setupOptDirReturnsOnCall == nil {
+		fake.setupOptDirReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.setupOptDirReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakePlatform) SetupRawEphemeralDisks(arg1 []settings.DiskSettings) error {
 	var arg1Copy []settings.DiskSettings
 	if arg1 != nil {
@@ -4254,6 +4317,8 @@ func (fake *FakePlatform) Invocations() map[string][][]interface{} {
 	defer fake.setupMonitUserMutex.RUnlock()
 	fake.setupNetworkingMutex.RLock()
 	defer fake.setupNetworkingMutex.RUnlock()
+	fake.setupOptDirMutex.RLock()
+	defer fake.setupOptDirMutex.RUnlock()
 	fake.setupRawEphemeralDisksMutex.RLock()
 	defer fake.setupRawEphemeralDisksMutex.RUnlock()
 	fake.setupRecordsJSONPermissionMutex.RLock()

--- a/platform/windows_platform.go
+++ b/platform/windows_platform.go
@@ -593,6 +593,10 @@ func (p WindowsPlatform) SetupLogDir() error {
 	return nil
 }
 
+func (p WindowsPlatform) SetupOptDir() error {
+	return nil
+}
+
 func (p WindowsPlatform) SetupBlobsDir() error {
 	blobsDirPath := p.dirProvider.BlobsDir()
 	err := p.fs.MkdirAll(blobsDirPath, blobsDirPermissions)


### PR DESCRIPTION
Similar to what we do with /var/log, we've seen issues where
people are installing 3rd party software on stemcells using automation.

For example, the Microsoft OMI Agent.

This software gets installed into /var/opt and logs into /var/opt/omi/log.
This ends up filling up the root disk eventually and VMs need
to be recreated. This software has no configuration options to log
into /var/log (and it seems that logging into /var/opt/THING/log
may be the correct linux spot to log to)

While this is not the suggested way to install software
onto a stemcell, this type of software is often put there
by people not involved with Bosh lifecycles.

Signed-off-by: Joseph Palermo <jpalermo@pivotal.io>