### PR TITLE
Disable error messages related to networks/network interface cards

### DIFF
--- a/agent/bootstrap_test.go
+++ b/agent/bootstrap_test.go
@@ -1209,14 +1209,6 @@ var _ = Describe("bootstrap", func() {
 							}`
 				})
 
-				Context("and no physical network interfaces exist", func() {
-					It("raises an error", func() {
-						err := boot.Run()
-						Expect(err).To(HaveOccurred())
-						Expect(err.Error()).To(ContainSubstring("Number of network settings '1' is greater than the number of network devices '0"))
-					})
-				})
-
 				Context("and a single physical network interface exists", func() {
 					BeforeEach(func() {
 						stubInterfaces([][]string{{"eth0", "aa:bb:cc"}})
@@ -1262,14 +1254,6 @@ var _ = Describe("bootstrap", func() {
 									}
 								}
 							}`
-				})
-
-				Context("and no physical network interfaces exist", func() {
-					It("raises an error", func() {
-						err := boot.Run()
-						Expect(err).To(HaveOccurred())
-						Expect(err.Error()).To(ContainSubstring("Number of network settings '1' is greater than the number of network devices '0"))
-					})
 				})
 
 				Context("and a single physical network interface exists", func() {
@@ -1336,10 +1320,9 @@ var _ = Describe("bootstrap", func() {
 						stubInterfaces([][]string{{"eth0", "aa:bb:cc"}})
 					})
 
-					It("raises an error", func() {
+					It("succeeds", func() {
 						err := boot.Run()
-						Expect(err).To(HaveOccurred())
-						Expect(err.Error()).To(ContainSubstring("Number of network settings '2' is greater than the number of network devices '1"))
+						Expect(err).ToNot(HaveOccurred())
 					})
 				})
 

--- a/platform/net/interface_configuration_creator.go
+++ b/platform/net/interface_configuration_creator.go
@@ -126,10 +126,6 @@ func NewInterfaceConfigurationCreator(logger boshlog.Logger) InterfaceConfigurat
 }
 
 func (creator interfaceConfigurationCreator) CreateInterfaceConfigurations(networks boshsettings.Networks, interfacesByMAC map[string]string) ([]StaticInterfaceConfiguration, []DHCPInterfaceConfiguration, error) {
-	if !networks.HasInterfaceAlias() && len(interfacesByMAC) < len(networks) {
-		return nil, nil, bosherr.Errorf("Number of network settings '%d' is greater than the number of network devices '%d'", len(networks), len(interfacesByMAC))
-	}
-
 	// In cases where we only have one network and it has no MAC address (either because the IAAS doesn't give us one or
 	// it's an old CPI), if we only have one interface, we should map them
 	if len(networks) == 1 && len(interfacesByMAC) == 1 {

--- a/platform/net/interface_configuration_creator_test.go
+++ b/platform/net/interface_configuration_creator_test.go
@@ -136,18 +136,6 @@ var _ = Describe("InterfaceConfigurationCreator", func() {
 						Expect(len(dhcpInterfaceConfigurations)).To(Equal(0))
 					})
 				})
-
-				Context("And there are no network devices", func() {
-					BeforeEach(func() {
-						interfacesByMAC = map[string]string{}
-					})
-
-					It("returns an error", func() {
-						_, _, err := interfaceConfigurationCreator.CreateInterfaceConfigurations(networks, interfacesByMAC)
-						Expect(err).To(HaveOccurred())
-						Expect(err.Error()).To(ContainSubstring("Number of network settings '1' is greater than the number of network devices '0'"))
-					})
-				})
 			})
 
 			Context("And the network has an alias", func() {


### PR DESCRIPTION
Some iaas (e.g. AWS) support dual-stack network interface cards. However as bosh only supports to provide one range (either ipv4 or ipv6) in the cloud config two networks need to be defined to specify both ranges. Therefore the error message can be deleted.