### PR TITLE
Fix Network Resolution For IPv6 addresses

### DIFF
--- a/platform/net/ip/ip_resolver.go
+++ b/platform/net/ip/ip_resolver.go
@@ -49,7 +49,7 @@ func (r ipResolver) GetPrimaryIP(interfaceName string, ipProtocol IPProtocol) (*
 			continue
 		}
 
-		if ip.IP.To16() != nil && ip.IP.IsGlobalUnicast() && ipProtocol == IPv6 {
+		if ip.IP.To4() == nil && ip.IP.IsGlobalUnicast() && ipProtocol == IPv6 {
 			return ip, nil
 		}
 

--- a/platform/net/ip/ip_resolver_test.go
+++ b/platform/net/ip/ip_resolver_test.go
@@ -72,6 +72,19 @@ var _ = Describe("ipResolver", func() {
 				Expect(ip.String()).To(Equal("ff::/64"))
 			})
 
+			It("returns first non-local ipv6 address if available from associated interface", func() {
+				addrs = []gonet.Addr{
+					NotIPNet{},
+					&gonet.IPNet{IP: gonet.ParseIP("10.0.73.0"), Mask: gonet.CIDRMask(19, 32)},
+					&gonet.IPNet{IP: gonet.ParseIP("2001:db8::103"), Mask: gonet.CIDRMask(128, 128)},
+					&gonet.IPNet{IP: gonet.ParseIP("3fff::100"), Mask: gonet.CIDRMask(64, 128)},
+				}
+
+				ip, err := ipResolver.GetPrimaryIP("fake-iface-name", IPv6)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ip.String()).To(Equal("2001:db8::103/128"))
+			})
+
 			It("returns error if associated interface does not have any addresses", func() {
 				addrs = []gonet.Addr{}
 


### PR DESCRIPTION
When resolving for IPv6 Addresses, in some cases the GetPrimaryIP method still returns IPv4 Addresses (Depending on the sorting of the Addresses on the network interface), because the To16() method just checks if the ip address is a valid ip address or not. Actually the To4() method is the correct one to use as it returns something if the ip address is Ipv4 and "nil" if the ip address is Ipv6. We introduced this with https://github.com/cloudfoundry/bosh-agent/pull/351 . We thought our unit test cases covered all scenarios, but missed this one. Added a separate test as well for this case.