### PR TITLE
Handles "system" & "all" types in fetch log action

### DIFF
--- a/agent/action/fetch_logs.go
+++ b/agent/action/fetch_logs.go
@@ -36,8 +36,8 @@ func (a FetchLogsAction) IsLoggable() bool {
 	return true
 }
 
-func (a FetchLogsAction) Run(logType string, filters []string) (value map[string]string, err error) {
-	tarball, err := a.logsTarProvider.Get(logType, filters)
+func (a FetchLogsAction) Run(logTypes string, filters []string) (value map[string]string, err error) {
+	tarball, err := a.logsTarProvider.Get(logTypes, filters)
 	if err != nil {
 		return
 	}

--- a/agent/action/fetch_logs_with_signed_url_test.go
+++ b/agent/action/fetch_logs_with_signed_url_test.go
@@ -3,10 +3,9 @@ package action_test
 import (
 	"errors"
 
+	fakelogstarprovider "github.com/cloudfoundry/bosh-agent/agent/logstarprovider/logstarproviderfakes"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	fakelogstarprovider "github.com/cloudfoundry/bosh-agent/agent/logstarprovider/logstarproviderfakes"
 
 	boshassert "github.com/cloudfoundry/bosh-utils/assert"
 	boshcrypto "github.com/cloudfoundry/bosh-utils/crypto"

--- a/agent/logstarprovider/logs_tar_provider_test.go
+++ b/agent/logstarprovider/logs_tar_provider_test.go
@@ -3,9 +3,10 @@ package logstarprovider
 import (
 	"errors"
 
-	fakecmd "github.com/cloudfoundry/bosh-utils/fileutil/fakes"
-
 	boshdirs "github.com/cloudfoundry/bosh-agent/settings/directories"
+	boshassert "github.com/cloudfoundry/bosh-utils/assert"
+
+	fakecmd "github.com/cloudfoundry/bosh-utils/fileutil/fakes"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -39,7 +40,7 @@ var _ = Describe("LogsTarProvider", func() {
 					_, err := provider.Get("job", []string{})
 					Expect(err).NotTo(HaveOccurred())
 
-					Expect(copier.FilteredCopyToTempDir).To(Equal(dirProvider.LogsDir()))
+					Expect(copier.FilteredMultiCopyToTempDirs[0].Dir).To(boshassert.MatchPath(dirProvider.LogsDir()))
 				})
 			})
 
@@ -48,29 +49,51 @@ var _ = Describe("LogsTarProvider", func() {
 					_, err := provider.Get("agent", []string{})
 					Expect(err).NotTo(HaveOccurred())
 
-					Expect(copier.FilteredCopyToTempDir).To(Equal(dirProvider.AgentLogsDir()))
+					Expect(copier.FilteredMultiCopyToTempDirs[0].Dir).To(boshassert.MatchPath(dirProvider.AgentLogsDir()))
 				})
+			})
+
+			Context("system logs", func() {
+				It("uses the correct logs dir", func() {
+					_, err := provider.Get("system", []string{})
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(copier.FilteredMultiCopyToTempDirs[0].Dir).To(boshassert.MatchPath("/var/log"))
+				})
+			})
+
+			Context("multiple logs", func() {
+				It("uses the correct logs dirs", func() {
+					_, err := provider.Get("job,agent,system", []string{})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(len(copier.FilteredMultiCopyToTempDirs)).To(Equal(3))
+
+					Expect(copier.FilteredMultiCopyToTempDirs[0].Dir).To(boshassert.MatchPath("/fake/dir/sys/log"))
+					Expect(copier.FilteredMultiCopyToTempDirs[1].Dir).To(boshassert.MatchPath("/fake/dir/bosh/log"))
+					Expect(copier.FilteredMultiCopyToTempDirs[2].Dir).To(boshassert.MatchPath("/var/log"))
+				})
+
 			})
 		})
 
 		Describe("filters", func() {
-			Context("job logs", func() {
-				BeforeEach(func() {
-					Expect(copier.FilteredCopyToTempFilters).To(BeEmpty())
-				})
+			BeforeEach(func() {
+				Expect(copier.FilteredMultiCopyToTempFilters).To(BeEmpty())
+			})
 
+			Context("job logs", func() {
 				It("uses the filters provided", func() {
 					_, err := provider.Get("job", []string{"foo", "bar"})
 					Expect(err).NotTo(HaveOccurred())
 
-					Expect(copier.FilteredCopyToTempFilters).To(ConsistOf("foo", "bar"))
+					Expect(copier.FilteredMultiCopyToTempFilters).To(ConsistOf("foo", "bar"))
 				})
 
 				It("uses the default filters when none are provided", func() {
 					_, err := provider.Get("job", []string{})
 					Expect(err).NotTo(HaveOccurred())
 
-					Expect(copier.FilteredCopyToTempFilters).To(ConsistOf("**/*"))
+					Expect(copier.FilteredMultiCopyToTempFilters).To(ConsistOf("**/*"))
 				})
 			})
 
@@ -79,14 +102,46 @@ var _ = Describe("LogsTarProvider", func() {
 					_, err := provider.Get("agent", []string{"foo", "bar"})
 					Expect(err).NotTo(HaveOccurred())
 
-					Expect(copier.FilteredCopyToTempFilters).To(ConsistOf("foo", "bar"))
+					Expect(copier.FilteredMultiCopyToTempFilters).To(ConsistOf("foo", "bar"))
 				})
 
 				It("uses the default filters when none are provided", func() {
 					_, err := provider.Get("agent", []string{})
 					Expect(err).NotTo(HaveOccurred())
 
-					Expect(copier.FilteredCopyToTempFilters).To(ConsistOf("**/*"))
+					Expect(copier.FilteredMultiCopyToTempFilters).To(ConsistOf("**/*"))
+				})
+			})
+
+			Context("system logs", func() {
+				It("uses the filters provided", func() {
+					_, err := provider.Get("system", []string{"foo", "bar"})
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(copier.FilteredMultiCopyToTempFilters).To(ConsistOf("foo", "bar"))
+				})
+
+				It("uses the default filters when none are provided", func() {
+					_, err := provider.Get("system", []string{})
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(copier.FilteredMultiCopyToTempFilters).To(ConsistOf("**/*"))
+				})
+			})
+
+			Context("multiple log types", func() {
+				It("uses the filters provided, just as it does with one log type", func() {
+					_, err := provider.Get("system,agent,job", []string{"foo", "bar"})
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(copier.FilteredMultiCopyToTempFilters).To(ConsistOf("foo", "bar"))
+				})
+
+				It("uses the default filters when none are provided", func() {
+					_, err := provider.Get("agent,system,job", []string{})
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(copier.FilteredMultiCopyToTempFilters).To(ConsistOf("**/*"))
 				})
 			})
 
@@ -100,7 +155,7 @@ var _ = Describe("LogsTarProvider", func() {
 			Context("copying", func() {
 				Context("error", func() {
 					BeforeEach(func() {
-						copier.FilteredCopyToTempError = errors.New("plagiarization")
+						copier.FilteredMultiCopyToTempError = errors.New("plagiarization")
 					})
 
 					It("returns an error if the copier returns an error", func() {
@@ -111,7 +166,7 @@ var _ = Describe("LogsTarProvider", func() {
 				})
 
 				It("cleans up temp dir", func() {
-					copier.FilteredCopyToTempTempDir = "/tmp/dir"
+					copier.FilteredMultiCopyToTempDir = "/tmp/dir"
 					Expect(copier.CleanUpTempDir).To(BeZero())
 
 					_, err := provider.Get("job", []string{})

--- a/integration/fetch_logs_test.go
+++ b/integration/fetch_logs_test.go
@@ -51,8 +51,8 @@ var _ = Describe("fetch_logs", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("puts the logs in the appropriate blobstore location", func() {
-		_, err := testEnvironment.RunCommand("echo 'foobarbaz' | sudo tee /var/vcap/sys/log/fetch-logs")
+	It("job log fetch works", func() {
+		_, err := testEnvironment.RunCommand("echo 'foobarbaz-job-log-fetch' | sudo tee /var/vcap/sys/log/fetch-logs-job")
 		Expect(err).NotTo(HaveOccurred())
 
 		logsResponse, err := testEnvironment.AgentClient.FetchLogs("job", nil)
@@ -61,8 +61,36 @@ var _ = Describe("fetch_logs", func() {
 		output, err := testEnvironment.RunCommand(fmt.Sprintf("sudo zcat /var/vcap/data/blobs/%s", logsResponse["blobstore_id"]))
 
 		Expect(err).NotTo(HaveOccurred())
-		Expect(output).To(ContainSubstring("foobarbaz"))
-		Expect(output).To(ContainSubstring("fetch-logs"))
+		Expect(output).To(ContainSubstring("foobarbaz-job-log-fetch"))
+		Expect(output).To(ContainSubstring("fetch-logs-job"))
+	})
+
+	It("agent log fetch works", func() {
+		_, err := testEnvironment.RunCommand("echo 'foobarbaz-agent-log-fetch' | sudo tee /var/vcap/bosh/log/fetch-logs-agent")
+		Expect(err).NotTo(HaveOccurred())
+
+		logsResponse, err := testEnvironment.AgentClient.FetchLogs("agent", nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		output, err := testEnvironment.RunCommand(fmt.Sprintf("sudo zcat /var/vcap/data/blobs/%s", logsResponse["blobstore_id"]))
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(output).To(ContainSubstring("foobarbaz-agent-log-fetch"))
+		Expect(output).To(ContainSubstring("fetch-logs-agent"))
+	})
+
+	It("system log fetch works", func() {
+		_, err := testEnvironment.RunCommand("echo 'foobarbaz-system-log-fetch' | sudo tee /var/log/fetch-logs-system")
+		Expect(err).NotTo(HaveOccurred())
+
+		logsResponse, err := testEnvironment.AgentClient.FetchLogs("system", nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		output, err := testEnvironment.RunCommand(fmt.Sprintf("sudo zcat /var/vcap/data/blobs/%s", logsResponse["blobstore_id"]))
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(output).To(ContainSubstring("foobarbaz-system-log-fetch"))
+		Expect(output).To(ContainSubstring("fetch-logs-system"))
 	})
 
 })

--- a/integration/fetch_logs_with_signed_url_test.go
+++ b/integration/fetch_logs_with_signed_url_test.go
@@ -57,8 +57,8 @@ var _ = Describe("fetch_logs_with_signed_url", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("puts the logs in the appropriate blobstore location", func() {
-		_, err := testEnvironment.RunCommand("echo 'foobarbaz' | sudo tee /var/vcap/sys/log/fetch-logs")
+	It("job log fetch works", func() {
+		_, err := testEnvironment.RunCommand("echo 'foobarbaz-job-log-fetch' | sudo tee /var/vcap/sys/log/fetch-logs-job")
 		Expect(err).NotTo(HaveOccurred())
 
 		signedURL := "http://127.0.0.1:9091/upload_package/logs.tgz"
@@ -68,8 +68,38 @@ var _ = Describe("fetch_logs_with_signed_url", func() {
 
 		output, err := testEnvironment.RunCommand(fmt.Sprintf("sudo zcat %s", filepath.Join(testEnvironment.BlobstoreDir(), "logs.tgz")))
 		Expect(err).NotTo(HaveOccurred())
-		Expect(output).To(ContainSubstring("foobarbaz"))
-		Expect(output).To(ContainSubstring("fetch-logs"))
+		Expect(output).To(ContainSubstring("foobarbaz-job-log-fetch"))
+		Expect(output).To(ContainSubstring("fetch-logs-job"))
+	})
+
+	It("agent log fetch works", func() {
+		_, err := testEnvironment.RunCommand("echo 'foobarbaz-agent-log-fetch' | sudo tee /var/vcap/bosh/log/fetch-logs-agent")
+		Expect(err).NotTo(HaveOccurred())
+
+		signedURL := "http://127.0.0.1:9091/upload_package/logs.tgz"
+
+		_, err = testEnvironment.AgentClient.FetchLogsWithSignedURLAction(signedURL, "agent", nil, map[string]string{"header": "value"})
+		Expect(err).NotTo(HaveOccurred())
+
+		output, err := testEnvironment.RunCommand(fmt.Sprintf("sudo zcat %s", filepath.Join(testEnvironment.BlobstoreDir(), "logs.tgz")))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(output).To(ContainSubstring("foobarbaz-agent-log-fetch"))
+		Expect(output).To(ContainSubstring("fetch-logs-agent"))
+	})
+
+	It("system log fetch works", func() {
+		_, err := testEnvironment.RunCommand("echo 'foobarbaz-system-log-fetch' | sudo tee /var/log/fetch-logs-system")
+		Expect(err).NotTo(HaveOccurred())
+
+		signedURL := "http://127.0.0.1:9091/upload_package/logs.tgz"
+		_, err = testEnvironment.AgentClient.FetchLogsWithSignedURLAction(signedURL, "system", nil, map[string]string{"header": "value"})
+
+		Expect(err).NotTo(HaveOccurred())
+
+		output, err := testEnvironment.RunCommand(fmt.Sprintf("sudo zcat %s", filepath.Join(testEnvironment.BlobstoreDir(), "logs.tgz")))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(output).To(ContainSubstring("foobarbaz-system-log-fetch"))
+		Expect(output).To(ContainSubstring("fetch-logs-system"))
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
This commit updates the Bosh Agent to support the "system" and "all" log types that are now (or will soon be) supported by the Bosh CLI. This work is backwards-compatible with versions of the Bosh CLI that do not support these new log types.

The "system" log type fetches the logs from "/var/log". System logs are placed into a "/var/log" directory inside the tarball. This is done to generally avoid confusion as to the source of these logs, but especially when the "all" log type is requested. Do note that if the "all" log type is requested, and the VM has a job named "var" deployed, then the system logs will be placed into a "log" subdirectory in the "var" job's log directory. For now, this seems to be a minor and unlikely problem, so avoiding this doesn't seem to be worth the hassle.

The "all" log type is a pseudo-type constructed by the Bosh CLI, which fetches all currently-known log types; "job" (the historical (and current) default when no log type is specified), "agent", and "system".

NOTE: Requests for the "system" log type will be sliently ignored when
      the Agent is running on an OS that is not Linux. Currently, only
      Windows and Linux are supported OSs. If we ever support another
      Unix-alike OS (or figure out how to do something sensible and
      useful on Windows), then the code that handles the "system" log
      type will need to be updated.

NOTE: The fetch log action can handle combinations of log types that
      are not supported by the Bosh CLI. This should generally be
      harmless, and probably makes it easier to extend in the future.
      We also do no deduplication of the log types passed to the action.
      A malicious user could take advantage of this to cause the Agent
      to consume large amounts of RAM or disk space (whether in the
      blobstore, or on the Agent's disk), but if a malicious user has
      the credentials required to talk to the Agent, they can already
      get up to significant mischief.

Signed-off-by: Brian Cunnie <bcunnie@vmware.com