### PR TITLE
Introduce error handling for nats disconnects and add logging handlers for nats connection issues

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -143,7 +143,6 @@ func (a Agent) sendAndRecordHeartbeat(errCh chan error, retry bool) {
 
 	heartbeatRetryable := boshretry.NewRetryable(func() (bool, error) {
 		a.logger.Info(agentLogTag, "Attempting to send Heartbeat")
-
 		err = a.mbusHandler.Send(boshhandler.HealthMonitor, boshhandler.Heartbeat, heartbeat)
 		if err != nil {
 			return true, bosherr.WrapError(err, "Sending Heartbeat")

--- a/mbus/handler_provider.go
+++ b/mbus/handler_provider.go
@@ -48,7 +48,7 @@ func (p HandlerProvider) Get(
 		f := func(url string, options ...nats.Option) (NatsConnection, error) {
 			return nats.Connect(url, options...)
 		}
-		return NewNatsHandler(p.settingsService, f, p.logger, platform, natsConnectRetryInterval, natsConnectMaxRetryInterval), nil
+		return NewNatsHandler(p.settingsService, f, p.logger, platform), nil
 	case "https":
 		mbusKeyPair := p.settingsService.GetSettings().GetMbusCerts()
 		return NewHTTPSHandler(mbusURL, mbusKeyPair, blobManager, p.logger, p.auditLogger), nil

--- a/mbus/handler_provider_test.go
+++ b/mbus/handler_provider_test.go
@@ -3,7 +3,6 @@ package mbus_test
 import (
 	gourl "net/url"
 	"reflect"
-	"time"
 
 	"github.com/cloudfoundry/bosh-agent/mbus/mbusfakes"
 	"github.com/nats-io/nats.go"
@@ -48,7 +47,7 @@ var _ = Describe("HandlerProvider", func() {
 			connector := func(url string, options ...nats.Option) (NatsConnection, error) {
 				return &mbusfakes.FakeNatsConnection{}, nil
 			}
-			expectedHandler := NewNatsHandler(settingsService, connector, logger, platform, time.Second, 1*time.Minute)
+			expectedHandler := NewNatsHandler(settingsService, connector, logger, platform)
 			Expect(reflect.TypeOf(handler)).To(Equal(reflect.TypeOf(expectedHandler)))
 		})
 

--- a/mbus/nats_handler.go
+++ b/mbus/nats_handler.go
@@ -137,7 +137,9 @@ func (h *natsHandler) Start(handlerFunc boshhandler.Func) error {
 		nats.DisconnectErrHandler(func(c *nats.Conn, err error) {
 			h.logger.Debug(natsHandlerLogTag, "Nats disconnected with Error: %v", err.Error())
 			h.logger.Debug(natsHandlerLogTag, "Attempting to reconnect: %v", c.IsReconnecting())
+
 			for c.IsReconnecting() {
+				h.arpClean()
 				h.logger.Debug(natsHandlerLogTag, fmt.Sprintf("Waiting to reconnect to nats.. Connected: %v", c.IsConnected()))
 				time.Sleep(time.Second)
 			}

--- a/mbus/nats_handler_test.go
+++ b/mbus/nats_handler_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"io/ioutil"
-	"time"
 
 	"github.com/cloudfoundry/bosh-agent/mbus/mbusfakes"
 	"github.com/nats-io/nats.go"
@@ -77,7 +76,7 @@ func init() { //nolint:funlen,gochecknoinits
 		})
 
 		JustBeforeEach(func() {
-			handler = NewNatsHandler(settingsService, connector, logger, platform, time.Millisecond, time.Millisecond)
+			handler = NewNatsHandler(settingsService, connector, logger, platform)
 		})
 
 		Describe("Start", func() {
@@ -242,7 +241,7 @@ func init() { //nolint:funlen,gochecknoinits
 
 			It("does not err when no username and password", func() {
 				settingsService.Settings.Mbus = "nats://127.0.0.1:1234"
-				handler = NewNatsHandler(settingsService, connector, logger, platform, time.Millisecond, time.Millisecond)
+				handler = NewNatsHandler(settingsService, connector, logger, platform)
 
 				err := handler.Start(func(req boshhandler.Request) (res boshhandler.Response) { return })
 				Expect(err).ToNot(HaveOccurred())
@@ -374,7 +373,7 @@ func init() { //nolint:funlen,gochecknoinits
 						err := VerifyPeerCertificateCallback(handler, connectorOptionsArg, certPath, caPath)
 
 						Expect(err).To(HaveOccurred())
-						Expect(err.Error()).To(Equal("Server Certificate CommonName does not match *.nats.bosh-internal"))
+						Expect(err.Error()).To(Equal("server Certificate CommonName does not match *.nats.bosh-internal"))
 					})
 
 					It("verify certificate common name is missing", func() {
@@ -383,7 +382,7 @@ func init() { //nolint:funlen,gochecknoinits
 						err := VerifyPeerCertificateCallback(handler, connectorOptionsArg, certPath, caPath)
 
 						Expect(err).To(HaveOccurred())
-						Expect(err.Error()).To(Equal("Server Certificate CommonName does not match *.nats.bosh-internal"))
+						Expect(err.Error()).To(Equal("server Certificate CommonName does not match *.nats.bosh-internal"))
 					})
 				})
 


### PR DESCRIPTION
We are seeing intermittent unresponsive agents in following scenario:

- upgrade bosh-director
- right after upgrade is finished, start recreating a deployment

In some situations there seems to be a race condition in between

1. the old director going down
2. Agent on the VM retries sending heartbeets
3. new director comes up and get's deploy command issued. Sends ping to agent
4. ???? Currently unclear why at this point the agent has not yet reconnected to nats
5. director doesn't get a response and the deploy command fails.

the issue has been solved in CI by introducing a 3 minute wait after the upgrade 
of the director but we would like to get to the root cause of this. It seems that if 
the agent DID NOT crash and restart within BOSHs downtime, the connection is 
somehow in a bad state. Cunnie suggested it that the arp cache could be the 
reason the connection is not successfully re-established after the director comes 
back up.

Use nats client handler functions to add additional logging and an arp flush on 
connection issues.

In case the arp cache should not be issue at hand, the introduced routine can be 
changed to solve the actual problem

Tracker: **[ 181274434, #181759211]**