### PR TITLE
Update Windows integration test fixture

### DIFF
--- a/integration/windows/fixtures/psFixture/psFixture.psm1
+++ b/integration/windows/fixtures/psFixture/psFixture.psm1
@@ -13,19 +13,19 @@ function Protect-Path {
     )
 
     Write-Log "Protect-Path: Grant Administrator"
-    cmd.exe /c cacls.exe $path /E /P Administrators:F
+    icacls.exe $path /grant "Administrators:(OI)(CI)F"
     if ($LASTEXITCODE -ne 0) {
         Throw "Error setting ACL for $path exited with $LASTEXITCODE"
     }
 
     Write-Log "Protect-Path: Remove BUILTIN\Users"
-    cmd.exe /c cacls.exe $path /E /R "BUILTIN\Users"
+    icacls.exe $path /remove "BUILTIN\Users"
     if ($LASTEXITCODE -ne 0) {
         Throw "Error setting ACL for $path exited with $LASTEXITCODE"
     }
 
     Write-Log "Protect-Path: Remove BUILTIN\IIS_IUSRS"
-    cmd.exe /c cacls.exe $path /E /R "BUILTIN\IIS_IUSRS"
+    icacls.exe $path /remove "BUILTIN\IIS_IUSRS"
     if ($LASTEXITCODE -ne 0) {
         Throw "Error setting ACL for $path exited with $LASTEXITCODE"
     }


### PR DESCRIPTION
cacls.exe is deprecated, and should be replaced with icacls.

We are seeing integration test failures coinciding with a Windows update that take the form:
```
 [FAILED] Expected data directory to have correct ACLs. Counted 1 errors.
  'Check-Acls C:\var\vcap\data\' command output: 
  Adding 2016 ACLs
  5
  Error (C:\var\vcap\data\testfile): BUILTIN\Users,Allow

  Expected
      <bool>: false
  to be true
```

Attempting to update this deprecated tool to see if that fixes the error.