### PR TITLE
Support Linux sparse files

### DIFF
--- a/platform/linux_platform.go
+++ b/platform/linux_platform.go
@@ -1394,7 +1394,7 @@ func (p linux) MigratePersistentDisk(fromMountPoint, toMountPoint string) error 
 	// Golang does not implement a file copy that would allow us to preserve dates...
 	// So we have to shell out to tar to perform the copy instead of delegating to the FileSystem
 	// The --xattrs and --xattrs-include=*.* flags ensure that all extended attributes (ex. capabilities) are preserved
-	tarCopy := fmt.Sprintf("(tar -C %s --xattrs --xattrs-include=*.* -cf - .) | (tar -C %s --xattrs --xattrs-include=*.* -xpf -)", fromMountPoint, toMountPoint)
+	tarCopy := fmt.Sprintf("(tar -C %s --xattrs --xattrs-include=*.* --sparse -cf - .) | (tar -C %s --xattrs --xattrs-include=*.* -xpf -)", fromMountPoint, toMountPoint)
 	_, _, _, err = p.cmdRunner.RunCommand("sh", "-c", tarCopy)
 	if err != nil {
 		return bosherr.WrapError(err, "Copying files from old disk to new disk")

--- a/platform/linux_platform_test.go
+++ b/platform/linux_platform_test.go
@@ -3682,7 +3682,7 @@ sam:fakeanotheruser`)
 			Expect(mounter.RemountAsReadonlyArgsForCall(0)).To(Equal("/from/path"))
 
 			Expect(len(cmdRunner.RunCommands)).To(Equal(1))
-			Expect(cmdRunner.RunCommands[0]).To(Equal([]string{"sh", "-c", "(tar -C /from/path --xattrs --xattrs-include=*.* -cf - .) | (tar -C /to/path --xattrs --xattrs-include=*.* -xpf -)"}))
+			Expect(cmdRunner.RunCommands[0]).To(Equal([]string{"sh", "-c", "(tar -C /from/path --xattrs --xattrs-include=*.* --sparse -cf - .) | (tar -C /to/path --xattrs --xattrs-include=*.* -xpf -)"}))
 
 			Expect(mounter.UnmountCallCount()).To(Equal(1))
 			Expect(mounter.UnmountArgsForCall(0)).To(Equal("/from/path"))
@@ -3743,7 +3743,7 @@ from-device-path  dm-0 NETAPP  ,LUN C-Mode
 				Expect(mounter.RemountAsReadonlyArgsForCall(0)).To(Equal("/from/path"))
 
 				Expect(len(cmdRunner.RunCommands)).To(Equal(3))
-				Expect(cmdRunner.RunCommands[0]).To(Equal([]string{"sh", "-c", "(tar -C /from/path --xattrs --xattrs-include=*.* -cf - .) | (tar -C /to/path --xattrs --xattrs-include=*.* -xpf -)"}))
+				Expect(cmdRunner.RunCommands[0]).To(Equal([]string{"sh", "-c", "(tar -C /from/path --xattrs --xattrs-include=*.* --sparse -cf - .) | (tar -C /to/path --xattrs --xattrs-include=*.* -xpf -)"}))
 
 				Expect(mounter.UnmountCallCount()).To(Equal(1))
 				Expect(mounter.UnmountArgsForCall(0)).To(Equal("/from/path"))


### PR DESCRIPTION
Pass the --sparse to the tar create archive command used for disk resize. This option will detect holes in the file and only copy non-empty data. The --sparse option is omitted on the tar extraction command where it has no effect.

Fixes https://github.com/cloudfoundry/bosh-agent/issues/313