### PR TITLE
When mounting /var/opt to the ephemeral disk, also mount /opt

### DIFF
--- a/integration/test_environment.go
+++ b/integration/test_environment.go
@@ -174,6 +174,11 @@ func (t *TestEnvironment) CleanupDataDir() error {
 		return err
 	}
 
+	err = t.DetachDevice("/opt")
+	if err != nil {
+		return err
+	}
+
 	err = t.DetachDevice("/var/opt")
 	if err != nil {
 		return err
@@ -225,6 +230,21 @@ func (t *TestEnvironment) CleanupDataDir() error {
 	}
 
 	_, err = t.RunCommand("sudo chown root:root /var/opt")
+	if err != nil {
+		return err
+	}
+
+	_, err = t.RunCommand("sudo mkdir -p /opt")
+	if err != nil {
+		return err
+	}
+
+	_, err = t.RunCommand("sudo chmod 775 /opt")
+	if err != nil {
+		return err
+	}
+
+	_, err = t.RunCommand("sudo chown root:root /opt")
 	if err != nil {
 		return err
 	}

--- a/platform/linux_platform.go
+++ b/platform/linux_platform.go
@@ -1082,6 +1082,8 @@ func (p linux) SetupOptDir() error {
 		return bosherr.WrapError(err, "Chowning root var opt dir")
 	}
 
+	//Mount our /var/opt bind mount without the 'noexec' option. Binaries are
+	//often in subdirectories of /var/opt, and folks expect to be able to execute them.
 	err = p.bindMountDir(boshRootVarOptDirPath, varOptDir, true)
 	if err != nil {
 		return err
@@ -1100,6 +1102,8 @@ func (p linux) SetupOptDir() error {
 		return bosherr.WrapError(err, "Chowning root opt dir")
 	}
 
+	//Mount our /opt bind mount without the 'noexec' option. Binaries are
+	//often in subdirectories of /opt, and folks expect to be able to execute them.
 	err = p.bindMountDir(boshRootOptDirPath, optDir, true)
 	if err != nil {
 		return err

--- a/platform/linux_platform.go
+++ b/platform/linux_platform.go
@@ -1069,10 +1069,28 @@ func (p linux) SetupLogDir() error {
 }
 
 func (p linux) SetupOptDir() error {
-	optDir := "/var/opt"
+	varOptDir := "/var/opt"
+
+	boshRootVarOptDirPath := path.Join(p.dirProvider.DataDir(), "root_var_opt")
+	err := p.fs.MkdirAll(boshRootVarOptDirPath, userRootOptDirPermissions)
+	if err != nil {
+		return bosherr.WrapError(err, "Creating root var opt dir")
+	}
+
+	_, _, _, err = p.cmdRunner.RunCommand("chown", "root:root", boshRootVarOptDirPath)
+	if err != nil {
+		return bosherr.WrapError(err, "Chowning root var opt dir")
+	}
+
+	err = p.bindMountDir(boshRootVarOptDirPath, varOptDir)
+	if err != nil {
+		return err
+	}
+
+	optDir := "/opt"
 
 	boshRootOptDirPath := path.Join(p.dirProvider.DataDir(), "root_opt")
-	err := p.fs.MkdirAll(boshRootOptDirPath, userRootOptDirPermissions)
+	err = p.fs.MkdirAll(boshRootOptDirPath, userRootOptDirPermissions)
 	if err != nil {
 		return bosherr.WrapError(err, "Creating root opt dir")
 	}

--- a/platform/linux_platform_test.go
+++ b/platform/linux_platform_test.go
@@ -2547,16 +2547,25 @@ sam:fakeanotheruser`)
 	})
 
 	Describe("SetupOptDir", func() {
+		It("creates a root_var_opt folder with permissions", func() {
+			err := platform.SetupOptDir()
+			Expect(err).NotTo(HaveOccurred())
+			testFileStat := fs.GetFileTestStat("/fake-dir/data/root_var_opt")
+			Expect(testFileStat.FileType).To(Equal(fakesys.FakeFileTypeDir))
+			Expect(testFileStat.FileMode).To(Equal(os.FileMode(0755)))
+			Expect(cmdRunner.RunCommands[0]).To(Equal([]string{"chown", "root:root", "/fake-dir/data/root_var_opt"}))
+		})
+
 		It("creates a root_opt folder with permissions", func() {
 			err := platform.SetupOptDir()
 			Expect(err).NotTo(HaveOccurred())
 			testFileStat := fs.GetFileTestStat("/fake-dir/data/root_opt")
 			Expect(testFileStat.FileType).To(Equal(fakesys.FakeFileTypeDir))
 			Expect(testFileStat.FileMode).To(Equal(os.FileMode(0755)))
-			Expect(cmdRunner.RunCommands[0]).To(Equal([]string{"chown", "root:root", "/fake-dir/data/root_opt"}))
+			Expect(cmdRunner.RunCommands[1]).To(Equal([]string{"chown", "root:root", "/fake-dir/data/root_opt"}))
 		})
 
-		Context("mounting root_opt into /var/opt", func() {
+		Context("mounting root_var_opt into /var/opt", func() {
 			Context("when /var/opt is not a mount point", func() {
 				BeforeEach(func() {
 					mounter.IsMountPointReturns("", false, nil)
@@ -2566,9 +2575,8 @@ sam:fakeanotheruser`)
 					err := platform.SetupOptDir()
 					Expect(err).NotTo(HaveOccurred())
 
-					Expect(mounter.MountFilesystemCallCount()).To(Equal(1))
 					partition, mntPt, fstype, options := mounter.MountFilesystemArgsForCall(0)
-					Expect(partition).To(Equal("/fake-dir/data/root_opt"))
+					Expect(partition).To(Equal("/fake-dir/data/root_var_opt"))
 					Expect(mntPt).To(Equal("/var/opt"))
 					Expect(fstype).To(Equal(""))
 					Expect(options).To(Equal([]string{"bind"}))
@@ -2591,7 +2599,7 @@ sam:fakeanotheruser`)
 					Expect(err).ToNot(HaveOccurred())
 				})
 
-				It("does not try to mount root_opt into /var/opt", func() {
+				It("does not try to mount root_var_opt into /var/opt", func() {
 					platform.SetupOptDir()
 					Expect(mounter.MountCallCount()).To(Equal(0))
 				})
@@ -2614,6 +2622,69 @@ sam:fakeanotheruser`)
 				})
 
 				It("does not try to mount /var/opt", func() {
+					platform.SetupOptDir()
+					Expect(mounter.MountCallCount()).To(Equal(0))
+				})
+			})
+		})
+
+		Context("mounting root_opt into /opt", func() {
+			Context("when /opt is not a mount point", func() {
+				BeforeEach(func() {
+					mounter.IsMountPointReturns("", false, nil)
+				})
+
+				It("bind mounts it in /opt", func() {
+					err := platform.SetupOptDir()
+					Expect(err).NotTo(HaveOccurred())
+
+					partition, mntPt, fstype, options := mounter.MountFilesystemArgsForCall(1)
+					Expect(partition).To(Equal("/fake-dir/data/root_opt"))
+					Expect(mntPt).To(Equal("/opt"))
+					Expect(fstype).To(Equal(""))
+					Expect(options).To(Equal([]string{"bind"}))
+				})
+			})
+
+			Context("when /opt is a mount point", func() {
+				BeforeEach(func() {
+					mounter.IsMountedStub = func(devicePathOrMountPoint string) (bool, error) {
+						if devicePathOrMountPoint == "/opt" {
+							return true, nil
+						}
+						return false, nil
+					}
+				})
+
+				It("returns without an error", func() {
+					err := platform.SetupOptDir()
+					Expect(mounter.IsMountedArgsForCall(1)).To(Equal("/opt"))
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				It("does not try to mount root_opt into /opt", func() {
+					platform.SetupOptDir()
+					Expect(mounter.MountCallCount()).To(Equal(0))
+				})
+			})
+
+			Context("when /opt cannot be determined if it is a mount point", func() {
+				BeforeEach(func() {
+					mounter.IsMountedStub = func(devicePathOrMountPoint string) (bool, error) {
+						if devicePathOrMountPoint == "/opt" {
+							return false, errors.New("fake-is-mounted-error")
+						}
+						return false, nil
+					}
+				})
+
+				It("returns error", func() {
+					err := platform.SetupOptDir()
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("fake-is-mounted-error"))
+				})
+
+				It("does not try to mount /opt", func() {
 					platform.SetupOptDir()
 					Expect(mounter.MountCallCount()).To(Equal(0))
 				})

--- a/platform/linux_platform_test.go
+++ b/platform/linux_platform_test.go
@@ -2062,7 +2062,7 @@ Number  Start   End     Size    File system  Name             Flags
 						Expect(mounter.RemountInPlaceCallCount()).To(Equal(2))
 						mntPt, options = mounter.RemountInPlaceArgsForCall(0)
 						Expect(mntPt).To(Equal("/tmp"))
-						Expect(options).To(Equal([]string{"nodev", "noexec", "nosuid"}))
+						Expect(options).To(Equal([]string{"nodev", "nosuid", "noexec"}))
 					})
 				})
 
@@ -2096,7 +2096,7 @@ Number  Start   End     Size    File system  Name             Flags
 						Expect(mounter.RemountInPlaceCallCount()).To(Equal(2))
 						mntPt, options := mounter.RemountInPlaceArgsForCall(0)
 						Expect(mntPt).To(Equal("/tmp"))
-						Expect(options).To(Equal([]string{"nodev", "noexec", "nosuid"}))
+						Expect(options).To(Equal([]string{"nodev", "nosuid", "noexec"}))
 					})
 
 					It("does not create new tmp filesystem", func() {
@@ -2164,7 +2164,7 @@ Number  Start   End     Size    File system  Name             Flags
 						Expect(mounter.RemountInPlaceCallCount()).To(Equal(2))
 						mntPt, options = mounter.RemountInPlaceArgsForCall(1)
 						Expect(mntPt).To(Equal("/var/tmp"))
-						Expect(options).To(Equal([]string{"nodev", "noexec", "nosuid"}))
+						Expect(options).To(Equal([]string{"nodev", "nosuid", "noexec"}))
 					})
 
 					It("changes permissions for the system /var/tmp folder", func() {
@@ -2580,6 +2580,10 @@ sam:fakeanotheruser`)
 					Expect(mntPt).To(Equal("/var/opt"))
 					Expect(fstype).To(Equal(""))
 					Expect(options).To(Equal([]string{"bind"}))
+
+					mntPt, options = mounter.RemountInPlaceArgsForCall(0)
+					Expect(mntPt).To(Equal("/var/opt"))
+					Expect(options).To(Equal([]string{"nodev", "nosuid"}))
 				})
 			})
 
@@ -2643,6 +2647,10 @@ sam:fakeanotheruser`)
 					Expect(mntPt).To(Equal("/opt"))
 					Expect(fstype).To(Equal(""))
 					Expect(options).To(Equal([]string{"bind"}))
+
+					mntPt, options = mounter.RemountInPlaceArgsForCall(1)
+					Expect(mntPt).To(Equal("/opt"))
+					Expect(options).To(Equal([]string{"nodev", "nosuid"}))
 				})
 			})
 


### PR DESCRIPTION
We've heard reports of additional agents being installed into `/opt` and filling up the root disk. `/opt` is empty by default so this should be a safe operation.

We changed the mount point for `/var/opt` from `/var/vcap/data/root_opt` to `/var/vcap/data/root_var_opt` to avoid name confusion. Since this is all on the ephemeral disk it shouldn't cause breakage when those paths change.