### PR TITLE
Allow the agent to accept multiple async tasks at the same time

### DIFF
--- a/agent/task/async_task_service.go
+++ b/agent/task/async_task_service.go
@@ -22,7 +22,7 @@ func NewAsyncTaskService(uuidGen boshuuid.Generator, logger boshlog.Logger) (ser
 		uuidGen:      uuidGen,
 		logger:       logger,
 		currentTasks: make(map[string]Task),
-		taskChan:     make(chan Task),
+		taskChan:     make(chan Task, 5),
 		taskSem:      make(chan func()),
 	}
 

--- a/agent/task/async_task_service_test.go
+++ b/agent/task/async_task_service_test.go
@@ -182,6 +182,26 @@ func init() { //nolint:funlen,gochecknoinits
 					time.Sleep(200 * time.Millisecond)
 				}
 			})
+
+			It("will not block if another task is already started", func(ctx SpecContext) {
+				taskChannel := make(chan bool)
+				task1Func := func() (interface{}, error) {
+					<-taskChannel
+					return nil, nil
+				}
+				task1, _ := service.CreateTask(task1Func, nil, nil)
+				service.StartTask(task1)
+				task2Func := func() (interface{}, error) {
+					return nil, nil
+				}
+				task2, _ := service.CreateTask(task2Func, nil, nil)
+				Eventually(func() bool {
+					service.StartTask(task2)
+					return true
+				}).WithContext(ctx).Should(BeTrue())
+
+				taskChannel <- true
+			}, SpecTimeout(time.Second*5))
 		})
 
 		Describe("CreateTask", func() {


### PR DESCRIPTION
The agent is not currently capable of handling multiple async tasks in parallel.

When the second task is received, StartTask tries to put the task onto the taskChan of the async task service but that channel is already full with the current processing task. This prevents StartTask from returning, which prevents the dispatcher from returning, which prevents all incoming actions from being processed by the handler.

Once the handler and dispatcher are blocked, the agent is unable to process incoming get_task requests, which ultimately leads to the director timing out.

This commit changes the taskChan to a length of 5. This won't actually let the agent process multiple async tasks at the same time, but it will accept them and store them on the channel without blocking the dispatcher or the handler. This allow the get_tasks for the current async tasks to continue to be processed. Once the task it complete, the additional queued tasks can be processed.

You can reproduce the problem state by having a VM perform a long running task such as a pre-start or drain script. Then perform a "logs" action on the VM which calls the "fetch_logs" async action.

Even with this change, it will still be possible to get the VM into a broken state by performing more than 5 concurrent async actions at the same time. Such as multiple fetch logs attempts; since the first one won't work if the agent is processing a different task, they may cancel and retry it which will just queue up additional tasks. But this changes makes it less likely to cause a deploy to fail by attempting to perform a second task at the same time.