### PR TITLE
correct the diskID for device path resolution

### DIFF
--- a/infrastructure/devicepathresolver/id_device_path_resolver.go
+++ b/infrastructure/devicepathresolver/id_device_path_resolver.go
@@ -3,6 +3,7 @@ package devicepathresolver
 import (
 	"fmt"
 	"path"
+	"strings"
 	"time"
 
 	boshudev "github.com/cloudfoundry/bosh-agent/platform/udevdevice"
@@ -51,9 +52,17 @@ func (idpr idDevicePathResolver) GetRealDevicePath(diskSettings boshsettings.Dis
 	stopAfter := time.Now().Add(idpr.diskWaitTimeout)
 	found := false
 
-	var realPath string
+	var realPath, diskID string
 
-	diskID := diskSettings.ID
+	dashIndex := strings.IndexRune(diskSettings.ID, '-')
+	if dashIndex != -1 {
+		//some disks are mounted without the dash or without the prefix,
+		//we remove it here entirely so the Glob by-id works for all scenarios
+		diskID = diskSettings.ID[dashIndex+1:]
+	} else {
+		diskID = diskSettings.ID
+	}
+
 	deviceGlobPattern := fmt.Sprintf("*%s", diskID)
 	deviceIDPathGlobPattern := path.Join("/", "dev", "disk", "by-id", deviceGlobPattern)
 


### PR DESCRIPTION
For ali and aws the device path is not correctly resolved, due to some differences in the ID/Name of the disk between /dev/disk/by-id/ and the ID/Name of the disk in the IAAS provider