### PR TITLE
Support multi nats

### DIFF
--- a/agent/bootstrap.go
+++ b/agent/bootstrap.go
@@ -96,7 +96,7 @@ func (boot bootstrap) Run() (err error) { //nolint:gocyclo
 		return bosherr.WrapError(err, "Setting up hostname")
 	}
 
-	if err = boot.platform.SetupNetworking(settings.Networks, settings.GetMbusURL()); err != nil {
+	if err = boot.platform.SetupNetworking(settings.Networks, settings.GetMbusURLs()); err != nil {
 		return bosherr.WrapError(err, "Setting up networking")
 	}
 

--- a/agent/bootstrap_test.go
+++ b/agent/bootstrap_test.go
@@ -266,9 +266,9 @@ var _ = Describe("bootstrap", func() {
 			err := bootstrap()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(platform.SetupNetworkingCallCount()).To(Equal(1))
-			net, mbusURL := platform.SetupNetworkingArgsForCall(0)
+			net, mbusURLs := platform.SetupNetworkingArgsForCall(0)
 			Expect(net).To(Equal(networks))
-			Expect(mbusURL).To(Equal(mbus))
+			Expect(mbusURLs).To(Equal([]string{mbus}))
 
 		})
 

--- a/bin/repack-stemcell/repack-vsphere.sh
+++ b/bin/repack-stemcell/repack-vsphere.sh
@@ -1,0 +1,161 @@
+#!/bin/bash -eu
+#
+# Repack a vSphere stemcell with a locally compiled bosh-agent binary.
+#
+# This script must run on Linux because it mounts disk images. On macOS, run it
+# inside the bosh/agent Docker image, which already has the right Go toolchain.
+# The bosh-agent source tree is bind-mounted into the container so the freshly
+# compiled binary is used.
+#
+# --- macOS usage ---
+#
+# 1. Download a full (non-light) vSphere stemcell, e.g.:
+#      curl -L -o /tmp/bosh-stemcell.tgz \
+#        https://bosh.io/d/stemcells/bosh-vsphere-esxi-ubuntu-jammy-go_agent
+#
+# 2. Run from the root of the bosh-agent checkout:
+#      docker run --privileged \
+#        -v $(pwd):/bosh-agent \
+#        -v /tmp:/stemcell \
+#        -w /bosh-agent \
+#        bosh/agent \
+#        bash -c "apt-get install -y -q qemu-utils 2>&1 | tail -3 && \
+#                 bin/repack-stemcell/repack-vsphere.sh \
+#                   /stemcell/bosh-stemcell.tgz <new-version> && \
+#                 cp /tmp/stemcell-vsphere-repacked.tgz /stemcell/"
+#
+#    Replace <new-version> with any version string, e.g. 1.1202.1
+#    --privileged is required for loop device mounts.
+#
+# The repacked stemcell is written to /tmp/stemcell-vsphere-repacked.tgz
+# (inside the container). The example above copies it back to /tmp on the host.
+
+if [ $# != 2 ]; then
+  echo "USAGE: repack-vsphere.sh <base-stemcell.tgz> <new-version>"
+  exit 2
+fi
+
+stemcell_path=$(realpath "$1")
+VERSION="$2"
+
+input_stemcell=$(mktemp -d)
+input_disk=$(mktemp -d)
+chroot_dir=$(mktemp -d)
+output_stemcell=$(mktemp -d)
+raw_disk=$(mktemp)
+output_path=/tmp/stemcell-vsphere-repacked.tgz
+
+cleanup() {
+  if mountpoint -q "$chroot_dir" 2>/dev/null; then
+    umount "$chroot_dir"
+  fi
+  rm -f "$raw_disk"
+  rm -rf "$input_stemcell" "$input_disk" "$chroot_dir" "$output_stemcell"
+}
+trap cleanup EXIT
+
+echo "Building agent..."
+bosh_agent_root="$(dirname "$0")/../.."
+"$bosh_agent_root/bin/build-linux-amd64"
+agent_bin="$bosh_agent_root/out/bosh-agent"
+
+echo "Extracting input stemcell..."
+tar -xzf "$stemcell_path" -C "$input_stemcell"
+tar -xzf "$input_stemcell/image" -C "$input_disk"
+
+vmdk=$(find "$input_disk" -name '*.vmdk' | head -1)
+if [ -z "$vmdk" ]; then
+  echo "ERROR: no .vmdk found inside stemcell image"
+  exit 1
+fi
+echo "Found disk image: $vmdk"
+
+# vSphere stemcells use stream-optimized VMDKs which can't be directly
+# block-device-mounted. Convert to raw, read the partition offset with python3
+# (guaranteed present as a qemu-utils dependency), then mount with an explicit
+# offset — no partition device nodes needed.
+echo "Converting VMDK to raw (this may take a minute)..."
+qemu-img convert -f vmdk -O raw "$vmdk" "$raw_disk"
+
+echo "Finding partition offset..."
+# Finds the Linux root filesystem partition (not the EFI boot partition).
+# Handles both GPT (looks for Linux filesystem type GUID) and MBR (type 0x83).
+start_sector=$(python3 - "$raw_disk" <<'PYEOF'
+import struct, sys
+
+# Linux filesystem type GUID (mixed-endian as stored on disk):
+# 0FC63DAF-8483-4772-8E79-3D69D8477DE4
+LINUX_FS_GUID = bytes([0xAF,0x3D,0xC6,0x0F, 0x83,0x84, 0x72,0x47,
+                        0x8E,0x79, 0x3D,0x69,0xD8,0x47,0x7D,0xE4])
+
+with open(sys.argv[1], 'rb') as f:
+    header = f.read(1024)
+
+if header[512:520] == b'EFI PART':
+    part_entry_lba = struct.unpack_from('<Q', header, 512 + 72)[0]
+    num_entries    = struct.unpack_from('<I', header, 512 + 80)[0]
+    entry_size     = struct.unpack_from('<I', header, 512 + 84)[0]
+    with open(sys.argv[1], 'rb') as f:
+        f.seek(part_entry_lba * 512)
+        table = f.read(num_entries * entry_size)
+    # Prefer the Linux filesystem partition; fall back to first non-empty entry
+    fallback = None
+    for i in range(num_entries):
+        e = table[i*entry_size:(i+1)*entry_size]
+        start = struct.unpack_from('<Q', e, 32)[0]
+        if start == 0:
+            continue
+        if fallback is None:
+            fallback = start
+        if e[0:16] == LINUX_FS_GUID:
+            print(start)
+            sys.exit(0)
+    print(fallback)
+else:
+    # MBR: prefer type 0x83 (Linux), fall back to first non-empty entry
+    fallback = None
+    for i in range(4):
+        e = header[446 + i*16 : 446 + (i+1)*16]
+        ptype = e[4]
+        start = struct.unpack_from('<I', e, 8)[0]
+        if start == 0:
+            continue
+        if fallback is None:
+            fallback = start
+        if ptype == 0x83:
+            print(start)
+            sys.exit(0)
+    print(fallback)
+PYEOF
+)
+if [ -z "$start_sector" ] || [ "$start_sector" -eq 0 ]; then
+  echo "ERROR: could not determine partition offset"
+  exit 1
+fi
+offset=$((start_sector * 512))
+echo "Partition start: sector $start_sector (offset $offset bytes)"
+
+mount -o loop,offset="$offset" "$raw_disk" "$chroot_dir"
+
+echo "Copying new bosh-agent..."
+cp "$agent_bin" "$chroot_dir/var/vcap/bosh/bin/bosh-agent"
+chmod 755 "$chroot_dir/var/vcap/bosh/bin/bosh-agent"
+
+echo "Unmounting and converting back to VMDK..."
+umount "$chroot_dir"
+
+qemu-img convert -f raw -O vmdk -o subformat=streamOptimized "$raw_disk" "$vmdk"
+
+echo "Repacking stemcell..."
+pushd "$input_disk"
+  tar czf "$input_stemcell/image" ./*
+popd
+
+pushd "$input_stemcell"
+  sed -i -e "s/^version:.*/version: $VERSION/" stemcell.MF
+  tar czf "$output_stemcell/stemcell.tgz" ./*
+popd
+
+cp "$output_stemcell/stemcell.tgz" "$output_path"
+echo ""
+echo "Done. Repacked stemcell: $output_path"

--- a/infrastructure/http_metadata_service.go
+++ b/infrastructure/http_metadata_service.go
@@ -286,7 +286,7 @@ func (ms HTTPMetadataService) ensureMinimalNetworkSetup() error {
 			"eth0": {
 				Type: boshsettings.NetworkTypeDynamic,
 			},
-		}, "")
+		}, nil)
 		if err != nil {
 			return bosherr.WrapError(err, "Setting up initial DHCP network")
 		}

--- a/integration/nats_firewall_test.go
+++ b/integration/nats_firewall_test.go
@@ -54,6 +54,77 @@ var _ = Describe("nats firewall", func() {
 		})
 	})
 
+	Context("multi-url", func() {
+		var dummyIP = "192.0.2.1" // RFC 5737 TEST-NET-1 — unreachable by design
+
+		BeforeEach(func() {
+			boshEnv := os.Getenv("BOSH_ENVIRONMENT")
+
+			fileSettings := settings.Settings{
+				AgentID: "fake-agent-id",
+				Blobstore: settings.Blobstore{
+					Type: "local",
+					Options: map[string]interface{}{
+						"blobstore_path": "/var/vcap/data",
+					},
+				},
+				Env: settings.Env{
+					Bosh: settings.BoshEnv{
+						Mbus: settings.MBus{
+							URLs: []string{
+								fmt.Sprintf("nats://%s:4222", dummyIP),
+								fmt.Sprintf("nats://%s:4222", boshEnv),
+							},
+						},
+					},
+				},
+				Disks: settings.Disks{
+					Ephemeral: "/dev/sdh",
+				},
+			}
+
+			err := testEnvironment.CreateSettingsFile(fileSettings)
+			Expect(err).ToNot(HaveOccurred())
+			err = testEnvironment.UpdateAgentConfig("file-settings-agent.json")
+			Expect(err).ToNot(HaveOccurred())
+			err = testEnvironment.AttachDevice("/dev/sdh", 128, 2)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Flush legacy iptables mangle rules as in the ipv4 case.
+			_, _ = testEnvironment.RunCommand("sudo iptables -t mangle -F")  //nolint:errcheck
+			_, _ = testEnvironment.RunCommand("sudo ip6tables -t mangle -F") //nolint:errcheck
+		})
+
+		AfterEach(func() {
+			err := testEnvironment.DetachDevice("/dev/sdh")
+			Expect(err).ToNot(HaveOccurred())
+			_, err = testEnvironment.RunCommand("sudo nft flush chain inet bosh_agent nats_access")
+			Expect(err).To(BeNil())
+		})
+
+		It("adds allow/block rules for both NATS server IPs", func() {
+			format.MaxLength = 0
+			boshEnv := os.Getenv("BOSH_ENVIRONMENT")
+
+			Eventually(func() string {
+				logs, _ := testEnvironment.RunCommand("sudo cat /var/vcap/bosh/log/current") //nolint:errcheck
+				return logs
+			}, 300).Should(ContainSubstring("Updated NATS firewall rules"))
+
+			output, err := testEnvironment.RunCommand("sudo nft list chain inet bosh_agent nats_access")
+			Expect(err).To(BeNil())
+			Expect(output).To(ContainSubstring("ct state established,related accept"))
+
+			// Rules for the real NATS server IP
+			Expect(output).To(MatchRegexp(`meta skuid 0 ip daddr %s tcp dport 4222 accept`, boshEnv))
+			Expect(output).To(MatchRegexp(`ip daddr %s tcp dport 4222 drop`, boshEnv))
+
+			// Rules for the dummy/unreachable IP
+			Expect(output).To(MatchRegexp(`meta skuid 0 ip daddr %s tcp dport 4222 accept`, dummyIP))
+			Expect(output).To(MatchRegexp(`ip daddr %s tcp dport 4222 drop`, dummyIP))
+		})
+	})
+
 	Context("ipv6", func() {
 		BeforeEach(func() {
 			fileSettings := settings.Settings{

--- a/integration/windows/fixtures/templates/agent-configuration/multi-nats-settings.json.tmpl
+++ b/integration/windows/fixtures/templates/agent-configuration/multi-nats-settings.json.tmpl
@@ -59,7 +59,7 @@
       "preconfigured": false
     }
   },
-  "mbus": "nats://192.0.2.2:4222",
+  "mbus": "nats://192.0.2.1:4222",
   "vm": {
     "name": "vm-1f1aaed4-b479-4cf5-b73e-a7cbf0abf4ae"
   },

--- a/integration/windows/fixtures/templates/agent-configuration/multi-nats-settings.json.tmpl
+++ b/integration/windows/fixtures/templates/agent-configuration/multi-nats-settings.json.tmpl
@@ -1,0 +1,67 @@
+{
+  "agent_id": "123-456-789",
+  "blobstore": {
+    "provider": "dav",
+    "options": {
+      "endpoint": "http://{{.NatsPrivateIP}}:25250",
+      "password": "password",
+      "user": "agent"
+    }
+  },
+  "disks": {
+    "system": "/dev/xvda",
+    "ephemeral": {{.EphemeralDiskConfig}},
+    "persistent": {},
+    "raw_ephemeral": null
+  },
+  "env": {
+    "bosh": {
+      "password": "",
+      "blobstores": [
+        {
+          "provider": "dav",
+          "options": {
+            "endpoint": "http://{{.NatsPrivateIP}}:25250",
+            "password": "password",
+            "user": "agent"
+          }
+        }
+      ],
+      "mbus": {
+        "cert": {
+          "ca": "{{.NatsCA}}",
+          "private_key": "{{.NatsPrivateKey}}",
+          "certificate": "{{.NatsCertificate}}"
+        },
+        "urls": [
+          "nats://192.0.2.1:4222",
+          "nats://nats:nats@{{.NatsPrivateIP}}:4222"
+        ]
+      }
+    }
+  },
+  "networks": {
+    "default": {
+      "type": "manual",
+      "ip": "{{.AgentIP}}",
+      "netmask": "{{.AgentNetmask}}",
+      "gateway": "{{.AgentGateway}}",
+      "resolved": false,
+      "use_dhcp": true,
+      "default": [
+        "dns",
+        "gateway"
+      ],
+      "dns": [
+        "8.8.8.8"
+      ],
+      "mac": "",
+      "preconfigured": false
+    }
+  },
+  "mbus": "nats://nats:nats@{{.NatsPrivateIP}}:4222",
+  "vm": {
+    "name": "vm-1f1aaed4-b479-4cf5-b73e-a7cbf0abf4ae"
+  },
+  "trusted_certs": ""
+}

--- a/integration/windows/fixtures/templates/agent-configuration/multi-nats-settings.json.tmpl
+++ b/integration/windows/fixtures/templates/agent-configuration/multi-nats-settings.json.tmpl
@@ -59,7 +59,7 @@
       "preconfigured": false
     }
   },
-  "mbus": "nats://nats:nats@{{.NatsPrivateIP}}:4222",
+  "mbus": "nats://192.0.2.2:4222",
   "vm": {
     "name": "vm-1f1aaed4-b479-4cf5-b73e-a7cbf0abf4ae"
   },

--- a/integration/windows/windows_suite_test.go
+++ b/integration/windows/windows_suite_test.go
@@ -48,6 +48,7 @@ var _ = BeforeSuite(func() {
 	templateEphemeralDiskSettings(natsIP, `"/dev/sdb"`, "second-disk-settings.json")
 	templateEphemeralDiskSettings(natsIP, `"1"`, "second-disk-digit-settings.json")
 	templateEphemeralDiskSettings(natsIP, `{"path": "/dev/sdc"}`, "third-disk-settings.json")
+	templateMultiNatsSettings(natsIP, `""`, "multi-nats-settings.json")
 
 	sshClient, err := utils.GetSSHTunnelClient()
 	Expect(err).ToNot(HaveOccurred())
@@ -102,6 +103,37 @@ func templateEphemeralDiskSettings(natsPrivateIP, ephemeralDiskConfig, filename 
 	Expect(err).NotTo(HaveOccurred())
 
 	outputFile, err := os.CreateTemp("", "agent-settings")
+	Expect(err).NotTo(HaveOccurred())
+	defer outputFile.Close() //nolint:errcheck
+
+	err = settingsTmpl.Execute(outputFile, agentSettings)
+	Expect(err).ToNot(HaveOccurred())
+	err = outputFile.Close()
+	Expect(err).ToNot(HaveOccurred())
+
+	command := exec.Command("scp", outputFile.Name(), fmt.Sprintf("%s:/bosh/agent-configuration/%s", utils.AgentIP(), filename))
+	session, err := gexec.Start(command, io.Discard, io.Discard)
+	Expect(err).NotTo(HaveOccurred())
+	Eventually(session, 1*time.Minute).Should(gexec.Exit(0))
+}
+
+func templateMultiNatsSettings(natsPrivateIP, ephemeralDiskConfig, filename string) {
+	agentSettings := BoshAgentSettings{
+		NatsPrivateIP:       natsPrivateIP,
+		EphemeralDiskConfig: ephemeralDiskConfig,
+		AgentIP:             utils.AgentIP(),
+		AgentNetmask:        utils.AgentNetmask(),
+		AgentGateway:        utils.AgentGateway(),
+		NatsCA:              strings.Replace(utils.NatsCA(), "\n", "\\n", -1),          //nolint:staticcheck
+		NatsCertificate:     strings.Replace(utils.NatsCertificate(), "\n", "\\n", -1), //nolint:staticcheck
+		NatsPrivateKey:      strings.Replace(utils.NatsPrivateKey(), "\n", "\\n", -1),  //nolint:staticcheck
+	}
+	settingsTmpl, err := template.ParseFiles(
+		filepath.Join(utils.AgentDir(), "integration", "windows", "fixtures", "templates", "agent-configuration", "multi-nats-settings.json.tmpl"),
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	outputFile, err := os.CreateTemp("", "multi-nats-agent-settings")
 	Expect(err).NotTo(HaveOccurred())
 	defer outputFile.Close() //nolint:errcheck
 

--- a/integration/windows/windows_test.go
+++ b/integration/windows/windows_test.go
@@ -109,6 +109,32 @@ var _ = Describe("An Agent running on Windows", func() {
 
 		Eventually(getStateSpecAgentID, DefaultTimeout, DefaultInterval).Should(Equal(agentGUID))
 	})
+	It("connects to NATS when the first server is unreachable", func() {
+		// Stop agent, switch to multi-NATS settings (first URL is 192.0.2.1 — RFC 5737
+		// documentation address, guaranteed unreachable; second URL is the real NATS server),
+		// restart agent, and assert it still answers get_state messages via the second server.
+		agent.EnsureAgentServiceStopped()
+		agent.RunPowershellCommand("cp c:\\bosh\\agent-configuration\\multi-nats-settings.json c:\\bosh\\settings.json")
+		agent.StartAgent()
+
+		getStateSpecAgentID := func() (string, error) {
+			message := fmt.Sprintf(`{"method":"get_state","arguments":[],"reply_to":"%s"}`, senderID)
+			rawResponse, err := natsClient.SendRawMessage(message)
+			if err != nil {
+				return "", err
+			}
+			response := map[string]action.GetStateV1ApplySpec{}
+			if err := json.Unmarshal(rawResponse, &response); err != nil {
+				return "", err
+			}
+			return response["value"].AgentID, nil
+		}
+
+		// Use a longer timeout: the NATS client will attempt the unreachable first URL before
+		// failing over to the working second URL.
+		Eventually(getStateSpecAgentID, 3*DefaultTimeout, DefaultInterval).Should(Equal(agentGUID))
+	})
+
 	It("its windows service is set to start automatically", func() {
 		output := agent.RunPowershellCommand("Get-Service -Name bosh-agent | select -property name,starttype")
 		Expect(output).To(MatchRegexp("bosh-agent *Automatic"))

--- a/mbus/nats_handler.go
+++ b/mbus/nats_handler.go
@@ -71,6 +71,7 @@ type natsHandler struct {
 type ConnectionInfo struct {
 	Addr      string
 	IP        string
+	IPs       []string
 	Dial      func(network, address string) (net.Conn, error)
 	TLSConfig *tls.Config
 }
@@ -102,8 +103,10 @@ func (h *natsHandler) arpClean() {
 		h.logger.Error(h.logTag, "Failed to get connection info for ARP clean: %v", err)
 		return
 	}
-	if err := h.platform.DeleteARPEntryWithIP(connectionInfo.IP); err != nil {
-		h.logger.Error(h.logTag, "Cleaning ip-mac address cache for: %s. Error: %v", connectionInfo.IP, err)
+	for _, ip := range connectionInfo.IPs {
+		if err := h.platform.DeleteARPEntryWithIP(ip); err != nil {
+			h.logger.Error(h.logTag, "Cleaning ip-mac address cache for: %s. Error: %v", ip, err)
+		}
 	}
 }
 
@@ -115,10 +118,8 @@ func (h *natsHandler) updateFirewallForNATS() {
 		return
 	}
 
-	settings := h.settingsService.GetSettings()
-	mbusURL := settings.GetMbusURL()
-
-	if err := hook.BeforeConnect(mbusURL); err != nil {
+	mbusURLs := h.settingsService.GetSettings().GetMbusURLs()
+	if err := hook.BeforeConnect(mbusURLs); err != nil {
 		// Log but don't fail - firewall update failure shouldn't prevent connection attempt
 		h.logger.Warn(h.logTag, "Failed to update NATS firewall rules: %v", err)
 	}
@@ -313,14 +314,23 @@ func (h *natsHandler) getConnectionInfo() (*ConnectionInfo, error) {
 	settings := h.settingsService.GetSettings()
 
 	connInfo := new(ConnectionInfo)
-	connInfo.Addr = settings.GetMbusURL()
-	natsURL, err := url.Parse(connInfo.Addr)
-	if err != nil {
-		return nil, bosherr.WrapError(err, "Parsing Nats URL")
-	}
+	mbusURLs := settings.GetMbusURLs()
 
-	hostSplit := strings.Split(natsURL.Host, ":")
-	connInfo.IP = hostSplit[0]
+	// Build comma-separated address string for nats.Connect cluster support.
+	connInfo.Addr = strings.Join(mbusURLs, ", ")
+
+	// Parse host IPs from each URL for ARP cleanup.
+	for _, rawURL := range mbusURLs {
+		natsURL, err := url.Parse(rawURL)
+		if err != nil {
+			return nil, bosherr.WrapErrorf(err, "Parsing Nats URL %q", rawURL)
+		}
+		hostSplit := strings.Split(natsURL.Host, ":")
+		connInfo.IPs = append(connInfo.IPs, hostSplit[0])
+	}
+	if len(connInfo.IPs) > 0 {
+		connInfo.IP = connInfo.IPs[0]
+	}
 
 	connInfo.TLSConfig = &tls.Config{MinVersion: tls.VersionTLS12}
 

--- a/mbus/nats_handler.go
+++ b/mbus/nats_handler.go
@@ -320,13 +320,13 @@ func (h *natsHandler) getConnectionInfo() (*ConnectionInfo, error) {
 	connInfo.Addr = strings.Join(mbusURLs, ", ")
 
 	// Parse host IPs from each URL for ARP cleanup.
+	// Use Hostname() so IPv6 addresses like [2001:db8::1] are returned without brackets.
 	for _, rawURL := range mbusURLs {
 		natsURL, err := url.Parse(rawURL)
 		if err != nil {
 			return nil, bosherr.WrapErrorf(err, "Parsing Nats URL %q", rawURL)
 		}
-		hostSplit := strings.Split(natsURL.Host, ":")
-		connInfo.IPs = append(connInfo.IPs, hostSplit[0])
+		connInfo.IPs = append(connInfo.IPs, natsURL.Hostname())
 	}
 	if len(connInfo.IPs) > 0 {
 		connInfo.IP = connInfo.IPs[0]

--- a/mbus/nats_handler_test.go
+++ b/mbus/nats_handler_test.go
@@ -425,14 +425,14 @@ func init() { //nolint:funlen,gochecknoinits
 					Expect(platform.GetNatsFirewallHookCallCount()).To(BeNumerically(">=", 1))
 				})
 
-				It("calls BeforeConnect with the mbus URL before initial connection", func() {
+				It("calls BeforeConnect with the mbus URLs before initial connection", func() {
 					err := handler.Start(func(req boshhandler.Request) (res boshhandler.Response) { return })
 					Expect(err).NotTo(HaveOccurred())
 					defer handler.Stop()
 
 					Expect(fakeFirewallHook.BeforeConnectCallCount()).To(Equal(1))
-					mbusURL := fakeFirewallHook.BeforeConnectArgsForCall(0)
-					Expect(mbusURL).To(Equal("nats://fake-username:fake-password@127.0.0.1:1234"))
+					mbusURLs := fakeFirewallHook.BeforeConnectArgsForCall(0)
+					Expect(mbusURLs).To(Equal([]string{"nats://fake-username:fake-password@127.0.0.1:1234"}))
 				})
 
 				It("does not fail if hook returns nil", func() {

--- a/mbus/nats_handler_test.go
+++ b/mbus/nats_handler_test.go
@@ -435,6 +435,25 @@ func init() { //nolint:funlen,gochecknoinits
 					Expect(mbusURLs).To(Equal([]string{"nats://fake-username:fake-password@127.0.0.1:1234"}))
 				})
 
+				It("passes all mbus URLs to BeforeConnect when multiple are configured", func() {
+					settingsService.Settings.Env.Bosh.Mbus.URLs = []string{
+						"nats://fake-username:fake-password@127.0.0.1:1234",
+						"nats://fake-username:fake-password@127.0.0.2:5678",
+					}
+					handler = mbus.NewNatsHandler(settingsService, connector, logger, platform)
+
+					err := handler.Start(func(req boshhandler.Request) (res boshhandler.Response) { return })
+					Expect(err).NotTo(HaveOccurred())
+					defer handler.Stop()
+
+					Expect(fakeFirewallHook.BeforeConnectCallCount()).To(Equal(1))
+					mbusURLs := fakeFirewallHook.BeforeConnectArgsForCall(0)
+					Expect(mbusURLs).To(Equal([]string{
+						"nats://fake-username:fake-password@127.0.0.1:1234",
+						"nats://fake-username:fake-password@127.0.0.2:5678",
+					}))
+				})
+
 				It("does not fail if hook returns nil", func() {
 					platform.GetNatsFirewallHookReturns(nil)
 

--- a/platform/dummy_platform.go
+++ b/platform/dummy_platform.go
@@ -196,7 +196,7 @@ func (p dummyPlatform) SetupHostname(hostname string) (err error) {
 	return
 }
 
-func (p dummyPlatform) SetupNetworking(networks boshsettings.Networks, mbus string) (err error) {
+func (p dummyPlatform) SetupNetworking(networks boshsettings.Networks, mbus []string) (err error) {
 	return
 }
 func (p dummyPlatform) GetConfiguredNetworkInterfaces() (interfaces []string, err error) {

--- a/platform/firewall/firewall.go
+++ b/platform/firewall/firewall.go
@@ -43,9 +43,9 @@ type Manager interface {
 	EnableMonitAccess() error
 
 	// SetupNATSFirewall creates firewall rules to protect NATS.
-	// Only root (UID 0) is allowed to connect to the resolved NATS address.
+	// Only root (UID 0) is allowed to connect to the resolved NATS addresses.
 	// This method resolves DNS and should be called before each connection attempt.
-	SetupNATSFirewall(mbusURL string) error
+	SetupNATSFirewall(mbusURLs []string) error
 
 	// Cleanup closes the nftables connection.
 	Cleanup() error
@@ -57,6 +57,6 @@ type Manager interface {
 //counterfeiter:generate . NatsFirewallHook
 type NatsFirewallHook interface {
 	// BeforeConnect is called before each NATS connection/reconnection attempt.
-	// It resolves the NATS URL and updates firewall rules with the resolved IP.
-	BeforeConnect(mbusURL string) error
+	// It resolves all NATS URLs and updates firewall rules with the resolved IPs.
+	BeforeConnect(mbusURLs []string) error
 }

--- a/platform/firewall/firewallfakes/fake_manager.go
+++ b/platform/firewall/firewallfakes/fake_manager.go
@@ -38,10 +38,10 @@ type FakeManager struct {
 	setupMonitFirewallReturnsOnCall map[int]struct {
 		result1 error
 	}
-	SetupNATSFirewallStub        func(string) error
+	SetupNATSFirewallStub        func([]string) error
 	setupNATSFirewallMutex       sync.RWMutex
 	setupNATSFirewallArgsForCall []struct {
-		arg1 string
+		arg1 []string
 	}
 	setupNATSFirewallReturns struct {
 		result1 error
@@ -212,15 +212,20 @@ func (fake *FakeManager) SetupMonitFirewallReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeManager) SetupNATSFirewall(arg1 string) error {
+func (fake *FakeManager) SetupNATSFirewall(arg1 []string) error {
+	var arg1Copy []string
+	if arg1 != nil {
+		arg1Copy = make([]string, len(arg1))
+		copy(arg1Copy, arg1)
+	}
 	fake.setupNATSFirewallMutex.Lock()
 	ret, specificReturn := fake.setupNATSFirewallReturnsOnCall[len(fake.setupNATSFirewallArgsForCall)]
 	fake.setupNATSFirewallArgsForCall = append(fake.setupNATSFirewallArgsForCall, struct {
-		arg1 string
-	}{arg1})
+		arg1 []string
+	}{arg1Copy})
 	stub := fake.SetupNATSFirewallStub
 	fakeReturns := fake.setupNATSFirewallReturns
-	fake.recordInvocation("SetupNATSFirewall", []interface{}{arg1})
+	fake.recordInvocation("SetupNATSFirewall", []interface{}{arg1Copy})
 	fake.setupNATSFirewallMutex.Unlock()
 	if stub != nil {
 		return stub(arg1)
@@ -237,13 +242,13 @@ func (fake *FakeManager) SetupNATSFirewallCallCount() int {
 	return len(fake.setupNATSFirewallArgsForCall)
 }
 
-func (fake *FakeManager) SetupNATSFirewallCalls(stub func(string) error) {
+func (fake *FakeManager) SetupNATSFirewallCalls(stub func([]string) error) {
 	fake.setupNATSFirewallMutex.Lock()
 	defer fake.setupNATSFirewallMutex.Unlock()
 	fake.SetupNATSFirewallStub = stub
 }
 
-func (fake *FakeManager) SetupNATSFirewallArgsForCall(i int) string {
+func (fake *FakeManager) SetupNATSFirewallArgsForCall(i int) []string {
 	fake.setupNATSFirewallMutex.RLock()
 	defer fake.setupNATSFirewallMutex.RUnlock()
 	argsForCall := fake.setupNATSFirewallArgsForCall[i]

--- a/platform/firewall/firewallfakes/fake_nats_firewall_hook.go
+++ b/platform/firewall/firewallfakes/fake_nats_firewall_hook.go
@@ -8,10 +8,10 @@ import (
 )
 
 type FakeNatsFirewallHook struct {
-	BeforeConnectStub        func(string) error
+	BeforeConnectStub        func([]string) error
 	beforeConnectMutex       sync.RWMutex
 	beforeConnectArgsForCall []struct {
-		arg1 string
+		arg1 []string
 	}
 	beforeConnectReturns struct {
 		result1 error
@@ -23,15 +23,20 @@ type FakeNatsFirewallHook struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeNatsFirewallHook) BeforeConnect(arg1 string) error {
+func (fake *FakeNatsFirewallHook) BeforeConnect(arg1 []string) error {
+	var arg1Copy []string
+	if arg1 != nil {
+		arg1Copy = make([]string, len(arg1))
+		copy(arg1Copy, arg1)
+	}
 	fake.beforeConnectMutex.Lock()
 	ret, specificReturn := fake.beforeConnectReturnsOnCall[len(fake.beforeConnectArgsForCall)]
 	fake.beforeConnectArgsForCall = append(fake.beforeConnectArgsForCall, struct {
-		arg1 string
-	}{arg1})
+		arg1 []string
+	}{arg1Copy})
 	stub := fake.BeforeConnectStub
 	fakeReturns := fake.beforeConnectReturns
-	fake.recordInvocation("BeforeConnect", []interface{}{arg1})
+	fake.recordInvocation("BeforeConnect", []interface{}{arg1Copy})
 	fake.beforeConnectMutex.Unlock()
 	if stub != nil {
 		return stub(arg1)
@@ -48,13 +53,13 @@ func (fake *FakeNatsFirewallHook) BeforeConnectCallCount() int {
 	return len(fake.beforeConnectArgsForCall)
 }
 
-func (fake *FakeNatsFirewallHook) BeforeConnectCalls(stub func(string) error) {
+func (fake *FakeNatsFirewallHook) BeforeConnectCalls(stub func([]string) error) {
 	fake.beforeConnectMutex.Lock()
 	defer fake.beforeConnectMutex.Unlock()
 	fake.BeforeConnectStub = stub
 }
 
-func (fake *FakeNatsFirewallHook) BeforeConnectArgsForCall(i int) string {
+func (fake *FakeNatsFirewallHook) BeforeConnectArgsForCall(i int) []string {
 	fake.beforeConnectMutex.RLock()
 	defer fake.beforeConnectMutex.RUnlock()
 	argsForCall := fake.beforeConnectArgsForCall[i]

--- a/platform/firewall/nftables_firewall.go
+++ b/platform/firewall/nftables_firewall.go
@@ -271,8 +271,12 @@ func (f *NftablesFirewall) SetupNATSFirewall(mbusURLs []string) error {
 		resolved = append(resolved, resolvedTarget{addrs: addrs, port: t.port, host: t.host})
 	}
 
-	// Ensure table and chain exist, then flush stale rules only when we have
-	// at least one successfully resolved address to replace them with.
+	if len(resolved) == 0 {
+		f.logger.Warn(f.logTag, "Skipping NATS firewall update: no targets resolved")
+		return nil
+	}
+
+	// At least one address resolved — safe to flush stale rules and replace them.
 	f.ensureTable()
 	f.ensureNATSChain()
 	f.conn.FlushChain(f.natsChain)
@@ -766,8 +770,7 @@ func parseNATSURL(mbusURL string) (string, int, error) {
 
 	host, portStr, err := net.SplitHostPort(u.Host)
 	if err != nil {
-		host = u.Hostname()
-		portStr = "4222"
+		return "", 0, fmt.Errorf("missing or invalid port in NATS URL %q: %w", mbusURL, err)
 	}
 
 	port, err := strconv.Atoi(portStr)

--- a/platform/firewall/nftables_firewall.go
+++ b/platform/firewall/nftables_firewall.go
@@ -225,60 +225,69 @@ func (f *NftablesFirewall) EnableMonitAccess() error {
 }
 
 // SetupNATSFirewall creates firewall rules to protect NATS.
+// It accepts a slice of NATS URLs, resolves each host, and adds allow+block rules
+// for every resolved IP in a single nftables flush.
 // This resolves DNS and should be called before each connection attempt.
-func (f *NftablesFirewall) SetupNATSFirewall(mbusURL string) error {
-	// Parse URL to get host and port
-	host, port, err := parseNATSURL(mbusURL)
-	if err != nil {
-		// Not an error for https URLs or empty URLs (create-env case)
-		f.logger.Info(f.logTag, "Skipping NATS firewall: %s", err)
+func (f *NftablesFirewall) SetupNATSFirewall(mbusURLs []string) error {
+	type hostPort struct {
+		host string
+		port int
+	}
+
+	var targets []hostPort
+	for _, mbusURL := range mbusURLs {
+		host, port, err := parseNATSURL(mbusURL)
+		if err != nil {
+			// Not an error for https URLs or empty URLs (create-env case)
+			f.logger.Info(f.logTag, "Skipping NATS firewall for %q: %s", mbusURL, err)
+			continue
+		}
+		targets = append(targets, hostPort{host, port})
+	}
+
+	if len(targets) == 0 {
 		return nil
 	}
 
-	// Resolve host to IP addresses
-	var addrs []net.IP
-	if ip := net.ParseIP(host); ip != nil {
-		addrs = []net.IP{ip}
-	} else {
-		addrs, err = f.resolver.LookupIP(host)
-		if err != nil {
-			f.logger.Warn(f.logTag, "DNS resolution failed for %s: %s", host, err)
-			return nil
-		}
-	}
-
-	f.logger.Debug(f.logTag, "Setting up NATS firewall for %s:%d (resolved to %v)", host, port, addrs)
-
-	// Ensure table exists
+	// Ensure table and chain exist, then flush stale rules.
 	f.ensureTable()
-
-	// Ensure NATS chain exists
 	f.ensureNATSChain()
-
-	// Flush NATS chain (removes old rules for previous IPs)
 	f.conn.FlushChain(f.natsChain)
 
-	// Allow return traffic for established/related connections
+	// Allow return traffic for established/related connections.
 	f.addConntrackRule(f.natsChain)
 
-	// Add rules for each resolved IP
-	for _, addr := range addrs {
-		f.addNATSAllowRule(addr, port)
-		f.addNATSBlockRule(addr, port)
+	// Resolve each host and add allow+block rules — all in one pending batch.
+	for _, t := range targets {
+		var addrs []net.IP
+		if ip := net.ParseIP(t.host); ip != nil {
+			addrs = []net.IP{ip}
+		} else {
+			var err error
+			addrs, err = f.resolver.LookupIP(t.host)
+			if err != nil {
+				f.logger.Warn(f.logTag, "DNS resolution failed for %s: %s", t.host, err)
+				continue
+			}
+		}
+		f.logger.Debug(f.logTag, "Setting up NATS firewall for %s:%d (resolved to %v)", t.host, t.port, addrs)
+		for _, addr := range addrs {
+			f.addNATSAllowRule(addr, t.port)
+			f.addNATSBlockRule(addr, t.port)
+		}
+		f.logger.Info(f.logTag, "Updated NATS firewall rules for %s:%d", t.host, t.port)
 	}
 
-	// Commit
 	if err := f.conn.Flush(); err != nil {
 		return bosherr.WrapError(err, "Flushing nftables rules")
 	}
 
-	f.logger.Info(f.logTag, "Updated NATS firewall rules for %s:%d", host, port)
 	return nil
 }
 
 // BeforeConnect implements NatsFirewallHook. Called before each NATS connection attempt.
-func (f *NftablesFirewall) BeforeConnect(mbusURL string) error {
-	return f.SetupNATSFirewall(mbusURL)
+func (f *NftablesFirewall) BeforeConnect(mbusURLs []string) error {
+	return f.SetupNATSFirewall(mbusURLs)
 }
 
 func (f *NftablesFirewall) Cleanup() error {

--- a/platform/firewall/nftables_firewall.go
+++ b/platform/firewall/nftables_firewall.go
@@ -249,15 +249,13 @@ func (f *NftablesFirewall) SetupNATSFirewall(mbusURLs []string) error {
 		return nil
 	}
 
-	// Ensure table and chain exist, then flush stale rules.
-	f.ensureTable()
-	f.ensureNATSChain()
-	f.conn.FlushChain(f.natsChain)
-
-	// Allow return traffic for established/related connections.
-	f.addConntrackRule(f.natsChain)
-
-	// Resolve each host and add allow+block rules — all in one pending batch.
+	// Resolve all hosts first so we can decide whether to flush.
+	type resolvedTarget struct {
+		addrs []net.IP
+		port  int
+		host  string
+	}
+	var resolved []resolvedTarget
 	for _, t := range targets {
 		var addrs []net.IP
 		if ip := net.ParseIP(t.host); ip != nil {
@@ -270,12 +268,26 @@ func (f *NftablesFirewall) SetupNATSFirewall(mbusURLs []string) error {
 				continue
 			}
 		}
-		f.logger.Debug(f.logTag, "Setting up NATS firewall for %s:%d (resolved to %v)", t.host, t.port, addrs)
-		for _, addr := range addrs {
-			f.addNATSAllowRule(addr, t.port)
-			f.addNATSBlockRule(addr, t.port)
+		resolved = append(resolved, resolvedTarget{addrs: addrs, port: t.port, host: t.host})
+	}
+
+	// Ensure table and chain exist, then flush stale rules only when we have
+	// at least one successfully resolved address to replace them with.
+	f.ensureTable()
+	f.ensureNATSChain()
+	f.conn.FlushChain(f.natsChain)
+
+	// Allow return traffic for established/related connections.
+	f.addConntrackRule(f.natsChain)
+
+	// Add allow+block rules for every resolved IP — all in one pending batch.
+	for _, rt := range resolved {
+		f.logger.Debug(f.logTag, "Setting up NATS firewall for %s:%d (resolved to %v)", rt.host, rt.port, rt.addrs)
+		for _, addr := range rt.addrs {
+			f.addNATSAllowRule(addr, rt.port)
+			f.addNATSBlockRule(addr, rt.port)
 		}
-		f.logger.Info(f.logTag, "Updated NATS firewall rules for %s:%d", t.host, t.port)
+		f.logger.Info(f.logTag, "Updated NATS firewall rules for %s:%d", rt.host, rt.port)
 	}
 
 	if err := f.conn.Flush(); err != nil {

--- a/platform/firewall/nftables_firewall_test.go
+++ b/platform/firewall/nftables_firewall_test.go
@@ -446,17 +446,19 @@ var _ = Describe("NftablesFirewall", func() {
 				Expect(err).NotTo(HaveOccurred()) // Should not return error, just log warning
 
 				Expect(fakeResolver.LookupIPCallCount()).To(Equal(1))
-				// Base conntrack rule is still added; per-IP allow/block rules are skipped.
-				Expect(fakeConn.AddRuleCallCount()).To(Equal(1))
+				// Chain is not flushed and no rules are added when all DNS lookups fail.
+				Expect(fakeConn.AddTableCallCount()).To(Equal(0))
+				Expect(fakeConn.AddRuleCallCount()).To(Equal(0))
 			})
 		})
 
-		Context("with default port", func() {
-			It("uses port 4222 when not specified", func() {
+		Context("with missing port", func() {
+			It("skips the URL and adds no rules", func() {
 				err := manager.SetupNATSFirewall([]string{"nats://192.168.1.100"})
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(fakeConn.AddRuleCallCount()).To(Equal(3))
+				Expect(fakeConn.AddTableCallCount()).To(Equal(0))
+				Expect(fakeConn.AddRuleCallCount()).To(Equal(0))
 			})
 		})
 

--- a/platform/firewall/nftables_firewall_test.go
+++ b/platform/firewall/nftables_firewall_test.go
@@ -446,7 +446,8 @@ var _ = Describe("NftablesFirewall", func() {
 				Expect(err).NotTo(HaveOccurred()) // Should not return error, just log warning
 
 				Expect(fakeResolver.LookupIPCallCount()).To(Equal(1))
-				Expect(fakeConn.AddRuleCallCount()).To(Equal(0)) // No rules added
+				// Base conntrack rule is still added; per-IP allow/block rules are skipped.
+				Expect(fakeConn.AddRuleCallCount()).To(Equal(1))
 			})
 		})
 

--- a/platform/firewall/nftables_firewall_test.go
+++ b/platform/firewall/nftables_firewall_test.go
@@ -340,9 +340,9 @@ var _ = Describe("NftablesFirewall", func() {
 	})
 
 	Describe("SetupNATSFirewall", func() {
-		Context("with an IPv4 address URL", func() {
+		Context("with a single IPv4 address URL", func() {
 			It("creates rules for the IPv4 address", func() {
-				err := manager.SetupNATSFirewall("nats://user:pass@192.168.1.100:4222")
+				err := manager.SetupNATSFirewall([]string{"nats://user:pass@192.168.1.100:4222"})
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(fakeConn.AddTableCallCount()).To(Equal(1))
@@ -354,7 +354,7 @@ var _ = Describe("NftablesFirewall", func() {
 			})
 
 			It("creates chain with correct configuration", func() {
-				err := manager.SetupNATSFirewall("nats://192.168.1.100:4222")
+				err := manager.SetupNATSFirewall([]string{"nats://192.168.1.100:4222"})
 				Expect(err).NotTo(HaveOccurred())
 
 				chain := fakeConn.AddChainArgsForCall(0)
@@ -364,7 +364,7 @@ var _ = Describe("NftablesFirewall", func() {
 			})
 
 			It("adds conntrack established,related rule as first rule", func() {
-				err := manager.SetupNATSFirewall("nats://192.168.1.100:4222")
+				err := manager.SetupNATSFirewall([]string{"nats://192.168.1.100:4222"})
 				Expect(err).NotTo(HaveOccurred())
 
 				ctRule := fakeConn.AddRuleArgsForCall(0)
@@ -385,9 +385,36 @@ var _ = Describe("NftablesFirewall", func() {
 			})
 		})
 
+		Context("with multiple URLs", func() {
+			It("creates rules for all URLs in a single flush", func() {
+				err := manager.SetupNATSFirewall([]string{
+					"nats://192.168.1.100:4222",
+					"nats://192.168.1.200:4222",
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				// Only one flush of the chain and one Flush() call for all URLs combined
+				Expect(fakeConn.FlushChainCallCount()).To(Equal(1))
+				Expect(fakeConn.FlushCallCount()).To(Equal(1))
+				// conntrack + (allow + block) * 2 IPs = 5 rules
+				Expect(fakeConn.AddRuleCallCount()).To(Equal(5))
+			})
+
+			It("skips https URLs and adds rules only for nats URLs", func() {
+				err := manager.SetupNATSFirewall([]string{
+					"https://director.example.com:25555",
+					"nats://192.168.1.100:4222",
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				// conntrack + allow + block for the one nats URL
+				Expect(fakeConn.AddRuleCallCount()).To(Equal(3))
+			})
+		})
+
 		Context("with an IPv6 address URL", func() {
 			It("creates rules for the IPv6 address", func() {
-				err := manager.SetupNATSFirewall("nats://user:pass@[2001:db8::1]:4222")
+				err := manager.SetupNATSFirewall([]string{"nats://user:pass@[2001:db8::1]:4222"})
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(fakeConn.AddRuleCallCount()).To(Equal(3))
@@ -402,7 +429,7 @@ var _ = Describe("NftablesFirewall", func() {
 					net.ParseIP("10.0.0.2"),
 				}, nil)
 
-				err := manager.SetupNATSFirewall("nats://user:pass@nats.example.com:4222")
+				err := manager.SetupNATSFirewall([]string{"nats://user:pass@nats.example.com:4222"})
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(fakeResolver.LookupIPCallCount()).To(Equal(1))
@@ -415,7 +442,7 @@ var _ = Describe("NftablesFirewall", func() {
 			It("handles DNS resolution failure gracefully", func() {
 				fakeResolver.LookupIPReturns(nil, errors.New("dns lookup failed"))
 
-				err := manager.SetupNATSFirewall("nats://user:pass@nats.example.com:4222")
+				err := manager.SetupNATSFirewall([]string{"nats://user:pass@nats.example.com:4222"})
 				Expect(err).NotTo(HaveOccurred()) // Should not return error, just log warning
 
 				Expect(fakeResolver.LookupIPCallCount()).To(Equal(1))
@@ -425,7 +452,7 @@ var _ = Describe("NftablesFirewall", func() {
 
 		Context("with default port", func() {
 			It("uses port 4222 when not specified", func() {
-				err := manager.SetupNATSFirewall("nats://192.168.1.100")
+				err := manager.SetupNATSFirewall([]string{"nats://192.168.1.100"})
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(fakeConn.AddRuleCallCount()).To(Equal(3))
@@ -434,7 +461,7 @@ var _ = Describe("NftablesFirewall", func() {
 
 		Context("with custom port", func() {
 			It("uses the specified port", func() {
-				err := manager.SetupNATSFirewall("nats://192.168.1.100:5222")
+				err := manager.SetupNATSFirewall([]string{"nats://192.168.1.100:5222"})
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(fakeConn.AddRuleCallCount()).To(Equal(3))
@@ -443,7 +470,7 @@ var _ = Describe("NftablesFirewall", func() {
 
 		Context("with https URL", func() {
 			It("skips setup and returns nil", func() {
-				err := manager.SetupNATSFirewall("https://director.example.com:25555")
+				err := manager.SetupNATSFirewall([]string{"https://director.example.com:25555"})
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(fakeConn.AddTableCallCount()).To(Equal(0))
@@ -451,9 +478,19 @@ var _ = Describe("NftablesFirewall", func() {
 			})
 		})
 
-		Context("with empty URL", func() {
+		Context("with empty slice", func() {
 			It("skips setup and returns nil", func() {
-				err := manager.SetupNATSFirewall("")
+				err := manager.SetupNATSFirewall([]string{})
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(fakeConn.AddTableCallCount()).To(Equal(0))
+				Expect(fakeConn.AddRuleCallCount()).To(Equal(0))
+			})
+		})
+
+		Context("with a single empty string in slice", func() {
+			It("skips setup and returns nil", func() {
+				err := manager.SetupNATSFirewall([]string{""})
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(fakeConn.AddTableCallCount()).To(Equal(0))
@@ -463,11 +500,11 @@ var _ = Describe("NftablesFirewall", func() {
 
 		Context("when called multiple times", func() {
 			It("flushes existing NATS chain before adding new rules", func() {
-				err := manager.SetupNATSFirewall("nats://192.168.1.100:4222")
+				err := manager.SetupNATSFirewall([]string{"nats://192.168.1.100:4222"})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(fakeConn.FlushChainCallCount()).To(Equal(1))
 
-				err = manager.SetupNATSFirewall("nats://192.168.1.200:4222")
+				err = manager.SetupNATSFirewall([]string{"nats://192.168.1.200:4222"})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(fakeConn.FlushChainCallCount()).To(Equal(2))
 			})
@@ -477,7 +514,7 @@ var _ = Describe("NftablesFirewall", func() {
 			It("returns an error", func() {
 				fakeConn.FlushReturns(errors.New("flush failed"))
 
-				err := manager.SetupNATSFirewall("nats://192.168.1.100:4222")
+				err := manager.SetupNATSFirewall([]string{"nats://192.168.1.100:4222"})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Flushing nftables rules"))
 			})
@@ -492,7 +529,7 @@ var _ = Describe("NftablesFirewall", func() {
 		})
 
 		It("delegates to SetupNATSFirewall", func() {
-			err := hook.BeforeConnect("nats://192.168.1.100:4222")
+			err := hook.BeforeConnect([]string{"nats://192.168.1.100:4222"})
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(fakeConn.AddTableCallCount()).To(Equal(1))
@@ -501,15 +538,27 @@ var _ = Describe("NftablesFirewall", func() {
 		})
 
 		It("returns nil on success", func() {
-			err := hook.BeforeConnect("nats://192.168.1.100:4222")
+			err := hook.BeforeConnect([]string{"nats://192.168.1.100:4222"})
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("returns error when SetupNATSFirewall fails", func() {
 			fakeConn.FlushReturns(errors.New("flush failed"))
 
-			err := hook.BeforeConnect("nats://192.168.1.100:4222")
+			err := hook.BeforeConnect([]string{"nats://192.168.1.100:4222"})
 			Expect(err).To(HaveOccurred())
+		})
+
+		It("accepts multiple URLs and creates rules for each", func() {
+			err := hook.BeforeConnect([]string{
+				"nats://192.168.1.100:4222",
+				"nats://192.168.1.200:4222",
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// conntrack + (allow + block) * 2 = 5 rules, all in one flush
+			Expect(fakeConn.AddRuleCallCount()).To(Equal(5))
+			Expect(fakeConn.FlushCallCount()).To(Equal(1))
 		})
 	})
 

--- a/platform/linux_platform.go
+++ b/platform/linux_platform.go
@@ -245,7 +245,7 @@ func (p linux) GetAuditLogger() AuditLogger {
 	return p.auditLogger
 }
 
-func (p linux) SetupNetworking(networks boshsettings.Networks, mbus string) (err error) {
+func (p linux) SetupNetworking(networks boshsettings.Networks, mbus []string) (err error) {
 	return p.netManager.SetupNetworking(networks, mbus, nil)
 }
 

--- a/platform/linux_platform_test.go
+++ b/platform/linux_platform_test.go
@@ -4185,7 +4185,7 @@ unit: sectors
 		It("delegates to the NetManager", func() {
 			networks := boshsettings.Networks{}
 
-			err := platform.SetupNetworking(networks, "")
+			err := platform.SetupNetworking(networks, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(netManager.SetupNetworkingNetworks).To(Equal(networks))

--- a/platform/net/centos_net_manager.go
+++ b/platform/net/centos_net_manager.go
@@ -77,7 +77,7 @@ func (net centosNetManager) GetConfiguredNetworkInterfaces() ([]string, error) {
 
 func (net centosNetManager) SetupIPv6(_ boshsettings.IPv6, _ <-chan struct{}) error { return nil }
 
-func (net centosNetManager) SetupNetworking(networks boshsettings.Networks, mbus string, errCh chan error) error {
+func (net centosNetManager) SetupNetworking(networks boshsettings.Networks, mbus []string, errCh chan error) error {
 	// NOTE: Do not overwrite `/etc/resolv.conf` here, as it is controlled by Network Manager
 	// This is an intentional asymmetry vs `ubuntu_net_manager.go`.
 	// See commit 63548d43c69180b761d96b8e42a699e0762779e2.
@@ -162,8 +162,8 @@ func (net centosNetManager) SetupNetworking(networks boshsettings.Networks, mbus
 	return nil
 }
 
-func (net centosNetManager) setupFirewall(mbus string) error {
-	if mbus == "" {
+func (net centosNetManager) setupFirewall(mbus []string) error {
+	if len(mbus) == 0 {
 		net.logger.Info("NetworkSetup", "Skipping adding Firewall for outgoing nats. Mbus url is empty")
 		return nil
 	}

--- a/platform/net/centos_net_manager_test.go
+++ b/platform/net/centos_net_manager_test.go
@@ -141,7 +141,7 @@ prepend domain-name-servers 8.8.8.8, 9.9.9.9;
 				"ethstatic": staticNetwork,
 			})
 
-			err := netManager.SetupNetworking(boshsettings.Networks{"dhcp-network": dhcpNetwork, "static-network": staticNetwork}, "", nil)
+			err := netManager.SetupNetworking(boshsettings.Networks{"dhcp-network": dhcpNetwork, "static-network": staticNetwork}, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			staticConfig := fs.GetFileTestStat("/etc/sysconfig/network-scripts/ifcfg-ethstatic")
@@ -159,7 +159,7 @@ prepend domain-name-servers 8.8.8.8, 9.9.9.9;
 				"ethstatic": staticNetwork,
 			})
 
-			err := netManager.SetupNetworking(boshsettings.Networks{"dhcp-network": dhcpNetwork, "static-network": staticNetwork}, "", nil)
+			err := netManager.SetupNetworking(boshsettings.Networks{"dhcp-network": dhcpNetwork, "static-network": staticNetwork}, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			resolvConf := fs.GetFileTestStat("/etc/resolv.conf")
@@ -180,7 +180,7 @@ nameserver 9.9.9.9
 				"ethdhcp": dhcpNetworkWithoutDNS,
 			})
 
-			err := netManager.SetupNetworking(boshsettings.Networks{"dhcp-network": dhcpNetworkWithoutDNS}, "", nil)
+			err := netManager.SetupNetworking(boshsettings.Networks{"dhcp-network": dhcpNetworkWithoutDNS}, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			resolvConf := fs.GetFileTestStat("/etc/resolv.conf")
@@ -198,7 +198,7 @@ nameserver 9.9.9.9
 				"static": staticNetwork,
 			})
 			fs.WriteFileError = errors.New("fs-write-file-error")
-			err := netManager.SetupNetworking(boshsettings.Networks{"dhcp-network": dhcpNetwork, "static-network": staticNetwork}, "", nil)
+			err := netManager.SetupNetworking(boshsettings.Networks{"dhcp-network": dhcpNetwork, "static-network": staticNetwork}, nil, nil)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("fs-write-file-error"))
 		})
@@ -209,7 +209,7 @@ nameserver 9.9.9.9
 			})
 
 			staticNetwork.Netmask = "not an ip" // will cause InterfaceConfigurationCreator to fail
-			err := netManager.SetupNetworking(boshsettings.Networks{"static-network": staticNetwork}, "", nil)
+			err := netManager.SetupNetworking(boshsettings.Networks{"static-network": staticNetwork}, nil, nil)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("Creating interface configurations"))
 		})
@@ -220,7 +220,7 @@ nameserver 9.9.9.9
 				"ethstatic": staticNetwork,
 			})
 
-			err := netManager.SetupNetworking(boshsettings.Networks{"dhcp-network": dhcpNetwork, "static-network": staticNetwork}, "", nil)
+			err := netManager.SetupNetworking(boshsettings.Networks{"dhcp-network": dhcpNetwork, "static-network": staticNetwork}, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			dhcpConfig := fs.GetFileTestStat("/etc/dhcp/dhclient.conf")
@@ -242,7 +242,7 @@ nameserver 9.9.9.9
 				"ethdhcp": dhcpNetwork,
 			})
 
-			err := netManager.SetupNetworking(boshsettings.Networks{"dhcp-network": dhcpNetworkWithoutDNS}, "", nil)
+			err := netManager.SetupNetworking(boshsettings.Networks{"dhcp-network": dhcpNetworkWithoutDNS}, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			dhcpConfig := fs.GetFileTestStat("/etc/dhcp/dhclient.conf")
@@ -272,7 +272,7 @@ request subnet-mask, broadcast-address, time-offset, routers,
 
 			fs.WriteFileErrors["/etc/dhcp/dhclient.conf"] = errors.New("dhclient.conf-write-error")
 
-			err := netManager.SetupNetworking(boshsettings.Networks{"dhcp-network": dhcpNetwork, "static-network": staticNetwork}, "", nil)
+			err := netManager.SetupNetworking(boshsettings.Networks{"dhcp-network": dhcpNetwork, "static-network": staticNetwork}, nil, nil)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("dhclient.conf-write-error"))
 		})
@@ -285,7 +285,7 @@ request subnet-mask, broadcast-address, time-offset, routers,
 
 			fs.SymlinkError = errors.New("dhclient-ethdhcp.conf-symlink-error")
 
-			err := netManager.SetupNetworking(boshsettings.Networks{"dhcp-network": dhcpNetwork, "static-network": staticNetwork}, "", nil)
+			err := netManager.SetupNetworking(boshsettings.Networks{"dhcp-network": dhcpNetwork, "static-network": staticNetwork}, nil, nil)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("dhclient-ethdhcp.conf-symlink-error"))
 		})
@@ -295,7 +295,7 @@ request subnet-mask, broadcast-address, time-offset, routers,
 				"ethstatic": staticNetwork,
 			})
 
-			err := netManager.SetupNetworking(boshsettings.Networks{"static-network": staticNetwork}, "", nil)
+			err := netManager.SetupNetworking(boshsettings.Networks{"static-network": staticNetwork}, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			dhcpConfig := fs.GetFileTestStat("/etc/dhcp/dhclient-ethdhcp.conf")
@@ -331,7 +331,7 @@ request subnet-mask, broadcast-address, time-offset, routers,
 				"changing-static-network": changingStaticNetwork,
 				"static-network":          staticNetwork,
 			},
-				"", nil)
+				nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(len(cmdRunner.RunCommands)).To(Equal(1))
@@ -351,7 +351,7 @@ request subnet-mask, broadcast-address, time-offset, routers,
 			err = fs.WriteFileString("/etc/dhcp/dhclient.conf", expectedDhclientConfiguration)
 			Expect(err).NotTo(HaveOccurred())
 
-			err = netManager.SetupNetworking(boshsettings.Networks{"dhcp-network": dhcpNetwork, "static-network": staticNetwork}, "", nil)
+			err = netManager.SetupNetworking(boshsettings.Networks{"dhcp-network": dhcpNetwork, "static-network": staticNetwork}, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			networkConfig := fs.GetFileTestStat("/etc/sysconfig/network-scripts/ifcfg-ethstatic")
@@ -373,7 +373,7 @@ request subnet-mask, broadcast-address, time-offset, routers,
 			err := fs.WriteFileString("/etc/sysconfig/network-scripts/ifcfg-ethstatic", expectedNetworkConfigurationForStatic)
 			Expect(err).NotTo(HaveOccurred())
 
-			err = netManager.SetupNetworking(boshsettings.Networks{"dhcp-network": dhcpNetwork, "static-network": staticNetwork}, "", nil)
+			err = netManager.SetupNetworking(boshsettings.Networks{"dhcp-network": dhcpNetwork, "static-network": staticNetwork}, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			networkConfig := fs.GetFileTestStat("/etc/sysconfig/network-scripts/ifcfg-ethstatic")
@@ -390,7 +390,7 @@ request subnet-mask, broadcast-address, time-offset, routers,
 				"ethstatic": staticNetwork,
 			})
 
-			err := netManager.SetupNetworking(boshsettings.Networks{"dhcp-network": dhcpNetwork, "static-network": staticNetwork}, "", nil)
+			err := netManager.SetupNetworking(boshsettings.Networks{"dhcp-network": dhcpNetwork, "static-network": staticNetwork}, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			Eventually(func() []boship.InterfaceAddress { return addressBroadcaster.Value() }).Should(
@@ -419,7 +419,7 @@ request subnet-mask, broadcast-address, time-offset, routers,
 				"dhcp-network":   dhcpNetwork,
 				"static-network": staticNetwork,
 				"vip-network":    vipNetwork,
-			}, "", nil)
+			}, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			networkConfig := fs.GetFileTestStat("/etc/sysconfig/network-scripts/ifcfg-ethstatic")
@@ -443,7 +443,7 @@ request subnet-mask, broadcast-address, time-offset, routers,
 			err := netManager.SetupNetworking(boshsettings.Networks{
 				"vip-network":    vipNetwork,
 				"static-network": staticNetwork,
-			}, "", nil)
+			}, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			networkConfig := fs.GetFileTestStat("/etc/sysconfig/network-scripts/ifcfg-ethstatic")
@@ -465,7 +465,7 @@ request subnet-mask, broadcast-address, time-offset, routers,
 				})
 
 				errCh := make(chan error)
-				err := netManager.SetupNetworking(boshsettings.Networks{"static-network": staticNetwork}, "", errCh)
+				err := netManager.SetupNetworking(boshsettings.Networks{"static-network": staticNetwork}, nil, errCh)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Validating static network configuration"))
 			})
@@ -494,7 +494,7 @@ request subnet-mask, broadcast-address, time-offset, routers,
 
 				err := netManager.SetupNetworking(boshsettings.Networks{
 					"static-network": staticNetworkWithoutMAC,
-				}, "", nil)
+				}, nil, nil)
 				Expect(err).ToNot(HaveOccurred())
 
 				networkConfig := fs.GetFileTestStat("/etc/sysconfig/network-scripts/ifcfg-ethstatic")
@@ -563,7 +563,7 @@ nameserver 10.0.80.12
 					"eth0": staticNetwork1,
 				})
 
-				err := netManager.SetupNetworking(boshsettings.Networks{"default": portableNetwork, "dynamic": staticNetwork, "dynamic_1": staticNetwork1}, "", nil)
+				err := netManager.SetupNetworking(boshsettings.Networks{"default": portableNetwork, "dynamic": staticNetwork, "dynamic_1": staticNetwork1}, nil, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				Eventually(func() []boship.InterfaceAddress {
@@ -663,7 +663,7 @@ DNS3=10.0.80.12
 			err := netManager.SetupNetworking(boshsettings.Networks{
 				"static-1": staticNetwork,
 				"static-2": secondStaticNetwork,
-			}, "", nil)
+			}, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			networkConfig0 := fs.GetFileTestStat("/etc/sysconfig/network-scripts/ifcfg-eth0")

--- a/platform/net/fakes/fake_net_manager.go
+++ b/platform/net/fakes/fake_net_manager.go
@@ -27,7 +27,7 @@ func (net *FakeManager) SetupIPv6(config boshsettings.IPv6, stopCh <-chan struct
 	return net.SetupIPv6Err
 }
 
-func (net *FakeManager) SetupNetworking(networks boshsettings.Networks, mbus string, errCh chan error) error {
+func (net *FakeManager) SetupNetworking(networks boshsettings.Networks, mbus []string, errCh chan error) error {
 	net.SetupNetworkingNetworks = networks
 	return net.SetupNetworkingErr
 }

--- a/platform/net/firewall_provider.go
+++ b/platform/net/firewall_provider.go
@@ -5,6 +5,6 @@ package net
 // SetupNatsFirewall is a no-op on non-Windows platforms.
 // On Linux, the nftables-based firewall in platform/firewall/ is used instead.
 // On Windows, a Windows Firewall rule is set up.
-func SetupNatsFirewall(mbus string) error {
+func SetupNatsFirewall(mbus []string) error {
 	return nil
 }

--- a/platform/net/firewall_provider_windows.go
+++ b/platform/net/firewall_provider_windows.go
@@ -74,7 +74,11 @@ func SetupNatsFirewall(mbusURLs []string) error {
 		if err != nil {
 			return bosherr.WrapError(err, "Resolving mbus ips from settings")
 		}
-		natsPort, err := strconv.Atoi(natsURI.Port())
+		portStr := natsURI.Port()
+		if portStr == "" {
+			portStr = "4222"
+		}
+		natsPort, err := strconv.Atoi(portStr)
 		if err != nil {
 			return bosherr.WrapError(err, "Parsing Nats Port from URI")
 		}
@@ -82,6 +86,10 @@ func SetupNatsFirewall(mbusURLs []string) error {
 			natsIP, err := gonetIP.ParseAddr(natsIPString)
 			if err != nil {
 				return bosherr.WrapError(err, "Parsing mbus ip")
+			}
+			// Only IPv4 ALE layers are currently active; skip IPv6 addresses.
+			if natsIP.Is6() && !natsIP.Is4In6() {
+				continue
 			}
 			// The Firewall rule will check if the Target IP is within natsIp/32 Range, thus matching exactly the NatsIP
 			natsIPCidr, err := natsIP.Prefix(32)

--- a/platform/net/firewall_provider_windows.go
+++ b/platform/net/firewall_provider_windows.go
@@ -74,11 +74,7 @@ func SetupNatsFirewall(mbusURLs []string) error {
 		if err != nil {
 			return bosherr.WrapError(err, "Resolving mbus ips from settings")
 		}
-		portStr := natsURI.Port()
-		if portStr == "" {
-			portStr = "4222"
-		}
-		natsPort, err := strconv.Atoi(portStr)
+		natsPort, err := strconv.Atoi(natsURI.Port())
 		if err != nil {
 			return bosherr.WrapError(err, "Parsing Nats Port from URI")
 		}

--- a/platform/net/firewall_provider_windows.go
+++ b/platform/net/firewall_provider_windows.go
@@ -14,15 +14,18 @@ import (
 	"inet.af/wf"
 )
 
-func SetupNatsFirewall(mbus string) error {
-	// return early if we get an empty string for mbus. this is the case when the network for the host is just getting setup or in unit tests.
-	if mbus == "" || strings.HasPrefix(mbus, "https://") {
+func SetupNatsFirewall(mbusURLs []string) error {
+	// Filter out empty and https URLs up front.
+	var natsURLs []string
+	for _, mbus := range mbusURLs {
+		if mbus != "" && !strings.HasPrefix(mbus, "https://") {
+			natsURLs = append(natsURLs, mbus)
+		}
+	}
+	if len(natsURLs) == 0 {
 		return nil
 	}
-	natsURI, err := gonetURL.Parse(mbus)
-	if err != nil || natsURI.Hostname() == "" {
-		return bosherr.WrapError(err, "Error parsing MbusURL")
-	}
+
 	session, err := wf.New(&wf.Options{
 		Name:    "Windows Firewall Session for Bosh Agent",
 		Dynamic: true, // setting this to true will create an ephemeral FW Rule that lasts as long as the Agent Process runs.
@@ -59,61 +62,68 @@ func SetupNatsFirewall(mbus string) error {
 		return bosherr.WrapError(err, "Getting the windows app id for bosh-agent.exe")
 	}
 
-	// We could technically have a hostname in the agent-settings.json for the mbus.
-	// If it is already an IP LookupHost will return an Array containing the IP addr.
-	natsIPs, err := gonet.LookupHost(natsURI.Hostname())
-	if err != nil {
-		return bosherr.WrapError(err, "Resolving mbus ips from settings")
-	}
-	natsPort, err := strconv.Atoi(natsURI.Port())
-	if err != nil {
-		return bosherr.WrapError(err, "Parsing Nats Port from URI")
-	}
-	for _, natsIPString := range natsIPs {
-		natsIP, err := gonetIP.ParseAddr(natsIPString)
-		if err != nil {
-			return bosherr.WrapError(err, "Parsing mbus ip")
+	for _, mbus := range natsURLs {
+		natsURI, err := gonetURL.Parse(mbus)
+		if err != nil || natsURI.Hostname() == "" {
+			return bosherr.WrapError(err, "Error parsing MbusURL")
 		}
-		// The Firewall rule will check if the Target IP is within natsIp/32 Range, thus matching exactly the NatsIP
-		natsIPCidr, err := natsIP.Prefix(32)
-		if err != nil {
-			return bosherr.WrapError(err, "Converting ip address to cidr annotation")
-		}
-		for _, layer := range layers {
-			guid, err := windows.GenerateGUID()
-			if err != nil {
-				return bosherr.WrapError(err, "Generating windows guid")
-			}
 
-			err = session.AddRule(&wf.Rule{
-				ID:       wf.RuleID(guid),
-				Name:     "Allow traffic to remote bosh nats for bosh-agent app id, block everything else",
-				Layer:    layer,
-				Sublayer: sublayerID,
-				Weight:   1000,
-				Conditions: []*wf.Match{
-					// Block traffic to natsIp:natsPort
-					{
-						Field: wf.FieldIPRemoteAddress,
-						Op:    wf.MatchTypePrefix,
-						Value: natsIPCidr,
-					},
-					{
-						Field: wf.FieldIPRemotePort,
-						Op:    wf.MatchTypeEqual,
-						Value: uint16(natsPort),
-					},
-					// Exemption for bosh-agent appID
-					{
-						Field: wf.FieldALEAppID,
-						Op:    wf.MatchTypeNotEqual,
-						Value: appID,
-					},
-				},
-				Action: wf.ActionBlock,
-			})
+		// We could technically have a hostname in the agent-settings.json for the mbus.
+		// If it is already an IP LookupHost will return an Array containing the IP addr.
+		natsIPs, err := gonet.LookupHost(natsURI.Hostname())
+		if err != nil {
+			return bosherr.WrapError(err, "Resolving mbus ips from settings")
+		}
+		natsPort, err := strconv.Atoi(natsURI.Port())
+		if err != nil {
+			return bosherr.WrapError(err, "Parsing Nats Port from URI")
+		}
+		for _, natsIPString := range natsIPs {
+			natsIP, err := gonetIP.ParseAddr(natsIPString)
 			if err != nil {
-				return bosherr.WrapError(err, "Adding firewall rule to limit remote nats access to bosh-agent")
+				return bosherr.WrapError(err, "Parsing mbus ip")
+			}
+			// The Firewall rule will check if the Target IP is within natsIp/32 Range, thus matching exactly the NatsIP
+			natsIPCidr, err := natsIP.Prefix(32)
+			if err != nil {
+				return bosherr.WrapError(err, "Converting ip address to cidr annotation")
+			}
+			for _, layer := range layers {
+				guid, err := windows.GenerateGUID()
+				if err != nil {
+					return bosherr.WrapError(err, "Generating windows guid")
+				}
+
+				err = session.AddRule(&wf.Rule{
+					ID:       wf.RuleID(guid),
+					Name:     "Allow traffic to remote bosh nats for bosh-agent app id, block everything else",
+					Layer:    layer,
+					Sublayer: sublayerID,
+					Weight:   1000,
+					Conditions: []*wf.Match{
+						// Block traffic to natsIp:natsPort
+						{
+							Field: wf.FieldIPRemoteAddress,
+							Op:    wf.MatchTypePrefix,
+							Value: natsIPCidr,
+						},
+						{
+							Field: wf.FieldIPRemotePort,
+							Op:    wf.MatchTypeEqual,
+							Value: uint16(natsPort),
+						},
+						// Exemption for bosh-agent appID
+						{
+							Field: wf.FieldALEAppID,
+							Op:    wf.MatchTypeNotEqual,
+							Value: appID,
+						},
+					},
+					Action: wf.ActionBlock,
+				})
+				if err != nil {
+					return bosherr.WrapError(err, "Adding firewall rule to limit remote nats access to bosh-agent")
+				}
 			}
 		}
 	}

--- a/platform/net/net_manager_interface.go
+++ b/platform/net/net_manager_interface.go
@@ -8,7 +8,7 @@ type Manager interface {
 	// SetupNetworking configures network interfaces with either a static ip or dhcp.
 	// If errCh is provided, nil or an error will be sent
 	// upon completion of background network reconfiguration (e.g. arping).
-	SetupNetworking(networks boshsettings.Networks, mbus string, errCh chan error) error
+	SetupNetworking(networks boshsettings.Networks, mbus []string, errCh chan error) error
 
 	// Returns the list of interfaces that have configurations for them present
 	GetConfiguredNetworkInterfaces() ([]string, error)

--- a/platform/net/ubuntu_net_manager.go
+++ b/platform/net/ubuntu_net_manager.go
@@ -108,7 +108,7 @@ func (net UbuntuNetManager) SetupIPv6(config boshsettings.IPv6, stopCh <-chan st
 	return nil
 }
 
-func (net UbuntuNetManager) SetupNetworking(networks boshsettings.Networks, mbus string, errCh chan error) error {
+func (net UbuntuNetManager) SetupNetworking(networks boshsettings.Networks, mbus []string, errCh chan error) error {
 	if networks.IsPreconfigured() {
 		// Note in this case IPs are not broadcast
 		dnsNetwork, _ := networks.DefaultNetworkFor("dns")

--- a/platform/net/ubuntu_net_manager_ipv6_test.go
+++ b/platform/net/ubuntu_net_manager_ipv6_test.go
@@ -99,7 +99,7 @@ var _ = Describe("UbuntuNetManager (IPv6)", func() {
 				"ethstatic1": static1Net,
 			})
 
-			err := netManager.SetupNetworking(boshsettings.Networks{"net1": static1Net}, "", nil)
+			err := netManager.SetupNetworking(boshsettings.Networks{"net1": static1Net}, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(kernelIPv6.Enabled).To(BeTrue())
@@ -121,7 +121,7 @@ var _ = Describe("UbuntuNetManager (IPv6)", func() {
 				"ethdhcp1": dhcp1Net,
 			})
 
-			err := netManager.SetupNetworking(boshsettings.Networks{"net1": dhcp1Net}, "", nil)
+			err := netManager.SetupNetworking(boshsettings.Networks{"net1": dhcp1Net}, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(kernelIPv6.Enabled).To(BeTrue())
@@ -164,7 +164,7 @@ var _ = Describe("UbuntuNetManager (IPv6)", func() {
 				"ethstatic1": static1Net,
 			})
 
-			err := netManager.SetupNetworking(boshsettings.Networks{"net1": static1Net, "net2": static2Net}, "", nil)
+			err := netManager.SetupNetworking(boshsettings.Networks{"net1": static1Net, "net2": static2Net}, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(kernelIPv6.Enabled).To(BeTrue())
@@ -223,7 +223,7 @@ Gateway=2001:db8::1
 
 			kernelIPv6.EnableErr = errors.New("fake-err")
 
-			err := netManager.SetupNetworking(boshsettings.Networks{"net1": static1Net}, "", nil)
+			err := netManager.SetupNetworking(boshsettings.Networks{"net1": static1Net}, nil, nil)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("fake-err"))
 		})
@@ -242,7 +242,7 @@ Gateway=2001:db8::1
 				"ethstatic2": static1Net,
 			})
 
-			err := netManager.SetupNetworking(boshsettings.Networks{"net1": static1Net}, "", nil)
+			err := netManager.SetupNetworking(boshsettings.Networks{"net1": static1Net}, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(kernelIPv6.Enabled).To(BeFalse())
@@ -263,7 +263,7 @@ Gateway=2001:db8::1
 				"ethstatic2": dhcp1Net,
 			})
 
-			err := netManager.SetupNetworking(boshsettings.Networks{"net1": dhcp1Net}, "", nil)
+			err := netManager.SetupNetworking(boshsettings.Networks{"net1": dhcp1Net}, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(kernelIPv6.Enabled).To(BeFalse())
@@ -307,7 +307,7 @@ Gateway=2001:db8::1
 				"net1": static1Net,
 				"net2": static2Net,
 				"net3": static3Net,
-			}, "", nil)
+			}, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			matches, err := fs.Ls("/etc/systemd/network/")
@@ -388,7 +388,7 @@ DNS=9.9.9.9
 
 			err := netManager.SetupNetworking(boshsettings.Networks{
 				"net1": static1Net,
-			}, "", nil)
+			}, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			matches, err := fs.Ls("/etc/systemd/network/")

--- a/platform/net/ubuntu_net_manager_test.go
+++ b/platform/net/ubuntu_net_manager_test.go
@@ -345,7 +345,7 @@ dns-nameservers 8.8.8.8 9.9.9.9`
 			err := netManager.SetupNetworking(boshsettings.Networks{
 				"static-1": staticNetwork,
 				"static-2": secondStaticNetwork,
-			}, "", nil)
+			}, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			matches, err := fs.Ls("/etc/systemd/network/")
@@ -416,7 +416,7 @@ DNS=8.8.8.8
 				err := netManager.SetupNetworking(boshsettings.Networks{
 					"static-1": staticNetwork,
 					"static-2": secondStaticNetwork,
-				}, "", nil)
+				}, nil, nil)
 				Expect(err).ToNot(HaveOccurred())
 
 				matches, err := fs.Ls("/etc/systemd/network/")
@@ -453,7 +453,7 @@ DNS=8.8.8.8
 
 				err := netManager.SetupNetworking(boshsettings.Networks{
 					"static-1": staticNetwork,
-				}, "", nil)
+				}, nil, nil)
 				Expect(err).ToNot(HaveOccurred())
 
 				matches, err := fs.Ls("/etc/systemd/network/")
@@ -522,7 +522,7 @@ DNS=8.8.8.8
 			err := netManager.SetupNetworking(boshsettings.Networks{
 				"static-1": staticNetwork,
 				"static-2": secondStaticNetwork,
-			}, "", nil)
+			}, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			matches, err := fs.Ls("/etc/systemd/network/")
@@ -602,7 +602,7 @@ DNS=8.8.8.8
 
 			err := netManager.SetupNetworking(boshsettings.Networks{
 				"static-1": staticNetwork,
-			}, "", nil)
+			}, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			matches, err := fs.Ls("/etc/systemd/network/")
@@ -649,7 +649,7 @@ Gateway=3.4.5.6
 				"ethstatic": staticNetworkWithoutDNS,
 			})
 
-			err := netManager.SetupNetworking(boshsettings.Networks{"static-network": staticNetworkWithoutDNS}, "", nil)
+			err := netManager.SetupNetworking(boshsettings.Networks{"static-network": staticNetworkWithoutDNS}, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			matches, err := fs.Ls("/etc/systemd/network/")
@@ -678,7 +678,7 @@ Gateway=3.4.5.6
 				"static": staticNetwork,
 			})
 			fs.WriteFileError = errors.New("fs-write-file-error")
-			err := netManager.SetupNetworking(boshsettings.Networks{"dhcp-network": dhcpNetwork, "static-network": staticNetwork}, "", nil)
+			err := netManager.SetupNetworking(boshsettings.Networks{"dhcp-network": dhcpNetwork, "static-network": staticNetwork}, nil, nil)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("fs-write-file-error"))
 		})
@@ -689,7 +689,7 @@ Gateway=3.4.5.6
 				"ethstatic": staticNetwork,
 			})
 			staticNetwork.Netmask = "not an ip" // will cause InterfaceConfigurationCreator to fail
-			err := netManager.SetupNetworking(boshsettings.Networks{"static-network": staticNetwork}, "", nil)
+			err := netManager.SetupNetworking(boshsettings.Networks{"static-network": staticNetwork}, nil, nil)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("Creating interface configurations"))
 		})
@@ -713,7 +713,7 @@ Gateway=3.4.5.6
 
 			err := netManager.SetupNetworking(boshsettings.Networks{
 				"static-1": staticNetwork,
-			}, "", nil)
+			}, nil, nil)
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError(`Updating network configs: Writing network configuration: Updating network configuration for eth0: netmask cannot be converted to CIDR: 255.0.255.0`))
 		})
@@ -724,7 +724,7 @@ Gateway=3.4.5.6
 				"ethstatic": staticNetwork,
 			})
 
-			err := netManager.SetupNetworking(boshsettings.Networks{"dhcp-network": dhcpNetwork, "static-network": staticNetwork}, "", nil)
+			err := netManager.SetupNetworking(boshsettings.Networks{"dhcp-network": dhcpNetwork, "static-network": staticNetwork}, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			dhcpConfig := fs.GetFileTestStat("/etc/dhcp/dhclient.conf")
@@ -755,7 +755,7 @@ prepend domain-name-servers 8.8.8.8, 9.9.9.9;
 				"ethdhcp": dhcpNetwork,
 			})
 
-			err := netManager.SetupNetworking(boshsettings.Networks{"dhcp-network": dhcpNetworkWithoutDNS}, "", nil)
+			err := netManager.SetupNetworking(boshsettings.Networks{"dhcp-network": dhcpNetworkWithoutDNS}, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			dhcpConfig := fs.GetFileTestStat("/etc/dhcp/dhclient.conf")
@@ -783,7 +783,7 @@ request subnet-mask, broadcast-address, time-offset, routers,
 
 			fs.WriteFileErrors["/etc/dhcp/dhclient.conf"] = errors.New("dhclient.conf-write-error")
 
-			err := netManager.SetupNetworking(boshsettings.Networks{"dhcp-network": dhcpNetwork, "static-network": staticNetwork}, "", nil)
+			err := netManager.SetupNetworking(boshsettings.Networks{"dhcp-network": dhcpNetwork, "static-network": staticNetwork}, nil, nil)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("dhclient.conf-write-error"))
 		})
@@ -793,7 +793,7 @@ request subnet-mask, broadcast-address, time-offset, routers,
 				"ethstatic": staticNetwork,
 			})
 
-			err := netManager.SetupNetworking(boshsettings.Networks{"static-network": staticNetwork}, "", nil)
+			err := netManager.SetupNetworking(boshsettings.Networks{"static-network": staticNetwork}, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			dhcpConfig := fs.GetFileTestStat("/etc/dhcp/dhclient.conf")
@@ -839,7 +839,7 @@ prepend domain-name-servers 8.8.8.8, 9.9.9.9;
 				Expect(fs.ReadFileString("/etc/dhcp/dhclient.conf")).To(Equal(initialDhcpConfig))
 			})
 
-			err = netManager.SetupNetworking(boshsettings.Networks{"dhcp-network": dhcpNetwork, "static-network": staticNetwork}, "", nil)
+			err = netManager.SetupNetworking(boshsettings.Networks{"dhcp-network": dhcpNetwork, "static-network": staticNetwork}, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(len(cmdRunner.RunCommands)).To(Equal(4))
@@ -852,7 +852,7 @@ prepend domain-name-servers 8.8.8.8, 9.9.9.9;
 
 			By("Setting up the networks with the same inputs, we do not restart networking")
 			cmdRunner.ClearCommandHistory()
-			err = netManager.SetupNetworking(boshsettings.Networks{"dhcp-network": dhcpNetwork, "static-network": staticNetwork}, "", nil)
+			err = netManager.SetupNetworking(boshsettings.Networks{"dhcp-network": dhcpNetwork, "static-network": staticNetwork}, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -880,7 +880,7 @@ prepend domain-name-servers 8.8.8.8, 9.9.9.9;
 			err = fs.WriteFileString("/etc/dhcp/dhclient.conf", initialDhcpConfig)
 			Expect(err).NotTo(HaveOccurred())
 
-			err = netManager.SetupNetworking(boshsettings.Networks{"dhcp-network": dhcpNetwork, "static-network": staticNetwork}, "", nil)
+			err = netManager.SetupNetworking(boshsettings.Networks{"dhcp-network": dhcpNetwork, "static-network": staticNetwork}, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			networkConfig := fs.GetFileTestStat("/etc/network/interfaces")
@@ -922,7 +922,7 @@ prepend domain-name-servers 8.8.8.8, 9.9.9.9;
 				Expect(fs.ReadFileString("/etc/dhcp/dhclient.conf")).To(Equal(initialDhcpConfig))
 			})
 
-			err = netManager.SetupNetworking(boshsettings.Networks{"dhcp-network": dhcpNetwork, "static-network": staticNetwork}, "", nil)
+			err = netManager.SetupNetworking(boshsettings.Networks{"dhcp-network": dhcpNetwork, "static-network": staticNetwork}, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(len(cmdRunner.RunCommands)).To(Equal(4))
@@ -940,7 +940,7 @@ prepend domain-name-servers 8.8.8.8, 9.9.9.9;
 				"ethstatic": staticNetwork,
 			})
 
-			err := netManager.SetupNetworking(boshsettings.Networks{"dhcp-network": dhcpNetwork, "static-network": staticNetwork}, "", nil)
+			err := netManager.SetupNetworking(boshsettings.Networks{"dhcp-network": dhcpNetwork, "static-network": staticNetwork}, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			Eventually(func() []boship.InterfaceAddress { return addressBroadcaster.Value() }).Should(
@@ -969,7 +969,7 @@ prepend domain-name-servers 8.8.8.8, 9.9.9.9;
 				"dhcp-network":   dhcpNetwork,
 				"static-network": staticNetwork,
 				"vip-network":    vipNetwork,
-			}, "", nil)
+			}, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			matches, err := fs.Ls("/etc/systemd/network/")
@@ -1027,7 +1027,7 @@ DNS=9.9.9.9
 				})
 
 				errCh := make(chan error)
-				err := netManager.SetupNetworking(boshsettings.Networks{"static-network": staticNetwork}, "", errCh)
+				err := netManager.SetupNetworking(boshsettings.Networks{"static-network": staticNetwork}, nil, errCh)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Validating static network configuration"))
 			})
@@ -1054,7 +1054,7 @@ DNS=9.9.9.9
 
 				err := netManager.SetupNetworking(boshsettings.Networks{
 					"static-network": staticNetworkWithoutMAC,
-				}, "", nil)
+				}, nil, nil)
 				Expect(err).ToNot(HaveOccurred())
 
 				matches, err := fs.Ls("/etc/systemd/network/")
@@ -1140,7 +1140,7 @@ nameserver 10.0.80.12
 					"eth0": staticNetwork1,
 				})
 
-				err := netManager.SetupNetworking(boshsettings.Networks{"default": portableNetwork, "dynamic": staticNetwork, "dynamic_1": staticNetwork1}, "", nil)
+				err := netManager.SetupNetworking(boshsettings.Networks{"default": portableNetwork, "dynamic": staticNetwork, "dynamic_1": staticNetwork1}, nil, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				Eventually(func() []boship.InterfaceAddress { return addressBroadcaster.Value() }).Should(
@@ -1230,7 +1230,7 @@ DNS=10.0.80.12
 
 			err = netManager.SetupNetworking(boshsettings.Networks{
 				"static": staticNetwork,
-			}, "", nil)
+			}, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			matches, err := fs.Ls("/etc/systemd/network/")

--- a/platform/net/windows_net_manager.go
+++ b/platform/net/windows_net_manager.go
@@ -106,7 +106,7 @@ func (net WindowsNetManager) setupNetworkInterfaces(networks boshsettings.Networ
 	return nil
 }
 
-func (net WindowsNetManager) SetupNetworking(networks boshsettings.Networks, mbus string, errCh chan error) error {
+func (net WindowsNetManager) SetupNetworking(networks boshsettings.Networks, mbus []string, errCh chan error) error {
 	if err := net.setupNetworkInterfaces(networks); err != nil {
 		return bosherr.WrapError(err, "setting up network interfaces")
 	}
@@ -137,8 +137,8 @@ func (net WindowsNetManager) SetupNetworking(networks boshsettings.Networks, mbu
 
 	return nil
 }
-func (net WindowsNetManager) setupFirewall(mbus string) error {
-	if mbus == "" {
+func (net WindowsNetManager) setupFirewall(mbus []string) error {
+	if len(mbus) == 0 {
 		net.logger.Info("NetworkSetup", "Skipping adding Firewall for outgoing nats. Mbus url is empty")
 		return nil
 	}

--- a/platform/net/windows_net_manager_test.go
+++ b/platform/net/windows_net_manager_test.go
@@ -77,7 +77,7 @@ var _ = Describe("WindowsNetManager", func() {
 	setupNetworking := func(networks boshsettings.Networks) error {
 		// Allow 5 seconds to pass so that the Sleep() in the function can pass.
 		go clock.WaitForWatcherAndIncrement(5 * time.Second)
-		return netManager.SetupNetworking(networks, "", nil)
+		return netManager.SetupNetworking(networks, nil, nil)
 	}
 
 	Describe("Setting NIC settings", func() {

--- a/platform/platform_interface.go
+++ b/platform/platform_interface.go
@@ -60,7 +60,7 @@ type Platform interface {
 	SetupBoshSettingsDisk() (err error)
 	SetupIPv6(boshsettings.IPv6) error
 	SetupHostname(hostname string) (err error)
-	SetupNetworking(networks boshsettings.Networks, mbus string) (err error)
+	SetupNetworking(networks boshsettings.Networks, mbus []string) (err error)
 	SetupLogrotate(groupName, basePath, size string) (err error)
 	SetTimeWithNtpServers(servers []string) (err error)
 	SetupEphemeralDiskWithPath(devicePath string, desiredSwapSizeInBytes *uint64, labelPrefix string) (err error)

--- a/platform/platformfakes/fake_platform.go
+++ b/platform/platformfakes/fake_platform.go
@@ -627,11 +627,11 @@ type FakePlatform struct {
 	setupMonitUserReturnsOnCall map[int]struct {
 		result1 error
 	}
-	SetupNetworkingStub        func(settings.Networks, string) error
+	SetupNetworkingStub        func(settings.Networks, []string) error
 	setupNetworkingMutex       sync.RWMutex
 	setupNetworkingArgsForCall []struct {
 		arg1 settings.Networks
-		arg2 string
+		arg2 []string
 	}
 	setupNetworkingReturns struct {
 		result1 error
@@ -3928,16 +3928,21 @@ func (fake *FakePlatform) SetupMonitUserReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakePlatform) SetupNetworking(arg1 settings.Networks, arg2 string) error {
+func (fake *FakePlatform) SetupNetworking(arg1 settings.Networks, arg2 []string) error {
+	var arg2Copy []string
+	if arg2 != nil {
+		arg2Copy = make([]string, len(arg2))
+		copy(arg2Copy, arg2)
+	}
 	fake.setupNetworkingMutex.Lock()
 	ret, specificReturn := fake.setupNetworkingReturnsOnCall[len(fake.setupNetworkingArgsForCall)]
 	fake.setupNetworkingArgsForCall = append(fake.setupNetworkingArgsForCall, struct {
 		arg1 settings.Networks
-		arg2 string
-	}{arg1, arg2})
+		arg2 []string
+	}{arg1, arg2Copy})
 	stub := fake.SetupNetworkingStub
 	fakeReturns := fake.setupNetworkingReturns
-	fake.recordInvocation("SetupNetworking", []interface{}{arg1, arg2})
+	fake.recordInvocation("SetupNetworking", []interface{}{arg1, arg2Copy})
 	fake.setupNetworkingMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2)
@@ -3954,13 +3959,13 @@ func (fake *FakePlatform) SetupNetworkingCallCount() int {
 	return len(fake.setupNetworkingArgsForCall)
 }
 
-func (fake *FakePlatform) SetupNetworkingCalls(stub func(settings.Networks, string) error) {
+func (fake *FakePlatform) SetupNetworkingCalls(stub func(settings.Networks, []string) error) {
 	fake.setupNetworkingMutex.Lock()
 	defer fake.setupNetworkingMutex.Unlock()
 	fake.SetupNetworkingStub = stub
 }
 
-func (fake *FakePlatform) SetupNetworkingArgsForCall(i int) (settings.Networks, string) {
+func (fake *FakePlatform) SetupNetworkingArgsForCall(i int) (settings.Networks, []string) {
 	fake.setupNetworkingMutex.RLock()
 	defer fake.setupNetworkingMutex.RUnlock()
 	argsForCall := fake.setupNetworkingArgsForCall[i]

--- a/platform/windows_platform.go
+++ b/platform/windows_platform.go
@@ -404,7 +404,7 @@ func (p WindowsPlatform) SetupHostname(hostname string) (err error) {
 	return
 }
 
-func (p WindowsPlatform) SetupNetworking(networks boshsettings.Networks, mbus string) (err error) {
+func (p WindowsPlatform) SetupNetworking(networks boshsettings.Networks, mbus []string) (err error) {
 	return p.netManager.SetupNetworking(networks, mbus, nil)
 }
 

--- a/platform/windows_platform_test.go
+++ b/platform/windows_platform_test.go
@@ -281,7 +281,7 @@ var _ = Describe("WindowsPlatform", func() {
 		It("delegates to the NetManager", func() {
 			networks := boshsettings.Networks{}
 
-			err := platform.SetupNetworking(networks, "")
+			err := platform.SetupNetworking(networks, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(netManager.SetupNetworkingNetworks).To(Equal(networks))

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -160,6 +160,17 @@ func (s Settings) GetMbusURL() string {
 	return s.Mbus
 }
 
+func (s Settings) GetMbusURLs() []string {
+	if len(s.UpdateSettings.Mbus.URLs) > 0 {
+		return s.UpdateSettings.Mbus.URLs
+	}
+	if len(s.Env.Bosh.Mbus.URLs) > 0 {
+		return s.Env.Bosh.Mbus.URLs
+	}
+
+	return []string{s.Mbus}
+}
+
 func (s Settings) GetMbusCerts() CertKeyPair {
 	if s.UpdateSettings.Mbus.Cert.CA != "" {
 		return s.UpdateSettings.Mbus.Cert

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -168,6 +168,9 @@ func (s Settings) GetMbusURLs() []string {
 		return s.Env.Bosh.Mbus.URLs
 	}
 
+	if s.Mbus == "" {
+		return nil
+	}
 	return []string{s.Mbus}
 }
 

--- a/settings/settings_test.go
+++ b/settings/settings_test.go
@@ -1293,6 +1293,22 @@ var _ = Describe("Settings", func() {
 				Expect(settings.GetMbusURLs()).To(Equal([]string{"nats://top-level:456"}))
 			})
 		})
+
+		Context("all URL sources are empty and Mbus is an empty string", func() {
+			It("returns nil so downstream URL parsing sees no entries", func() {
+				settings = Settings{
+					Mbus: "",
+					Env: Env{
+						Bosh: BoshEnv{
+							Mbus: MBus{
+								URLs: nil,
+							},
+						},
+					},
+				}
+				Expect(settings.GetMbusURLs()).To(BeNil())
+			})
+		})
 	})
 
 	Describe("#GetMbusCerts", func() {

--- a/settings/settings_test.go
+++ b/settings/settings_test.go
@@ -1224,6 +1224,77 @@ var _ = Describe("Settings", func() {
 		})
 	})
 
+	Describe("#GetMbusURLs", func() {
+		Context("UpdateSettings.Mbus.URLs is populated", func() {
+			It("returns the full UpdateSettings slice", func() {
+				settings = Settings{
+					Mbus: "nats://top-level:123",
+					Env: Env{
+						Bosh: BoshEnv{
+							Mbus: MBus{
+								URLs: []string{"nats://env:789"},
+							},
+						},
+					},
+					UpdateSettings: UpdateSettings{
+						Mbus: MBus{
+							URLs: []string{"nats://update1:4222", "nats://update2:4222"},
+						},
+					},
+				}
+				Expect(settings.GetMbusURLs()).To(Equal([]string{"nats://update1:4222", "nats://update2:4222"}))
+			})
+		})
+
+		Context("Env.Bosh.Mbus.URLs is populated", func() {
+			It("returns the full Env slice", func() {
+				settings = Settings{
+					Mbus: "nats://top-level:123",
+					Env: Env{
+						Bosh: BoshEnv{
+							Mbus: MBus{
+								URLs: []string{"nats://env1:4222", "nats://env2:4222"},
+							},
+						},
+					},
+				}
+				Expect(settings.GetMbusURLs()).To(Equal([]string{"nats://env1:4222", "nats://env2:4222"}))
+			})
+		})
+
+		Context("no URLs slice is set", func() {
+			It("returns the legacy top-level Mbus string as a single-element slice", func() {
+				settings = Settings{
+					Mbus: "nats://top-level:456",
+					Env: Env{
+						Bosh: BoshEnv{
+							Mbus: MBus{
+								URLs: nil,
+							},
+						},
+					},
+				}
+				Expect(settings.GetMbusURLs()).To(Equal([]string{"nats://top-level:456"}))
+			})
+		})
+
+		Context("Env.Bosh.Mbus.URLs is zero length", func() {
+			It("returns the legacy top-level Mbus string as a single-element slice", func() {
+				settings = Settings{
+					Mbus: "nats://top-level:456",
+					Env: Env{
+						Bosh: BoshEnv{
+							Mbus: MBus{
+								URLs: []string{},
+							},
+						},
+					},
+				}
+				Expect(settings.GetMbusURLs()).To(Equal([]string{"nats://top-level:456"}))
+			})
+		})
+	})
+
 	Describe("#GetMbusCerts", func() {
 		Context("UpdateSettings.Mbus.Cert is populated", func() {
 			It("returns UpdateSettings.Mbus.Certs", func() {


### PR DESCRIPTION
    Support multiple NATS URLs for message bus failover
    
    This change will facilitate future BOSH director migration use cases, where we want to be able to move the director to a different IP address. Setting up the NATS address list to include both the old and the new director IP addresses allows everything to continue to function cleanly while the old director is torn down and the new one is stood up at a different address.
    
    We already support setting multiple NATS urls via director job properties and the agent settings.json on the VM, but prior to this change we were only looking at the first URL in the array. This PR completes the feature.
    It extends the agent to consume the full MBus.URLs []string slice instead
    of only the first element, enabling NATS client-side failover across
    multiple servers.
    
    - Add GetMbusURLs() []string to settings with priority-ordered fallback
    - Join all URLs comma-separated for nats.Connect (native cluster format)
    - Extend ConnectionInfo with IPs []string; arpClean iterates all IPs
    - Change NatsFirewallHook.BeforeConnect and Manager.SetupNATSFirewall
      to accept []string; nftables implementation flushes once and adds
      allow/block rules for every resolved IP in a single batch
    - Change SetupNetworking(mbus string) to SetupNetworking(mbus []string)
      across all platform/net manager implementations; Windows firewall
      provider iterates all URLs to add per-IP rules at boot
    - Update bootstrap to pass GetMbusURLs(); http_metadata_service passes nil
    - Regenerate all affected counterfeiter fakes
    - Add integration tests: Linux multi-URL nftables rule verification and
      Windows NATS failover test with unreachable primary server
    - Add a new repack-vsphere.sh script to facilitate agent development on vsphere environments.