### PR TITLE
Remove nosuid flag from /opt and /var/opt

### DIFF
--- a/platform/linux_platform.go
+++ b/platform/linux_platform.go
@@ -962,12 +962,12 @@ func (p linux) SetupTmpDir() error {
 		return bosherr.WrapError(err, "Chmoding root tmp dir")
 	}
 
-	err = p.bindMountDir(boshRootTmpPath, systemTmpDir, false)
+	err = p.bindMountDir(boshRootTmpPath, systemTmpDir, false, false)
 	if err != nil {
 		return err
 	}
 
-	err = p.bindMountDir(boshRootTmpPath, varTmpDir, false)
+	err = p.bindMountDir(boshRootTmpPath, varTmpDir, false, false)
 	if err != nil {
 		return err
 	}
@@ -1059,7 +1059,7 @@ func (p linux) SetupLogDir() error {
 		return err
 	}
 
-	err = p.bindMountDir(boshRootLogPath, logDir, false)
+	err = p.bindMountDir(boshRootLogPath, logDir, false, false)
 	if err != nil {
 		return err
 	}
@@ -1108,7 +1108,7 @@ func (p linux) SetupOptDir() error {
 
 	// Mount our /var/opt bind mount without the 'noexec' option. Binaries are
 	// often in subdirectories of /var/opt, and folks expect to be able to execute them.
-	err = p.bindMountDir(boshRootVarOptDirPath, varOptDir, true)
+	err = p.bindMountDir(boshRootVarOptDirPath, varOptDir, true, true)
 	if err != nil {
 		return err
 	}
@@ -1128,7 +1128,7 @@ func (p linux) SetupOptDir() error {
 
 	// Mount our /opt bind mount without the 'noexec' option. Binaries are
 	// often in subdirectories of /opt, and folks expect to be able to execute them.
-	err = p.bindMountDir(boshRootOptDirPath, optDir, true)
+	err = p.bindMountDir(boshRootOptDirPath, optDir, true, true)
 	if err != nil {
 		return err
 	}
@@ -1163,7 +1163,7 @@ func (p linux) SetupLoggingAndAuditing() error {
 	return nil
 }
 
-func (p linux) bindMountDir(mountSource, mountPoint string, allowExec bool) error {
+func (p linux) bindMountDir(mountSource, mountPoint string, allowExec bool, allowSuid bool) error {
 	bindMounter := boshdisk.NewLinuxBindMounter(p.diskManager.GetMounter())
 	mounted, err := bindMounter.IsMounted(mountPoint)
 
@@ -1176,7 +1176,10 @@ func (p linux) bindMountDir(mountSource, mountPoint string, allowExec bool) erro
 		return err
 	}
 
-	mountOptions := []string{"nodev", "nosuid"}
+	mountOptions := []string{"nodev"}
+	if !allowSuid {
+		mountOptions = append(mountOptions, "nosuid")
+	}
 	if !allowExec {
 		mountOptions = append(mountOptions, "noexec")
 	}

--- a/platform/linux_platform_test.go
+++ b/platform/linux_platform_test.go
@@ -2752,7 +2752,7 @@ sam:fakeanotheruser`)
 
 					mntPt, options = mounter.RemountInPlaceArgsForCall(0)
 					Expect(mntPt).To(Equal("/var/opt"))
-					Expect(options).To(Equal([]string{"nodev", "nosuid"}))
+					Expect(options).To(Equal([]string{"nodev"}))
 				})
 			})
 
@@ -2821,7 +2821,7 @@ sam:fakeanotheruser`)
 
 					mntPt, options = mounter.RemountInPlaceArgsForCall(1)
 					Expect(mntPt).To(Equal("/opt"))
-					Expect(options).To(Equal([]string{"nodev", "nosuid"}))
+					Expect(options).To(Equal([]string{"nodev"}))
 				})
 			})
 


### PR DESCRIPTION
The work in [#254] and [#256] to mount `/opt` and `/var/opt` on the ephemeral disk accidentally added the nosuid flag to the mount.

We had a report that this is causing problems for bosh releases that use these folders.