### PR TITLE
remove deactivation of bosh agent service automatic starts [#182212385]

### DIFF
--- a/integration/windows/windows_test.go
+++ b/integration/windows/windows_test.go
@@ -109,6 +109,10 @@ var _ = Describe("An Agent running on Windows", func() {
 
 		Eventually(getStateSpecAgentID, DefaultTimeout, DefaultInterval).Should(Equal(agentGUID))
 	})
+	It("its windows service is set to start automatically", func() {
+		output := agent.RunPowershellCommand("Get-Service -Name bosh-agent | select -property name,starttype")
+		Expect(output).To(MatchRegexp("bosh-agent *Automatic"))
+	})
 
 	It("cleans up SSH users after session exits", func() {
 		time := strconv.Itoa(int(time.Now().Unix()))

--- a/jobsupervisor/windows_job_supervisor.go
+++ b/jobsupervisor/windows_job_supervisor.go
@@ -227,16 +227,6 @@ func (w *windowsJobSupervisor) Reload() error {
 }
 
 func (w *windowsJobSupervisor) Start() error {
-	// Set the starttype of the service running the Agent to 'manual'.
-	// This will prevent the agent from automatically starting if the
-	// machine is rebooted.
-	//
-	// Do this here, as we know the agent has successfully connected
-	// with the director and is healthy.
-	if err := w.mgr.DisableAgentAutoStart(); err != nil {
-		w.logger.Error(w.logTag, "Running DisableAgentAutoStart %s", err)
-	}
-
 	if err := w.mgr.Start(); err != nil {
 		return bosherr.WrapError(err, "Starting windows job process")
 	}

--- a/jobsupervisor/winsvc/winsvc.go
+++ b/jobsupervisor/winsvc/winsvc.go
@@ -540,17 +540,6 @@ func (m *Mgr) Unmonitor() error {
 	})
 }
 
-// DisableAgentAutoStart sets the start type of the bosh-agent to manual.
-func (m *Mgr) DisableAgentAutoStart() error {
-	const name = "bosh-agent"
-	s, err := m.m.OpenService("bosh-agent")
-	if err != nil {
-		return &ServiceError{"opening service", name, err}
-	}
-	defer s.Close()
-	return SetStartType(s, mgr.StartManual)
-}
-
 func svcStateString(s svc.State) string {
 	switch s {
 	case svc.Stopped:


### PR DESCRIPTION
once upon a time this was done to prevent issues with consul

since we're not using consul anymore, we do not rely on the
vm being recreated anymore and it should be safe to just
restart/reboot it. The underlying issues were caused by local
dns entries done for consul going missing and we're not
aware of any additional issues in that regard.

see #182212385 // #131643669 for more details / history

```
In consul_agent_windows prestart we set the primary DNS to be localhost
so that consul can resolve internal addresses, but the bosh deployment
manifest pulls in DNS config from cloud-config. This causes BOSH to
override that value at some point in the future. We saw this happening
on Stonetalon that had a windows vm deployed for a couple of weeks now.

We need to figure out a better way around resolving the internal domains
for consul or asking bosh_agent not to remove the localhost from DNS
config.
```

```
This bug showed up again when pairing with Consul. Here is a set of what
could make it re-producible:

Create a pre-start script that sets the DNS, like the one in Consul
Deploy the deployment
Change a random property in Deployment (to cause the vm to re-deploy)
Re-deploy the deployment
What we saw was that the DNS entries were reverted to an empty list.
```

once upon a time this was done to prevent issues with consul

since we're not using consul anymore, we do not rely on the
vm being recreated anymore and it should be safe to just
restart/reboot it. The underlying issues were caused by local
dns entries done for consul going missing and we're not
aware of any additional issues in that regard.