### PR TITLE
Add V6 iptables support

### DIFF
--- a/platform/net/firewall_provider_linux.go
+++ b/platform/net/firewall_provider_linux.go
@@ -61,10 +61,21 @@ func SetupNatsFirewall(mbus string) error {
 	if err != nil {
 		return bosherr.WrapError(err, "Error getting Port")
 	}
+
+	// Run the lookup for Host as it could be potentially a Hostname | IPv4 | IPv6
+	// the return for LookupIP will be a list of IP Addr and in case of the Input being an IP Addr,
+	// it will only contain one element with the Input IP
+	addr_array, err := net.LookupIP(host)
+	if err != nil {
+		return bosherr.WrapError(err, fmt.Sprintf("Error resolving mbus host: %v", host))
+	}
+
 	ipt, err := iptables.New()
 	if err != nil {
-		return bosherr.WrapError(err, "Iptables Error")
+		return bosherr.WrapError(err, "Creating Iptables Error")
 	}
+	// Even on a V6 VM, Monit will listen to only V4 loopback
+	// First create Monit V4 rules for natsIsolationClassID
 	exists, err := ipt.Exists("mangle", "POSTROUTING",
 		"-d", "127.0.0.1",
 		"-p", "tcp",
@@ -89,6 +100,18 @@ func SetupNatsFirewall(mbus string) error {
 			return bosherr.WrapError(err, "Iptables Error inserting for monit rule")
 		}
 	}
+
+	// For nats iptables rules we default to V4 unless below dns resolution gives us a V6 target
+	ipVersion := iptables.ProtocolIPv4
+	// Check if we're dealing with a V4 Target
+	if addr_array[0].To4() == nil {
+		ipVersion = iptables.ProtocolIPv6
+	}
+	ipt, err = iptables.NewWithProtocol(ipVersion)
+	if err != nil {
+		return bosherr.WrapError(err, "Creating Iptables Error")
+	}
+
 	err = ipt.AppendUnique("mangle", "POSTROUTING",
 		"-d", host,
 		"-p", "tcp",
@@ -109,6 +132,7 @@ func SetupNatsFirewall(mbus string) error {
 	if err != nil {
 		return bosherr.WrapError(err, "Iptables Error inserting for non-agent DROP rule")
 	}
+
 	var isolationClassID = natsIsolationClassID
 	natsAPICgroup, err := cgroups.New(cgroups.SingleSubsystem(cgroups.V1, cgroups.NetCLS), cgroups.StaticPath("/nats-api-access"), &specs.LinuxResources{
 		Network: &specs.LinuxNetwork{


### PR DESCRIPTION
Currently Stemcells build with the agent will not be able to successfully
deploy in a V6 setup. The reason/background is that the Iptables code is trying 
to add V6 addresses via the Iptables v4 API.  

Add logic to figure out if the actual IP behind the host in `mbus_string`
is an IPv4 vs IPv6 address and handle instantiation of Iptables lib accordingly

Monit runs on V4 locally, even on a V6 VM thus the created rule is always V4.