### PR TITLE
Allow EFI-enabled stemcells to boot with IPv6

### DIFF
--- a/platform/net/kernel_ipv6.go
+++ b/platform/net/kernel_ipv6.go
@@ -24,13 +24,20 @@ func NewKernelIPv6Impl(fs boshsys.FileSystem, cmdRunner boshsys.CmdRunner, logge
 
 func (net KernelIPv6Impl) Enable(stopCh <-chan struct{}) error {
 	const (
-		grubConfPath       = "/boot/grub/grub.cfg"
+		grubConfPathBIOS   = "/boot/grub/grub.cfg"
+		grubConfPathEFI    = "/boot/efi/EFI/grub/grub.cfg"
 		grubIPv6DisableOpt = "ipv6.disable=1"
 	)
 
+	grubConfPath := grubConfPathBIOS
+
 	grubConf, err := net.fs.ReadFileString(grubConfPath)
 	if err != nil {
-		return bosherr.WrapError(err, "Reading grub")
+		grubConfPath = grubConfPathEFI
+		grubConf, err = net.fs.ReadFileString(grubConfPath)
+		if err != nil {
+			return bosherr.WrapError(err, "Reading grub")
+		}
 	}
 
 	if strings.Contains(grubConf, grubIPv6DisableOpt) {


### PR DESCRIPTION
The introduction of the EFI (Extensible Firmware Interface) as a replacement of the BIOS (Basic Input/Output System) on the vSphere Jammy stemcell had an unintended consequence: any VM deployed with an IPv6 address became unresponsive.

The cause was the change of the location of the `grub.cfg` file: `/boot/grub/grub.cfg` → `/boot/efi/EFI/grub/grub.cfg`. The Agent needs to modify `grub.cfg` to remove the kernel commandline directive explicitly disallowing IPv6 (`ipv6.disable=1`).

The fix was simple: check the BIOS location, and if that fails, fall back to the EFI location.

Fixes, from `/var/vcap/bosh/log/current`:

```
ERROR - Agent exited with error: Running bootstrap: Setting up networking: Enabling IPv6 in kernel: Reading grub: Opening file /boot/grub/grub.cfg: open /boot/grub/grub.cfg: no such file or directory
```

The fix was tested on a custom-built 1.464 Jammy vSphere stemcell and deployed to an HAProxy VM with both IPv4 & IPv6 interfaces.

Commentary: A reasonable question is, "why go to the trouble of disabling IPv6 via a kernel commandline? Isn't that overkill?"

And the answer is that IPv6 was terrifying to the more conservative users back in 2015, and they insisted on disabling it via several mechanisms (kernel, network configuration). Thankfully the landscape today is much different.