### PR TITLE
introduce BTRFS

### DIFF
--- a/platform/disk/formatter_interface.go
+++ b/platform/disk/formatter_interface.go
@@ -4,12 +4,14 @@ type FileSystemType string
 
 const (
 	FileSystemSwap    FileSystemType = "swap"
+	FileSystemBTRFS   FileSystemType = "btrfs"
 	FileSystemExt4    FileSystemType = "ext4"
 	FileSystemXFS     FileSystemType = "xfs"
 	FileSystemDefault FileSystemType = ""
 
-	FileSystemExtResizeUtility = "resize2fs"
-	FileSystemXFSResizeUtility = "xfs_growfs"
+	FileSystemBTRFSResizeUtility = "btrfs"
+	FileSystemExtResizeUtility   = "resize2fs"
+	FileSystemXFSResizeUtility   = "xfs_growfs"
 )
 
 type Formatter interface {

--- a/platform/disk/linux_disk_manager.go
+++ b/platform/disk/linux_disk_manager.go
@@ -82,7 +82,7 @@ func NewLinuxDiskManager(
 	return linuxDiskManager{
 		ephemeralPartitioner:  ephemeralPartitioner,
 		diskUtil:              diskUtil,
-		formatter:             NewLinuxFormatter(runner, fs),
+		formatter:             NewLinuxFormatter(runner, fs, mounter),
 		fs:                    fs,
 		logger:                logger,
 		mounter:               mounter,


### PR DESCRIPTION
This patch attempt to introduce BTRFS as a usable filesystem under Linux stemcells as briefly discussed in #299.

BTRFS benefited noticeable improvements since Linux 5.17, further reducing the performance gap it suffered.

While *not* recommended for all usages, it has some interesting features we would like to use for some edge cases, such as online compression.

We are looking for feedback on this pull request.