### PR TITLE
Ensure mount point directory exists before mounting persistent disk for filesystem growing

### DIFF
--- a/platform/linux_platform.go
+++ b/platform/linux_platform.go
@@ -1303,6 +1303,11 @@ func (p linux) AdjustPersistentDiskPartitioning(diskSetting boshsettings.DiskSet
 			return bosherr.WrapError(err, "Resizing disk partition")
 		}
 
+		err = p.fs.MkdirAll(mountPoint, persistentDiskPermissions)
+		if err != nil {
+			return bosherr.WrapErrorf(err, "Creating directory %s", mountPoint)
+		}
+
 		err := p.diskManager.GetMounter().Mount(firstPartitionPath, mountPoint, diskSetting.MountOptions...)
 		if err != nil {
 			return bosherr.WrapError(err, "Failed to mount partition for filesystem growing")


### PR DESCRIPTION
Encountered this when migrating from N2 to N4 machine types on GCP while also changing disk type from pd-ssd to hyperdisk-balanced and increasing disk size (1GB/2GB -> 4GB).

[AdjustPersistentDiskPartitioning](https://github.com/cloudfoundry/bosh-agent/blob/b870cb59dd802aca1a5767d99d44b459e5af69fb/platform/linux_platform.go#L1306) has a path that temporarily mounts the persistent disk to grow the filesystem after resizing the partition. Unlike [MountPersistentDisk](https://github.com/cloudfoundry/bosh-agent/blob/b870cb59dd802aca1a5767d99d44b459e5af69fb/platform/linux_platform.go#L1372), it doesn't create the mount point directory first. On a freshly recreated VM, `/var/vcap/store` doesn't exist yet, so the mount fails:

This was never triggered because it requires a very specific condition: the disk must already have a partition that doesn't fill the whole disk. That doesn't happen in normal operations - but when the CPI changes disk types via snapshot-and-recreate, it copies the old (smaller) partition table onto a larger disk, which is exactly what triggers it.

Fix: add `MkdirAll` before the mount, same as [MountPersistentDisk](https://github.com/cloudfoundry/bosh-agent/blob/b870cb59dd802aca1a5767d99d44b459e5af69fb/platform/linux_platform.go#L1372) already does.

```
> mount /dev/nvme0n2p1
/var/vcap/store
mount: /var/vcap/store: mount point does not exist.
```