### PR TITLE
Replace the `sfdisk -uM` command with a cross-platform compatible...

### DIFF
--- a/platform/disk/sfdisk_partitioner.go
+++ b/platform/disk/sfdisk_partitioner.go
@@ -46,7 +46,7 @@ func (p sfdiskPartitioner) Partition(devicePath string, partitions []Partition) 
 	sfdiskInput := ""
 	for index, partition := range partitions {
 		sfdiskPartitionType := sfdiskPartitionTypes[partition.Type]
-		partitionSize := fmt.Sprintf("%d", ConvertFromBytesToMb(partition.SizeInBytes))
+		partitionSize := fmt.Sprintf("%dMiB", ConvertFromBytesToMb(partition.SizeInBytes))
 
 		if index == len(partitions)-1 {
 			partitionSize = ""
@@ -56,7 +56,7 @@ func (p sfdiskPartitioner) Partition(devicePath string, partitions []Partition) 
 	}
 
 	partitionRetryable := boshretry.NewRetryable(func() (bool, error) {
-		_, _, _, err := p.cmdRunner.RunCommandWithInput(sfdiskInput, "sfdisk", "-uM", devicePath)
+		_, _, _, err := p.cmdRunner.RunCommandWithInput(sfdiskInput, "sfdisk", devicePath)
 		if err != nil {
 			p.logger.Error(p.logTag, "Failed with an error: %s", err)
 			return true, bosherr.WrapError(err, "Shelling out to sfdisk")

--- a/platform/disk/sfdisk_partitioner_test.go
+++ b/platform/disk/sfdisk_partitioner_test.go
@@ -110,7 +110,7 @@ var _ = Describe("sfdiskPartitioner", func() {
 		partitioner.Partition("/dev/sda", partitions)
 
 		Expect(1).To(Equal(len(runner.RunCommandsWithInput)))
-		Expect(runner.RunCommandsWithInput[0]).To(Equal([]string{",512,S\n,1024,L\n,,L\n", "sfdisk", "-uM", "/dev/sda"}))
+		Expect(runner.RunCommandsWithInput[0]).To(Equal([]string{",512MiB,S\n,1024MiB,L\n,,L\n", "sfdisk", "/dev/sda"}))
 	})
 
 	Context("when sfdisk output has extra whitespace", func() {
@@ -128,7 +128,7 @@ var _ = Describe("sfdiskPartitioner", func() {
 			partitioner.Partition("/dev/sda", partitions)
 
 			Expect(1).To(Equal(len(runner.RunCommandsWithInput)))
-			Expect(runner.RunCommandsWithInput[0]).To(Equal([]string{",512,S\n,1024,L\n,,L\n", "sfdisk", "-uM", "/dev/sda"}))
+			Expect(runner.RunCommandsWithInput[0]).To(Equal([]string{",512MiB,S\n,1024MiB,L\n,,L\n", "sfdisk", "/dev/sda"}))
 		})
 	})
 
@@ -197,7 +197,7 @@ var _ = Describe("sfdiskPartitioner", func() {
 		partitioner.Partition("/dev/sda", partitions)
 
 		Expect(1).To(Equal(len(runner.RunCommandsWithInput)))
-		Expect(runner.RunCommandsWithInput[0]).To(Equal([]string{",512,S\n,1024,L\n,,L\n", "sfdisk", "-uM", "/dev/sda"}))
+		Expect(runner.RunCommandsWithInput[0]).To(Equal([]string{",512MiB,S\n,1024MiB,L\n,,L\n", "sfdisk", "/dev/sda"}))
 	})
 
 	It("sfdisk partition for multipath", func() {
@@ -212,7 +212,7 @@ var _ = Describe("sfdiskPartitioner", func() {
 		partitioner.Partition("/dev/mapper/xxxxxx", partitions)
 
 		Expect(1).To(Equal(len(runner.RunCommandsWithInput)))
-		Expect(runner.RunCommandsWithInput[0]).To(Equal([]string{",512,S\n,1024,L\n,,L\n", "sfdisk", "-uM", "/dev/mapper/xxxxxx"}))
+		Expect(runner.RunCommandsWithInput[0]).To(Equal([]string{",512MiB,S\n,1024MiB,L\n,,L\n", "sfdisk", "/dev/mapper/xxxxxx"}))
 		Expect(24).To(Equal(len(runner.RunCommands)))
 		Expect(runner.RunCommands[2]).To(Equal([]string{"/etc/init.d/open-iscsi", "restart"}))
 	})
@@ -275,7 +275,7 @@ var _ = Describe("sfdiskPartitioner", func() {
 		partitioner.Partition("/dev/sda", partitions)
 
 		Expect(len(runner.RunCommandsWithInput)).To(Equal(1))
-		Expect(runner.RunCommandsWithInput[0]).To(Equal([]string{",1024,L\n,,L\n", "sfdisk", "-uM", "/dev/sda"}))
+		Expect(runner.RunCommandsWithInput[0]).To(Equal([]string{",1024MiB,L\n,,L\n", "sfdisk", "/dev/sda"}))
 	})
 
 	It("sfdisk partition with last partition filling disk", func() {
@@ -298,13 +298,13 @@ var _ = Describe("sfdiskPartitioner", func() {
 	It("sfdisk command is retried 20 times", func() {
 		for i := 0; i < 19; i++ {
 			testError := fmt.Errorf("test error")
-			runner.AddCmdResult(",,L\n sfdisk -uM /dev/sda", fakesys.FakeCmdResult{ExitStatus: 1, Error: testError})
+			runner.AddCmdResult(",,L\n sfdisk /dev/sda", fakesys.FakeCmdResult{ExitStatus: 1, Error: testError})
 		}
 		runner.AddCmdResult("sfdisk -d /dev/sda", fakesys.FakeCmdResult{Stdout: devSdaSfdiskDumpOnePartition})
 		runner.AddCmdResult("sfdisk -s /dev/sda", fakesys.FakeCmdResult{Stdout: "1048576"})
 		runner.AddCmdResult("sfdisk -s /dev/sda", fakesys.FakeCmdResult{Stdout: "1048576"})
 
-		runner.AddCmdResult(",,L\n sfdisk -uM /dev/sda", fakesys.FakeCmdResult{Stdout: devSdaSfdiskDumpOnePartition})
+		runner.AddCmdResult(",,L\n sfdisk /dev/sda", fakesys.FakeCmdResult{Stdout: devSdaSfdiskDumpOnePartition})
 
 		partitions := []Partition{
 			{Type: PartitionTypeLinux},


### PR DESCRIPTION
... equivalent. (Fixes #265.)

This change adds explicit "multiplicative suffixes" in the sfdisk input to specify the units of the partition sizes (instead of the `-uM` command option, since `-uM` appears to be unsupported on many platforms and `-u` seems to be deprecated on many platforms). This change should produce identical partitioning behavior (vs the previous implementation), using an `sfdisk` input format which is more widely supported across linux platforms.

NOTE: Prior to this change, the `sfdisk -uM` command failed (on some stemcells), with agent log output like the following.

> ... ERROR - Failed with an error: Running command: 'sfdisk -uM /dev/sdc', stdout: '', stderr: 'sfdisk: unsupported unit 'M'

See:
- https://man7.org/linux/man-pages/man8/sfdisk.8.html#OPTIONS
- https://man7.org/linux/man-pages/man8/sfdisk.8.html#INPUT_FORMATS
- https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/considerations_in_adopting_rhel_8/file-systems-and-storage_considerations-in-adopting-rhel-8#removal-of-cylinder-head-sector-addressing-from-sfdisk-and-cfdisk_file-systems-and-storage
