### PR TITLE
unit test fixes

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -237,7 +237,7 @@ jobs:
           input_mapping:
             bosh-agent: bumped-bosh-agent
           tags:
-            - windows-nimbus
+            - windows-2019
       - put: bosh-agent
         params:
           repository: bumped-bosh-agent

--- a/platform/windows_platform_test.go
+++ b/platform/windows_platform_test.go
@@ -380,10 +380,10 @@ var _ = Describe("WindowsPlatform", func() {
 
 			// Use '/Windows' to make the fakefilesystem happy...
 			Expect(len(fs.RenameOldPaths)).To(Equal(1))
-			Expect(fs.RenameOldPaths).To(ContainElement("/Windows/System32/Drivers/etc/hosts-fake-uuid-0"))
+			Expect(strings.ToLower(fs.RenameOldPaths[0])).To(Equal("/windows/system32/drivers/etc/hosts-fake-uuid-0"))
 
 			Expect(len(fs.RenameNewPaths)).To(Equal(1))
-			Expect(fs.RenameNewPaths).To(ContainElement("/Windows/System32/Drivers/etc/hosts"))
+			Expect(strings.ToLower(fs.RenameNewPaths[0])).To(Equal("/windows/system32/drivers/etc/hosts"))
 		})
 	})
 


### PR DESCRIPTION
- compare case insenstively when testing paths in case the OS has C:/WINDOWS instead of C:/Windows
- add a 2019 worker tag to make sure we are running on the right concourse worker