### PR TITLE
🐞 Don't "leak" (fail to delete) BOSH users

### DIFF
--- a/integration/user_permissions_test.go
+++ b/integration/user_permissions_test.go
@@ -89,11 +89,11 @@ var _ = Describe("Instance Info", func() {
 		BeforeEach(func() {
 			testEnvironment.RunCommand("sudo groupadd bosh_sudoers")
 			testEnvironment.RunCommand("sudo groupadd bosh_sshers")
-			testEnvironment.RunCommand("sudo userdel -r username")
+			testEnvironment.RunCommand("sudo userdel -rf username")
 		})
 
 		AfterEach(func() {
-			testEnvironment.RunCommand("sudo userdel -r username")
+			testEnvironment.RunCommand("sudo userdel -rf username")
 		})
 
 		It("should contain the correct home directory permissions", func() {

--- a/platform/linux_platform.go
+++ b/platform/linux_platform.go
@@ -293,7 +293,7 @@ func (p linux) DeleteEphemeralUsersMatching(reg string) error {
 }
 
 func (p linux) deleteUser(user string) (err error) {
-	_, _, _, err = p.cmdRunner.RunCommand("userdel", "-r", user)
+	_, _, _, err = p.cmdRunner.RunCommand("userdel", "-rf", user)
 	return
 }
 

--- a/platform/linux_platform_test.go
+++ b/platform/linux_platform_test.go
@@ -223,8 +223,8 @@ bosh_foobar:...`
 			err := platform.DeleteEphemeralUsersMatching("bar$")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(cmdRunner.RunCommands)).To(Equal(2))
-			Expect(cmdRunner.RunCommands[0]).To(Equal([]string{"userdel", "-r", "bosh_bar"}))
-			Expect(cmdRunner.RunCommands[1]).To(Equal([]string{"userdel", "-r", "bosh_foobar"}))
+			Expect(cmdRunner.RunCommands[0]).To(Equal([]string{"userdel", "-rf", "bosh_bar"}))
+			Expect(cmdRunner.RunCommands[1]).To(Equal([]string{"userdel", "-rf", "bosh_foobar"}))
 		})
 	})
 


### PR DESCRIPTION
Newer stemcells (e.g. Jammy) "leak" BOSH users because the BOSH Agent fails to delete the user when the session is finished because the user still has an open process. Specifically, systemd's [User Manager](https://wiki.archlinux.org/title/systemd/User), which spawns a process which runs as the user, takes an addtional 7 seconds (approximately) to exit after the user has terminated their session.

To address this, we forcibly delete the user (`userdel -f`) after their session has finished. This doesn't harm the remaining systemd process; the kernel doesn't require the owner of a running process to have an entry in `/etc/passwd`; the kernel cares about UIDs, not usernames.

Fixes, from `/var/vcap/bosh/log/current`:
```
2022-01-21_19:46:44.20137 {"exception":{"message":"Action Failed ssh: SSH Cleanup: Deleting Ephemeral Users: Deleting user: Running command: 'userdel -r bosh_b706f857c12b4ec', stdout: '', stderr: 'userdel: user bosh_b706f857c12b4ec is currently used by process 9251\n': exit status 8"}}
```

From `journalctl` (note the 7-second delay to exit the systemd User
Manager process):
```
Jan 21 19:46:53 e7165095-c524-4437-961a-7841a457de3c systemd[1]: Stopping User Manager for UID 1001...
Jan 21 19:46:53 e7165095-c524-4437-961a-7841a457de3c audisp-syslog[1195]: type=SYSCALL msg=audit(1642794413.749:5895): arch=c000003e syscall=84 success=no exit=-2 a0=55dd1bfb8110 a1=0 a2=7f1e3a8decc0 a3=100 items=1 ppid=1 pid=9251 auid=1001 uid=1001 gid=1003 euid=1001 suid=1001 fsuid=1001 egid=1003 sgid=1003>
Jan 21 19:46:53 e7165095-c524-4437-961a-7841a457de3c systemd[9251]: Stopped target Main User Target.
Jan 21 19:46:53 e7165095-c524-4437-961a-7841a457de3c audisp-syslog[1195]: type=CWD msg=audit(1642794413.749:5895): cwd="/"
```