### PR TITLE
better network interface name validation

### DIFF
--- a/platform/net/interface_configuration_creator.go
+++ b/platform/net/interface_configuration_creator.go
@@ -2,6 +2,7 @@ package net
 
 import (
 	"net"
+	"unicode"
 
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 	boshlog "github.com/cloudfoundry/bosh-utils/logger"
@@ -126,6 +127,25 @@ func NewInterfaceConfigurationCreator(logger boshlog.Logger) InterfaceConfigurat
 	}
 }
 
+// validateInterfaceName follows the rules of the Linux kernel's dev_valid_name()
+// (net/core/dev.c) but permits ':' for IP alias names (e.g. eth0:0) and omits
+// the IFNAMSIZ length check since aliases are configuration labels, not kernel
+// device names.
+func validateInterfaceName(name string) error {
+	if name == "" {
+		return bosherr.Errorf("interface name must not be empty")
+	}
+	if name == "." || name == ".." {
+		return bosherr.Errorf("invalid interface name %q", name)
+	}
+	for _, c := range name {
+		if c == '/' || unicode.IsSpace(c) {
+			return bosherr.Errorf("invalid interface name %q: must not contain '/' or whitespace", name)
+		}
+	}
+	return nil
+}
+
 func (creator interfaceConfigurationCreator) CreateInterfaceConfigurations(networks boshsettings.Networks, interfacesByMAC map[string]string) ([]StaticInterfaceConfiguration, []DHCPInterfaceConfiguration, error) {
 	// In cases where we only have one network and it has no MAC address (either because the IAAS doesn't give us one or
 	// it's an old CPI), if we only have one interface, we should map them
@@ -173,6 +193,10 @@ func (creator interfaceConfigurationCreator) createMultipleInterfaceConfiguratio
 	for _, networkSettings = range networks {
 		if networkSettings.Mac != "" || networkSettings.Alias == "" {
 			continue
+		}
+
+		if err = validateInterfaceName(networkSettings.Alias); err != nil {
+			return nil, nil, bosherr.WrapError(err, "Creating interface configuration using alias")
 		}
 
 		staticConfigs, dhcpConfigs, err = creator.createInterfaceConfiguration(staticConfigs, dhcpConfigs, networkSettings.Alias, networkSettings)

--- a/platform/net/interface_configuration_creator_test.go
+++ b/platform/net/interface_configuration_creator_test.go
@@ -361,6 +361,48 @@ var _ = Describe("InterfaceConfigurationCreator", func() {
 				})
 			})
 
+			Context("when a network alias fails interface name validation", func() {
+				BeforeEach(func() {
+					networks["bar"] = dhcpNetwork
+					interfacesByMAC[dhcpNetwork.Mac] = "dhcp-interface-name"
+				})
+
+				It("returns an error when alias contains a forward slash", func() {
+					staticNetworkWithoutMAC.Alias = "/../../../../foo/bar"
+					networks["foo"] = staticNetworkWithoutMAC
+					_, _, err := interfaceConfigurationCreator.CreateInterfaceConfigurations(networks, interfacesByMAC)
+					Expect(err).To(HaveOccurred())
+				})
+
+				It("returns an error when alias contains whitespace", func() {
+					staticNetworkWithoutMAC.Alias = "eth0 bad"
+					networks["foo"] = staticNetworkWithoutMAC
+					_, _, err := interfaceConfigurationCreator.CreateInterfaceConfigurations(networks, interfacesByMAC)
+					Expect(err).To(HaveOccurred())
+				})
+
+				It("returns an error when alias is exactly '.'", func() {
+					staticNetworkWithoutMAC.Alias = "."
+					networks["foo"] = staticNetworkWithoutMAC
+					_, _, err := interfaceConfigurationCreator.CreateInterfaceConfigurations(networks, interfacesByMAC)
+					Expect(err).To(HaveOccurred())
+				})
+
+				It("returns an error when alias is exactly '..'", func() {
+					staticNetworkWithoutMAC.Alias = ".."
+					networks["foo"] = staticNetworkWithoutMAC
+					_, _, err := interfaceConfigurationCreator.CreateInterfaceConfigurations(networks, interfacesByMAC)
+					Expect(err).To(HaveOccurred())
+				})
+
+				It("succeeds when alias contains a colon (IP alias convention)", func() {
+					staticNetworkWithoutMAC.Alias = "eth0:0"
+					networks["foo"] = staticNetworkWithoutMAC
+					_, _, err := interfaceConfigurationCreator.CreateInterfaceConfigurations(networks, interfacesByMAC)
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+
 			Context("when static network has postup routes, dhcp network has no postup routes", func() {
 				BeforeEach(func() {
 					staticNetwork.Routes = []boshsettings.Route{

--- a/platform/net/ubuntu_net_manager_test.go
+++ b/platform/net/ubuntu_net_manager_test.go
@@ -228,6 +228,31 @@ var _ = Describe("ubuntuNetManager", func() {
 				Expect(dhcpInterfaceConfigurations).To(BeEmpty())
 				Expect(dnsServers).To(Equal([]string{"54.209.78.6", "127.0.0.5"}))
 			})
+
+			It("returns an error when alias is invalid", func() {
+				networks := boshsettings.Networks{
+					"default": factory.Network{
+						IP:      "10.10.0.32",
+						Netmask: "255.255.255.0",
+						Mac:     "mac-1",
+						Default: []string{"dns", "gateway"},
+						DNS:     &[]string{"8.8.8.8"},
+						Gateway: "10.10.0.1",
+					}.Build(),
+					"second": factory.Network{
+						IP:      "10.10.0.33",
+						Netmask: "255.255.255.0",
+						DNS:     &[]string{"8.8.8.8"},
+						Gateway: "10.10.0.1",
+						Alias:   "/../../../../foo/bar",
+					}.Build(),
+				}
+				addresses := map[string]string{"mac-1": "eth0"}
+				fakeMACAddressDetector.DetectMacAddressesReturns(addresses, nil)
+
+				_, _, _, err := netManager.ComputeNetworkConfig(networks)
+				Expect(err).To(HaveOccurred())
+			})
 		})
 	})
 


### PR DESCRIPTION
this (mostly) matches what the kernel allows and throws an error message if it is not allowed. We don't validate for length since bosh uses eth0:0 for virtual interfaces so we don't know a max length.