### PR TITLE
make tests not fail if the env has BOSH_ALL_PROXY set

### DIFF
--- a/bin/test-unit
+++ b/bin/test-unit
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -eu -o pipefail
-
+unset BOSH_ALL_PROXY
 ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 
 echo 'Note: if you want to quickly run tests for just one package, do it like this:'


### PR DESCRIPTION
running the test script from a shell that targets a
director that also requires BOSH_ALL_PROXY to be set
makes tests fail with:

```
  Unexpected error:
      <errors.ComplexError>: {
          Err: <*errors.errorString | 0xc0002be570>{
              s: "Getting open ssh key from url http://127.0.0.1:40481/ssh-keys",
          },
          Cause: <errors.ComplexError>{
              Err: <*errors.errorString | 0xc0002be550>{
                  s: "Performing GET request",
              },
              Cause: <*errors.errorString | 0xc0002be540>{
                  s: "Get \"http://127.0.0.1:40481/ssh-keys\": ssh: rejected: connect failed (Connection refused)",
              },
          },
      }
      Getting open ssh key from url http://127.0.0.1:40481/ssh-keys: Performing GET request: Get "http://127.0.0.1:40481/ssh-keys": ssh: rejected: connect failed (Connection refused)
  occurred

```
this is at best confusing and at worst requires dev
time to figure out.