### PR TITLE
scsi_volume_id_device_path_resolver flaky on ubuntu jammy

### DIFF
--- a/infrastructure/devicepathresolver/scsi_volume_id_device_path_resolver.go
+++ b/infrastructure/devicepathresolver/scsi_volume_id_device_path_resolver.go
@@ -40,7 +40,7 @@ func (devicePathResolver SCSIVolumeIDDevicePathResolver) GetRealDevicePath(diskS
 	volumeID := diskSettings.VolumeID
 
 	for _, rootDevicePath := range devicePaths {
-		if path.Base(rootDevicePath) == "sda" {
+		if strings.HasPrefix(path.Base(rootDevicePath), "sd") {
 			rootDevicePathSplits := strings.Split(rootDevicePath, "/")
 			if len(rootDevicePathSplits) > 5 {
 				scsiPath := rootDevicePathSplits[5]


### PR DESCRIPTION
We've gotten reports of intermittent agent_timed outs for deployments on vsphere with jammy stemcells (though it should also apply to bionic stemcells because it is caused by a change in the kernel) 

These we're caused by the agent failing to setup the ephemeral disk attached to the VM because the resolver code never entered the if statement: `if path.Base(rootDevicePath) == "sda"`

Investigation on the VM showed that:

`ls /sys/bus/scsi/devices/32:0:0:0/block` => `sdb` 
`ls /sys/bus/scsi/devices/32:0:1:0/block` => `sda`

```
Disk /dev/sda: 16 GiB, 17179869184 bytes, 33554432 sectors
Disk model: Virtual disk
Units: sectors of 1 * 512 = 512 bytes
Sector size (logical/physical): 512 bytes / 512 bytes
I/O size (minimum/optimal): 512 bytes / 512 bytes


Disk /dev/sdb: 5 GiB, 5368709120 bytes, 10485760 sectors
Disk model: Virtual disk
Units: sectors of 1 * 512 = 512 bytes
Sector size (logical/physical): 512 bytes / 512 bytes
I/O size (minimum/optimal): 512 bytes / 512 bytes
Disklabel type: dos
Disk identifier: 0x54a191e8

Device     Boot Start     End Sectors  Size Id Type
/dev/sdb1          63 9998046 9997984  4.8G 83 Linux
```

The good news is that the VolumeID the CPI  creates as a disk hint, still helps identifying the right `/dev/sdX` path for the ephemeral disk. 

https://github.com/cloudfoundry/bosh-vsphere-cpi-release/blob/master/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb#LL694C11-L694C56

We relied on the root disk to always be exposed at `/dev/sda`. Which has worked for ages (the code essentially didn't change since 2014) but actually is now problematic since it assumes that naming of `/dev/sd*` is deterministic.
Which according to
https://www.suse.com/support/kb/doc/?id=000018449

was the case until kernel version 5.3

The reliance seems unnecessary though, since both disks (os-root from the stemcell and the ephemeral disk) are associated  with the same scsi host (and the agent already assumes they are on they same host. So finding the hostID should be safe with either `/dev/sdX`).

fixes:

```
[linuxPlatform] 2022/12/02 13:56:04 INFO - Setting up raw ephemeral disks
[File System] 2022/12/02 13:56:04 DEBUG - Glob '/sys/bus/scsi/devices/*:0:0:0/block/*'
[linuxPlatform] 2022/12/02 13:56:04 DEBUG - Error getting ephermeral disk path Zero length hostID
[linuxPlatform] 2022/12/02 13:56:04 INFO - Setting up ephemeral disk...
[File System] 2022/12/02 13:56:04 DEBUG - Glob '/var/vcap/data/*'
[File System] 2022/12/02 13:56:04 DEBUG - Making dir /var/vcap/data with perm 0750
[main] 2022/12/02 13:56:04 ERROR - App setup Running bootstrap: Setting up ephemeral disk: No ephemeral disk found, cannot use root partition as ephemeral disk
[main] 2022/12/02 13:56:04 ERROR - Agent exited with error: Running bootstrap: Setting up ephemeral disk: No ephemeral disk found, cannot use root partition as ephemeral disk
[arping] 2022/12/02 13:56:04 DEBUG - Broadcasting MAC addresses
[File System] 2022/12/02 13:56:04 DEBUG - Checking if file exists /sys/class/net/eth0
[main] 2022/12/02 13:56:04 DEBUG - Starting agent
[File System] 2022/12/02 13:56:04 DEBUG - Reading file /var/vcap/bosh/agent.json
[File System] 2022/12/02 13:56:04 DEBUG - Read content
```


