### PR TITLE
Reorder code to boradcast address earlier

### DIFF
--- a/platform/net/ubuntu_net_manager.go
+++ b/platform/net/ubuntu_net_manager.go
@@ -185,12 +185,12 @@ func (net UbuntuNetManager) SetupNetworking(networks boshsettings.Networks, mbus
 		return bosherr.WrapError(err, "Validating dns configuration")
 	}
 
+	go net.addressBroadcaster.BroadcastMACAddresses(append(staticAddressesWithoutVirtual, dynamicAddresses...))
 	err = SetupNatsFirewall(mbus)
 	if err != nil {
 		return bosherr.WrapError(err, "Setting up nats firewall")
 	}
 	net.logger.Info(UbuntuNetManagerLogTag, "Successfully set up outgoing nats api firewall")
-	go net.addressBroadcaster.BroadcastMACAddresses(append(staticAddressesWithoutVirtual, dynamicAddresses...))
 	return nil
 }
 func (net UbuntuNetManager) ComputeNetworkConfig(networks boshsettings.Networks) ([]StaticInterfaceConfiguration, []DHCPInterfaceConfiguration, []string, error) {


### PR DESCRIPTION
This reorder should help prevent cases in which the firewall rule for NATS cannot be setup due to missing connectivity
Resolves:
https://github.com/cloudfoundry/bosh-linux-stemcell-builder/issues/280