### PR TITLE
Handles "system" & "all" types in fetch log action

### DIFF
--- a/agent/action/fetch_logs.go
+++ b/agent/action/fetch_logs.go
@@ -2,6 +2,7 @@ package action
 
 import (
 	"errors"
+
 	"github.com/cloudfoundry/bosh-agent/agent/logstarprovider"
 
 	blobdelegator "github.com/cloudfoundry/bosh-agent/agent/httpblobprovider/blobstore_delegator"
@@ -34,8 +35,8 @@ func (a FetchLogsAction) IsLoggable() bool {
 	return true
 }
 
-func (a FetchLogsAction) Run(logType string, filters []string) (value map[string]string, err error) {
-	tarball, err := a.logsTarProvider.Get(logType, filters)
+func (a FetchLogsAction) Run(logTypes string, filters []string) (value map[string]string, err error) {
+	tarball, err := a.logsTarProvider.Get(logTypes, filters)
 	if err != nil {
 		return
 	}

--- a/agent/action/fetch_logs_test.go
+++ b/agent/action/fetch_logs_test.go
@@ -2,6 +2,7 @@ package action_test
 
 import (
 	"errors"
+
 	fakeblobdelegator "github.com/cloudfoundry/bosh-agent/agent/httpblobprovider/blobstore_delegator/blobstore_delegatorfakes"
 	fakelogstarprovider "github.com/cloudfoundry/bosh-agent/agent/logstarprovider/logstarproviderfakes"
 	boshassert "github.com/cloudfoundry/bosh-utils/assert"

--- a/agent/action/fetch_logs_with_signed_url.go
+++ b/agent/action/fetch_logs_with_signed_url.go
@@ -2,6 +2,7 @@ package action
 
 import (
 	"errors"
+
 	"github.com/cloudfoundry/bosh-agent/agent/logstarprovider"
 
 	blobdelegator "github.com/cloudfoundry/bosh-agent/agent/httpblobprovider/blobstore_delegator"

--- a/agent/action/fetch_logs_with_signed_url_test.go
+++ b/agent/action/fetch_logs_with_signed_url_test.go
@@ -2,6 +2,7 @@ package action_test
 
 import (
 	"errors"
+
 	fakelogstarprovider "github.com/cloudfoundry/bosh-agent/agent/logstarprovider/logstarproviderfakes"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/agent/logstarprovider/logs_tar_provider.go
+++ b/agent/logstarprovider/logs_tar_provider.go
@@ -1,6 +1,9 @@
 package logstarprovider
 
 import (
+	"runtime"
+	"strings"
+
 	boshdirs "github.com/cloudfoundry/bosh-agent/settings/directories"
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 	boshcmd "github.com/cloudfoundry/bosh-utils/fileutil"
@@ -23,25 +26,37 @@ func NewLogsTarProvider(
 	}
 }
 
-func (l logsTarProvider) Get(logType string, filters []string) (string, error) {
-	var logsDir string
+func (l logsTarProvider) Get(logTypes string, filters []string) (string, error) {
+	var directoriesAndPrefixes []boshcmd.DirToCopy
+	var err error
 
-	switch logType {
-	case "job":
-		if len(filters) == 0 {
-			filters = []string{"**/*"}
-		}
-		logsDir = l.settingsDir.LogsDir()
-	case "agent":
-		if len(filters) == 0 {
-			filters = []string{"**/*"}
-		}
-		logsDir = l.settingsDir.AgentLogsDir()
-	default:
-		return "", bosherr.Error("Invalid log type")
+	if len(filters) == 0 {
+		filters = []string{"**/*"}
 	}
 
-	tmpDir, err := l.copier.FilteredCopyToTemp(logsDir, filters)
+	for _, logType := range strings.Split(logTypes, ",") {
+		if logType == "job" {
+			directoriesAndPrefixes = append(directoriesAndPrefixes,
+				boshcmd.DirToCopy{Dir: l.settingsDir.LogsDir(), Prefix: ""})
+			continue
+		}
+		if logType == "agent" {
+			directoriesAndPrefixes = append(directoriesAndPrefixes,
+				boshcmd.DirToCopy{Dir: l.settingsDir.AgentLogsDir(), Prefix: ""})
+			continue
+		}
+		if logType == "system" {
+			if runtime.GOOS == "linux" {
+				directoriesAndPrefixes = append(directoriesAndPrefixes,
+					boshcmd.DirToCopy{Dir: "/var/log/", Prefix: "/var/log/"})
+			}
+			continue
+		}
+		err = bosherr.Error("Invalid log type")
+		return "", err
+	}
+
+	tmpDir, err := l.copier.FilteredMultiCopyToTemp(directoriesAndPrefixes, filters)
 	if err != nil {
 		return "", bosherr.WrapError(err, "Copying filtered files to temp directory")
 	}

--- a/integration/fetch_logs_test.go
+++ b/integration/fetch_logs_test.go
@@ -77,8 +77,8 @@ var _ = Describe("fetch_logs", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("puts the logs in the appropriate blobstore location", func() {
-		_, err := testEnvironment.RunCommand("echo 'foobarbaz' | sudo tee /var/vcap/sys/log/fetch-logs")
+	It("job log fetch works", func() {
+		_, err := testEnvironment.RunCommand("echo 'foobarbaz-job-log-fetch' | sudo tee /var/vcap/sys/log/fetch-logs-job")
 		Expect(err).NotTo(HaveOccurred())
 
 		logsResponse, err := agentClient.FetchLogs("job", nil)
@@ -87,8 +87,36 @@ var _ = Describe("fetch_logs", func() {
 		output, err := testEnvironment.RunCommand(fmt.Sprintf("sudo zcat /var/vcap/data/blobs/%s", logsResponse["blobstore_id"]))
 
 		Expect(err).NotTo(HaveOccurred())
-		Expect(output).To(ContainSubstring("foobarbaz"))
-		Expect(output).To(ContainSubstring("fetch-logs"))
+		Expect(output).To(ContainSubstring("foobarbaz-job-log-fetch"))
+		Expect(output).To(ContainSubstring("fetch-logs-job"))
+	})
+
+	It("agent log fetch works", func() {
+		_, err := testEnvironment.RunCommand("echo 'foobarbaz-agent-log-fetch' | sudo tee /var/vcap/bosh/log/fetch-logs-agent")
+		Expect(err).NotTo(HaveOccurred())
+
+		logsResponse, err := agentClient.FetchLogs("agent", nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		output, err := testEnvironment.RunCommand(fmt.Sprintf("sudo zcat /var/vcap/data/blobs/%s", logsResponse["blobstore_id"]))
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(output).To(ContainSubstring("foobarbaz-agent-log-fetch"))
+		Expect(output).To(ContainSubstring("fetch-logs-agent"))
+	})
+
+	It("system log fetch works", func() {
+		_, err := testEnvironment.RunCommand("echo 'foobarbaz-system-log-fetch' | sudo tee /var/log/fetch-logs-system")
+		Expect(err).NotTo(HaveOccurred())
+
+		logsResponse, err := agentClient.FetchLogs("system", nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		output, err := testEnvironment.RunCommand(fmt.Sprintf("sudo zcat /var/vcap/data/blobs/%s", logsResponse["blobstore_id"]))
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(output).To(ContainSubstring("foobarbaz-system-log-fetch"))
+		Expect(output).To(ContainSubstring("fetch-logs-system"))
 	})
 
 })

--- a/integration/fetch_logs_with_signed_url_test.go
+++ b/integration/fetch_logs_with_signed_url_test.go
@@ -88,8 +88,8 @@ var _ = Describe("fetch_logs_with_signed_url", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("puts the logs in the appropriate blobstore location", func() {
-		_, err := testEnvironment.RunCommand("echo 'foobarbaz' | sudo tee /var/vcap/sys/log/fetch-logs")
+	It("job log fetch works", func() {
+		_, err := testEnvironment.RunCommand("echo 'foobarbaz-job-log-fetch' | sudo tee /var/vcap/sys/log/fetch-logs-job")
 		Expect(err).NotTo(HaveOccurred())
 
 		signedURL := "http://127.0.0.1:9091/upload_package/logs.tgz"
@@ -99,7 +99,38 @@ var _ = Describe("fetch_logs_with_signed_url", func() {
 
 		output, err := testEnvironment.RunCommand(fmt.Sprintf("sudo zcat %s", filepath.Join(testEnvironment.BlobstoreDir(), "logs.tgz")))
 		Expect(err).NotTo(HaveOccurred())
-		Expect(output).To(ContainSubstring("foobarbaz"))
-		Expect(output).To(ContainSubstring("fetch-logs"))
+		Expect(output).To(ContainSubstring("foobarbaz-job-log-fetch"))
+		Expect(output).To(ContainSubstring("fetch-logs-job"))
 	})
+
+	It("agent log fetch works", func() {
+		_, err := testEnvironment.RunCommand("echo 'foobarbaz-agent-log-fetch' | sudo tee /var/vcap/bosh/log/fetch-logs-agent")
+		Expect(err).NotTo(HaveOccurred())
+
+		signedURL := "http://127.0.0.1:9091/upload_package/logs.tgz"
+
+		_, err = agentClient.FetchLogsWithSignedURLAction(signedURL, "agent", nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		output, err := testEnvironment.RunCommand(fmt.Sprintf("sudo zcat %s", filepath.Join(testEnvironment.BlobstoreDir(), "logs.tgz")))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(output).To(ContainSubstring("foobarbaz-agent-log-fetch"))
+		Expect(output).To(ContainSubstring("fetch-logs-agent"))
+	})
+
+	It("system log fetch works", func() {
+		_, err := testEnvironment.RunCommand("echo 'foobarbaz-system-log-fetch' | sudo tee /var/log/fetch-logs-system")
+		Expect(err).NotTo(HaveOccurred())
+
+		signedURL := "http://127.0.0.1:9091/upload_package/logs.tgz"
+
+		_, err = agentClient.FetchLogsWithSignedURLAction(signedURL, "system", nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		output, err := testEnvironment.RunCommand(fmt.Sprintf("sudo zcat %s", filepath.Join(testEnvironment.BlobstoreDir(), "logs.tgz")))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(output).To(ContainSubstring("foobarbaz-system-log-fetch"))
+		Expect(output).To(ContainSubstring("fetch-logs-system"))
+	})
+
 })


### PR DESCRIPTION
This commit updates the Bosh Agent to support the "system" and "all" log types that are now (or will soon be) supported by the Bosh CLI. This work is backwards-compatible with versions of the Bosh CLI that do not support these new log types.

The "system" log type fetches the logs from "/var/log". System logs are placed into a "/var/log" directory inside the tarball. This is done to generally avoid confusion as to the source of these logs, but especially when the "all" log type is requested. Do note that if the "all" log type is requested, and the VM has a job named "var" deployed, then the system logs will be placed into a "log" subdirectory in the "var" job's log directory. For now, this seems to be a minor and unlikely problem, so avoiding this doesn't seem to be worth the hassle.

The "all" log type is a pseudo-type constructed by the Bosh CLI, which fetches all currently-known log types; "job" (the historical (and current) default when no log type is specified), "agent", and "system".

NOTE: Requests for the "system" log type will be sliently ignored when
      the Agent is running on an OS that is not Linux. Currently, only
      Windows and Linux are supported OSs. If we ever support another
      Unix-alike OS (or figure out how to do something sensible and
      useful on Windows), then the code that handles the "system" log
      type will need to be updated.

NOTE: The fetch log action can handle combinations of log types that
      are not supported by the Bosh CLI. This should generally be
      harmless, and probably makes it easier to extend in the future.
      We also do no deduplication of the log types passed to the action.
      A malicious user could take advantage of this to cause the Agent
      to consume large amounts of RAM or disk space (whether in the
      blobstore, or on the Agent's disk), but if a malicious user has
      the credentials required to talk to the Agent, they can already
      get up to significant mischief.

Signed-off-by: Brian Cunnie <bcunnie@vmware.com