### PR TITLE
parted partitioner: Use `wipefs --force` when removing partitions.

### DIFF
--- a/platform/disk/ephemeral_device_partitioner_test.go
+++ b/platform/disk/ephemeral_device_partitioner_test.go
@@ -140,7 +140,7 @@ var _ = Describe("EphemeralDevicePartitioner", func() {
 					Expect(len(fakeCmdRunner.RunCommands)).To(Equal(13))
 
 					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"parted", "-m", "/dev/edx", "unit", "B", "print"}))
-					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"wipefs", "-a", "/dev/edx"}))
+					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"wipefs", "--force", "-a", "/dev/edx"}))
 					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"parted", "-s", "/dev/edx", "unit", "B", "mkpart", "fake-agent-id-0", "1048576", "17180917759"}))
 					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"parted", "-s", "/dev/edx", "unit", "B", "mkpart", "fake-agent-id-1", "17180917760", "25770852351"}))
 					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"partprobe", "/dev/edx"}))
@@ -196,7 +196,7 @@ var _ = Describe("EphemeralDevicePartitioner", func() {
 					Expect(len(fakeCmdRunner.RunCommands)).To(Equal(13))
 
 					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"parted", "-m", "/dev/edx", "unit", "B", "print"}))
-					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"wipefs", "-a", "/dev/edx"}))
+					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"wipefs", "--force", "-a", "/dev/edx"}))
 					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"parted", "-s", "/dev/edx", "unit", "B", "mkpart", "fake-agent-id-0", "1048576", "8590983167"}))
 					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"parted", "-s", "/dev/edx", "unit", "B", "mkpart", "fake-agent-id-1", "8590983168", "17180917759"}))
 					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"partprobe", "/dev/edx"}))
@@ -285,7 +285,7 @@ var _ = Describe("EphemeralDevicePartitioner", func() {
 					Expect(len(fakeCmdRunner.RunCommands)).To(Equal(13))
 
 					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"parted", "-m", "/dev/edx", "unit", "B", "print"}))
-					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"wipefs", "-a", "/dev/edx"}))
+					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"wipefs", "--force", "-a", "/dev/edx"}))
 					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"parted", "-s", "/dev/edx", "unit", "B", "mkpart", "fake-agent-id-0", "1048576", "8590983167"}))
 					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"parted", "-s", "/dev/edx", "unit", "B", "mkpart", "fake-agent-id-1", "8590983168", "17180917759"}))
 					Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"partprobe", "/dev/edx"}))
@@ -329,7 +329,7 @@ var _ = Describe("EphemeralDevicePartitioner", func() {
 				)
 				for i := 0; i < 20; i++ {
 					fakeCmdRunner.AddCmdResult(
-						"wipefs -a /dev/edx",
+						"wipefs --force -a /dev/edx",
 						fakesys.FakeCmdResult{Stdout: "", ExitStatus: 2, Error: errors.New("fake-cmd-error")},
 					)
 				}

--- a/platform/disk/parted_partitioner.go
+++ b/platform/disk/parted_partitioner.go
@@ -192,6 +192,7 @@ func (p partedPartitioner) RemovePartitions(partitions []ExistingPartition, devi
 	partitionRetryable := boshretry.NewRetryable(func() (bool, error) {
 		_, _, _, err := p.cmdRunner.RunCommand(
 			"wipefs",
+			"--force", // to prevent "wipefs: error: /**: probing initialization failed: Device or resource busy" errors
 			"-a",
 			devicePath,
 		)

--- a/platform/disk/parted_partitioner_test.go
+++ b/platform/disk/parted_partitioner_test.go
@@ -863,7 +863,7 @@ var _ = Describe("PartedPartitioner", func() {
 
 			It("removes partitions", func() {
 				fakeCmdRunner.AddCmdResult(
-					"wipefs -a /dev/sda",
+					"wipefs --force -a /dev/sda",
 					fakesys.FakeCmdResult{Stdout: "", ExitStatus: 0},
 				)
 
@@ -871,14 +871,14 @@ var _ = Describe("PartedPartitioner", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(fakeCmdRunner.RunCommands).To(Equal([][]string{
-					{"wipefs", "-a", "/dev/sda"},
+					{"wipefs", "--force", "-a", "/dev/sda"},
 				}))
 			})
 
 			It("failed to remove partitions when removing device path error", func() {
 				for i := 0; i < 20; i++ {
 					fakeCmdRunner.AddCmdResult(
-						"wipefs -a /dev/sda",
+						"wipefs --force -a /dev/sda",
 						fakesys.FakeCmdResult{Stdout: "", ExitStatus: 2, Error: errors.New("fake-cmd-error")},
 					)
 				}
@@ -887,7 +887,7 @@ var _ = Describe("PartedPartitioner", func() {
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Removing device path"))
 
-				Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"wipefs", "-a", "/dev/sda"}))
+				Expect(fakeCmdRunner.RunCommands).To(ContainElement([]string{"wipefs", "--force", "-a", "/dev/sda"}))
 			})
 		})
 	})


### PR DESCRIPTION
See:
- https://util-linux.vger.kernel.narkive.com/u1AkqI6Q/patch-wipefs-add-force-option

NOTE: This fix is meant to resolve VM startup errors like the following, which resulted from failure to resize a partition (on RHEL 8.5):

```
2022-02-18_20:48:56.73277 [attemptRetryStrategy] 2022/02/18 20:48:56 DEBUG - Making attempt #0
2022-02-18_20:48:56.73278 [Cmd Runner] 2022/02/18 20:48:56 DEBUG - Running command 'wipefs -a /dev/sdb'
2022-02-18_20:48:56.73530 [Cmd Runner] 2022/02/18 20:48:56 DEBUG - Stdout:
2022-02-18_20:48:56.73532 [Cmd Runner] 2022/02/18 20:48:56 DEBUG - Stderr: wipefs: error: /dev/sdb: probing initialization failed: Device or resource busy
2022-02-18_20:48:56.73533 [Cmd Runner] 2022/02/18 20:48:56 DEBUG - Successful: false (1)
```