### PR TITLE
fix overflow bug in nats_handler.go / nats.CustomReconnectDelay()

### DIFF
--- a/mbus/nats_handler.go
+++ b/mbus/nats_handler.go
@@ -154,13 +154,13 @@ func (h *natsHandler) Start(handlerFunc boshhandler.Func) error {
 			h.logger.Debug(natsHandlerLogTag, err.Error())
 		}),
 		nats.CustomReconnectDelay(func(attempts int) time.Duration {
-		    reconnectSeconds := natsMinReconnectSeconds * math.Pow(2.0, math.Min(20.0, float64(attempts - 1)))
-		    if (reconnectSeconds > natsMaxReconnectSeconds || reconnectSeconds <= 0.0) {
-		        reconnectSeconds = natsMaxReconnectSeconds
-		    }
-		    reconnectDelay := time.Duration(reconnectSeconds * float64(time.Second))
-		    h.logger.Debug(natsHandlerLogTag, "Increased reconnect to: %v", reconnectDelay)
-		    return reconnectDelay
+			reconnectSeconds := natsMinReconnectSeconds * math.Pow(2.0, math.Min(20.0, float64(attempts - 1)))
+			if (reconnectSeconds > natsMaxReconnectSeconds || reconnectSeconds <= 0.0) {
+				reconnectSeconds = natsMaxReconnectSeconds
+			}
+			reconnectDelay := time.Duration(reconnectSeconds * float64(time.Second))
+			h.logger.Debug(natsHandlerLogTag, "Increased reconnect to: %v", reconnectDelay)
+			return reconnectDelay
 		}),
 		nats.MaxReconnects(-1),
 		nats.Secure(connectionInfo.TLSConfig),

--- a/mbus/nats_handler.go
+++ b/mbus/nats_handler.go
@@ -31,9 +31,9 @@ import (
 const (
 	responseMaxLength = 1024 * 1024
 	natsHandlerLogTag = "NATS Handler"
-	natsMinRetryWait  = 2
-	//natsMaxReconnectWait should be lower than the setting we have in BOSH for https://github.com/cloudfoundry/bosh/blob/main/src/bosh-director/lib/bosh/director/agent_client.rb#L44.
-	natsMaxReconnectWait = 10 * time.Second
+	natsMinReconnectSeconds = 2.0
+	//natsMaxReconnectSeconds should be lower than the setting we have in BOSH for https://github.com/cloudfoundry/bosh/blob/main/src/bosh-director/lib/bosh/director/agent_client.rb#L44.
+	natsMaxReconnectSeconds = 10.0
 )
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
@@ -154,13 +154,13 @@ func (h *natsHandler) Start(handlerFunc boshhandler.Func) error {
 			h.logger.Debug(natsHandlerLogTag, err.Error())
 		}),
 		nats.CustomReconnectDelay(func(attempts int) time.Duration {
-			exponentialReconnectWait := time.Duration(math.Pow(natsMinRetryWait, float64(attempts))) * time.Second
-			if natsMaxReconnectWait > exponentialReconnectWait {
-				h.logger.Debug(natsHandlerLogTag, "Increased reconnect to: %v", exponentialReconnectWait)
-				return exponentialReconnectWait
-			}
-			h.logger.Debug(natsHandlerLogTag, "Increased reconnect to: %v", natsMaxReconnectWait)
-			return natsMaxReconnectWait
+		    reconnectSeconds := natsMinReconnectSeconds * math.Pow(2.0, math.Min(20.0, float64(attempts - 1)))
+		    if (reconnectSeconds > natsMaxReconnectSeconds || reconnectSeconds <= 0.0) {
+		        reconnectSeconds = natsMaxReconnectSeconds
+		    }
+		    reconnectDelay := time.Duration(reconnectSeconds * float64(time.Second))
+		    h.logger.Debug(natsHandlerLogTag, "Increased reconnect to: %v", reconnectDelay)
+		    return reconnectDelay
 		}),
 		nats.MaxReconnects(-1),
 		nats.Secure(connectionInfo.TLSConfig),

--- a/mbus/nats_handler.go
+++ b/mbus/nats_handler.go
@@ -154,7 +154,7 @@ func (h *natsHandler) Start(handlerFunc boshhandler.Func) error {
 			h.logger.Debug(natsHandlerLogTag, err.Error())
 		}),
 		nats.CustomReconnectDelay(func(attempts int) time.Duration {
-			reconnectSeconds := natsMinReconnectSeconds * math.Pow(2.0, math.Min(20.0, float64(attempts - 1)))
+			reconnectSeconds := natsMinReconnectSeconds * float64(attempts)
 			if (reconnectSeconds > natsMaxReconnectSeconds || reconnectSeconds <= 0.0) {
 				reconnectSeconds = natsMaxReconnectSeconds
 			}


### PR DESCRIPTION
fix for https://github.com/cloudfoundry/bosh-agent/issues/289
- avoid arithmetic overflow with math.Pow and subsequent conversion to int64 (by limiting exponent to a safe value)
- add sanity check for reconnect delay to safeguard against negative values or zero
- add support for delay in non-integer seconds (by fixing how time.Duration() is used with time.Second)
- use more consistent naming of constants and variables