### PR TITLE
Fix panic in sfdiskPartitioner.GetPartitions from extra whitespace in…

### DIFF
--- a/platform/disk/sfdisk_partitioner.go
+++ b/platform/disk/sfdisk_partitioner.go
@@ -148,6 +148,11 @@ func (p sfdiskPartitioner) GetPartitions(devicePath string) (partitions []Existi
 	partitionLines := allLines[3 : len(allLines)-1]
 
 	for _, partitionLine := range partitionLines {
+		partitionLine = strings.TrimSpace(partitionLine)
+		if partitionLine == "" {
+			continue
+		}
+
 		partitionPath, partitionType := extractPartitionPathAndType(partitionLine)
 		if partitionType == PartitionTypeGPT {
 			return partitions, deviceFullSizeInBytes, ErrGPTPartitionEncountered


### PR DESCRIPTION
… sfdisk output. (Fixes #260.)

NOTE: Prior to this change, the extractPartitionPathAndType func would panic with "panic: runtime error: index out of range [-1]" if there were any whitespace-only or blank lines in the STDOUT output from the `sfdisk -d` command. For example, a trailing blank line.