### PR TITLE
Preserve extended attributes when migrating disk data

### DIFF
--- a/platform/linux_platform.go
+++ b/platform/linux_platform.go
@@ -1380,7 +1380,8 @@ func (p linux) MigratePersistentDisk(fromMountPoint, toMountPoint string) error 
 
 	// Golang does not implement a file copy that would allow us to preserve dates...
 	// So we have to shell out to tar to perform the copy instead of delegating to the FileSystem
-	tarCopy := fmt.Sprintf("(tar -C %s --xattrs -cf - .) | (tar -C %s --xattrs -xpf -)", fromMountPoint, toMountPoint)
+	// The --xattrs and --xattrs-include=*.* flags ensure that all extended attributes (ex. capabilities) are preserved
+	tarCopy := fmt.Sprintf("(tar -C %s --xattrs --xattrs-include=*.* -cf - .) | (tar -C %s --xattrs --xattrs-include=*.* -xpf -)", fromMountPoint, toMountPoint)
 	_, _, _, err = p.cmdRunner.RunCommand("sh", "-c", tarCopy)
 	if err != nil {
 		return bosherr.WrapError(err, "Copying files from old disk to new disk")

--- a/platform/linux_platform_test.go
+++ b/platform/linux_platform_test.go
@@ -3674,7 +3674,7 @@ sam:fakeanotheruser`)
 			Expect(mounter.RemountAsReadonlyArgsForCall(0)).To(Equal("/from/path"))
 
 			Expect(len(cmdRunner.RunCommands)).To(Equal(1))
-			Expect(cmdRunner.RunCommands[0]).To(Equal([]string{"sh", "-c", "(tar -C /from/path --xattrs -cf - .) | (tar -C /to/path --xattrs -xpf -)"}))
+			Expect(cmdRunner.RunCommands[0]).To(Equal([]string{"sh", "-c", "(tar -C /from/path --xattrs --xattrs-include=*.* -cf - .) | (tar -C /to/path --xattrs --xattrs-include=*.* -xpf -)"}))
 
 			Expect(mounter.UnmountCallCount()).To(Equal(1))
 			Expect(mounter.UnmountArgsForCall(0)).To(Equal("/from/path"))
@@ -3734,7 +3734,7 @@ from-device-path  dm-0 NETAPP  ,LUN C-Mode
 				Expect(mounter.RemountAsReadonlyArgsForCall(0)).To(Equal("/from/path"))
 
 				Expect(len(cmdRunner.RunCommands)).To(Equal(3))
-				Expect(cmdRunner.RunCommands[0]).To(Equal([]string{"sh", "-c", "(tar -C /from/path --xattrs -cf - .) | (tar -C /to/path --xattrs -xpf -)"}))
+				Expect(cmdRunner.RunCommands[0]).To(Equal([]string{"sh", "-c", "(tar -C /from/path --xattrs --xattrs-include=*.* -cf - .) | (tar -C /to/path --xattrs --xattrs-include=*.* -xpf -)"}))
 
 				Expect(mounter.UnmountCallCount()).To(Equal(1))
 				Expect(mounter.UnmountArgsForCall(0)).To(Equal("/from/path"))


### PR DESCRIPTION
The following commit tried to fix the preservation of extended attributes when migrating disk data, however is not complete, as also the `--xattrs-include=*.*` parameter is required to achieve for example the preservation of capabilities: https://github.com/cloudfoundry/bosh-agent/commit/c3f558b4d705c0d78b624bfc2b378901d338600b
    
With this we try to finally fix the preservation of all extended attributes, such as capabilities for example.
    
Preservation of capabilities are for importance in PKS (Tanzu Kubernetes Grid Integrated Edition / TKGI), as Docker images are stored on persistent disks.
Whenever a Docker image includes a binary with some capabilities (for example nginx-ingress-controller), these capabilities, without this change, get lost after disk migrations, which prevents the successful starting of containers after the disk migration.
    
So far in TKGI all docker images need to be manually wiped from disk, after disk migration and re-pulled, so that the capabilities get instanciated.
    
Behaviour comparison of both commands (current vs. proposed):
```
$ getcap original/nginx-ingress-controller
original/nginx-ingress-controller = cap_net_bind_service+ep

$ (tar -C original --xattrs -cf - .) | (tar -C copy --xattrs -xpf -)
$ getcap copy/nginx-ingress-controller
$

$ (tar -C original --xattrs --xattrs-include=*.* -cf - .) | (tar -C copy --xattrs --xattrs-include=*.* -xpf -)
$ getcap copy/nginx-ingress-controller
copy/nginx-ingress-controller = cap_net_bind_service+ep
```

For further reference:
* https://www.gnu.org/software/tar/manual/html_node/Extended-File-Attributes.html
* VMware Bug: BOSH-180