### PR TITLE
Retry mechanism for http_blob_provider

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -177,7 +177,7 @@ func (app *app) Setup(opts Options) error {
 
 	blobstoreDelegator := blobstore_delegator.NewBlobstoreDelegator(
 		httpblobprovider.NewHTTPBlobImpl(app.platform.GetFs(), blobstoreHTTPClient),
-		blobstore,
+		blobstore, app.logger,
 	)
 
 	applier, compiler := app.buildApplierAndCompiler(


### PR DESCRIPTION
We experience intermittently failing Get request to fetch the blobs from an external blobstore due to network issues. To make the Get mechanism more resilient we introduce a retry strategy.