### PR TITLE
Noble VMs on AWS don't have /dev/sdX devices for some reason.

### DIFF
--- a/infrastructure/devicepathresolver/mapped_device_path_resolver.go
+++ b/infrastructure/devicepathresolver/mapped_device_path_resolver.go
@@ -1,6 +1,7 @@
 package devicepathresolver
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -56,16 +57,17 @@ func (dpr mappedDevicePathResolver) findPossibleDevice(devicePath string) (strin
 	needsMapping := strings.HasPrefix(devicePath, "/dev/sd")
 
 	if needsMapping { //nolint:nestif
-		pathSuffix := strings.Split(devicePath, "/dev/sd")[1]
+		pathLetterSuffix := strings.Split(devicePath, "/dev/sd")[1]
+		pathNumberSuffix := fmt.Sprintf("%d", pathLetterSuffix[0]-97) // a=0, b=1
 
-		possiblePrefixes := []string{
-			"/dev/xvd", // Xen
-			"/dev/vd",  // KVM
-			"/dev/sd",
+		possiblePaths := []string{
+			"/dev/xvd" + pathLetterSuffix, // Xen
+			"/dev/vd" + pathLetterSuffix,  // KVM
+			"/dev/sd" + pathLetterSuffix,
+			"/dev/nvme" + pathNumberSuffix + "n1", // Nitro instances with Noble
 		}
 
-		for _, prefix := range possiblePrefixes {
-			path := prefix + pathSuffix
+		for _, path := range possiblePaths {
 			if dpr.fs.FileExists(path) {
 				return path, true, nil
 			}

--- a/infrastructure/devicepathresolver/mapped_device_path_resolver_test.go
+++ b/infrastructure/devicepathresolver/mapped_device_path_resolver_test.go
@@ -90,6 +90,20 @@ var _ = Describe("mappedDevicePathResolver", func() {
 		})
 	})
 
+	Context("when a matching /dev/nvmeXn1 device is found", func() {
+		BeforeEach(func() {
+			err := fs.WriteFile("/dev/nvme0n1", []byte{})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("returns the match", func() {
+			realPath, timedOut, err := resolver.GetRealDevicePath(diskSettings)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(timedOut).To(BeFalse())
+			Expect(realPath).To(Equal("/dev/nvme0n1"))
+		})
+	})
+
 	Context("when no matching device is found the first time", func() {
 		Context("when the timeout has not expired", func() {
 			BeforeEach(func() {


### PR DESCRIPTION
We'd like to use the idDevicePathResolver and disk hints instead, but we don't actually know the volume id for the ephemeral disk until the instance is created at which point it's too late to put the disk into into the metadata because the VM has to be in a stopped state to do that.

So instead, we just guess here and hope the nvme devices match up. Which isn't much worse than what we were doing before, but AWS was also just sort of hoping that the device would end up on /dev/sdb.