### PR TITLE
Add StripVolumeRegex configuration property

### DIFF
--- a/infrastructure/devicepathresolver/id_device_path_resolver.go
+++ b/infrastructure/devicepathresolver/id_device_path_resolver.go
@@ -3,6 +3,7 @@ package devicepathresolver
 import (
 	"fmt"
 	"path"
+	"regexp"
 	"time"
 
 	boshudev "github.com/cloudfoundry/bosh-agent/platform/udevdevice"
@@ -12,20 +13,25 @@ import (
 )
 
 type idDevicePathResolver struct {
-	diskWaitTimeout time.Duration
-	udev            boshudev.UdevDevice
-	fs              boshsys.FileSystem
+	diskWaitTimeout     time.Duration
+	udev                boshudev.UdevDevice
+	fs                  boshsys.FileSystem
+	stripVolumeRegex    string
+	stripVolumeCompiled *regexp.Regexp
 }
 
 func NewIDDevicePathResolver(
 	diskWaitTimeout time.Duration,
 	udev boshudev.UdevDevice,
 	fs boshsys.FileSystem,
+	stripVolumeRegex string,
 ) DevicePathResolver {
 	return idDevicePathResolver{
-		diskWaitTimeout: diskWaitTimeout,
-		udev:            udev,
-		fs:              fs,
+		diskWaitTimeout:     diskWaitTimeout,
+		udev:                udev,
+		fs:                  fs,
+		stripVolumeRegex:    stripVolumeRegex,
+		stripVolumeCompiled: nil,
 	}
 }
 
@@ -48,13 +54,20 @@ func (idpr idDevicePathResolver) GetRealDevicePath(diskSettings boshsettings.Dis
 		return "", false, bosherr.WrapError(err, "Running udevadm settle")
 	}
 
+	if idpr.stripVolumeRegex != "" && idpr.stripVolumeCompiled == nil {
+		idpr.stripVolumeCompiled, err = regexp.Compile(idpr.stripVolumeRegex)
+		if err != nil {
+			return "", false, bosherr.WrapError(err, "Compiling stripVolumeRegex")
+		}
+	}
+
 	stopAfter := time.Now().Add(idpr.diskWaitTimeout)
 	found := false
 
 	var realPath string
 
 	diskID := diskSettings.ID
-	deviceGlobPattern := fmt.Sprintf("*%s", diskID)
+	deviceGlobPattern := fmt.Sprintf("*%s", idpr.stripDiskID(diskID))
 	deviceIDPathGlobPattern := path.Join("/", "dev", "disk", "by-id", deviceGlobPattern)
 
 	for !found {
@@ -86,4 +99,11 @@ func (idpr idDevicePathResolver) GetRealDevicePath(diskSettings boshsettings.Dis
 	}
 
 	return realPath, false, nil
+}
+
+func (idpr idDevicePathResolver) stripDiskID(diskID string) string {
+	if idpr.stripVolumeCompiled != nil {
+		return idpr.stripVolumeCompiled.ReplaceAllLiteralString(diskID, "")
+	}
+	return diskID
 }

--- a/platform/linux_platform.go
+++ b/platform/linux_platform.go
@@ -78,6 +78,10 @@ type LinuxOptions struct {
 	// Strategy for resolving ephemeral & persistent disk partitioners;
 	// possible values: parted, "" (default is sfdisk if disk < 2TB, parted otherwise)
 	PartitionerType string
+
+	// Regular expression specifying what part of volume ID to strip.
+	// possible values:  valid RE2 regex e.g. "^vol-", "" (default is not to strip)
+	StripVolumeRegex string
 }
 
 type linux struct {

--- a/platform/provider.go
+++ b/platform/provider.go
@@ -115,7 +115,7 @@ func NewProvider(logger boshlog.Logger, dirProvider boshdirs.Provider, statsColl
 	switch options.Linux.DevicePathResolutionType {
 	case "virtio":
 		udev := boshudev.NewConcreteUdevDevice(runner, logger)
-		idDevicePathResolver := devicepathresolver.NewIDDevicePathResolver(500*time.Millisecond, udev, fs)
+		idDevicePathResolver := devicepathresolver.NewIDDevicePathResolver(500*time.Millisecond, udev, fs, options.Linux.StripVolumeRegex)
 		mappedDevicePathResolver := devicepathresolver.NewMappedDevicePathResolver(30000*time.Millisecond, fs)
 		devicePathResolver = devicepathresolver.NewVirtioDevicePathResolver(idDevicePathResolver, mappedDevicePathResolver, logger)
 	case "scsi":


### PR DESCRIPTION
Add a `StripVolumeRegex` configuration property that will be used to strip some part of `disk-id` (aka volume ID) before device path resolve step, as proposed by the Working Group:

_Create a configuration property for the bosh agent to configure a strip-volume-regex,
which would allow specifying a regex prefix per IaaS in the bosh stemcell builder [here](https://github.com/cloudfoundry/bosh-linux-stemcell-builder/blob/ubuntu-jammy/master/stemcell_builder/stages/bosh_alicloud_agent_settings/apply.sh#L11-L1) (in the case of Ali Cloud)._

The potential benefit is that this could solve issue #310.