### PR TITLE
CI: Fix flaky EphemeralDisk Windows integration tests

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -464,6 +464,8 @@ jobs:
             stemcells:
               - "aws-stemcell/*.tgz"
               - "aws-windows-stemcell/*.tgz"
+            ops_files:
+              - "bosh-agent/integration/assets/agent-windows-large-root-disk.yml"
             vars:
               deployment_name: bosh-agent-integration-windows-main
         - task: get-agent-info
@@ -508,6 +510,7 @@ jobs:
               - "aws-stemcell/*.tgz"
               - "aws-windows-stemcell/*.tgz"
             ops_files:
+              - "bosh-agent/integration/assets/agent-windows-large-root-disk.yml"
               - "bosh-agent/integration/assets/agent-windows-nats-blobstore.yml"
             releases:
               - bosh-bosh-release/release.tgz

--- a/integration/assets/agent-windows-large-root-disk.yml
+++ b/integration/assets/agent-windows-large-root-disk.yml
@@ -1,0 +1,12 @@
+# Expand the root EBS volume of the agent_test VM to 100 GB so that
+# ShrinkRootPartition() in the Windows integration tests can free enough
+# contiguous space for a second ephemeral partition on disk 0 (C: drive).
+#
+# On AWS, BOSH merges instance-group cloud_properties with the vm_type's
+# cloud_properties, so root_disk.size here overrides the stemcell AMI default
+# (typically 30 GB for Windows 2019) without requiring a cloud config change.
+- type: replace
+  path: /instance_groups/name=agent_test/cloud_properties?/root_disk
+  value:
+    size: 102400
+    type: gp3

--- a/integration/windows/ephemeral_disk_test.go
+++ b/integration/windows/ephemeral_disk_test.go
@@ -28,7 +28,7 @@ var _ = Describe("EphemeralDisk", func() {
 
 		agent.EnsureDataDirDoesntExist()
 
-		if diskLetter != "" {
+		if diskLetter != "" && strings.ToUpper(diskLetter) != "C" {
 			agent.RunPowershellCommand(fmt.Sprintf("Remove-Partition -DriveLetter %s -Confirm:$false", diskLetter))
 		}
 		if diskNumber != "0" {
@@ -50,7 +50,10 @@ var _ = Describe("EphemeralDisk", func() {
 			agent.StartAgent()
 
 			agent.EnsureLinkTargetedToDisk(dataDir, diskNumber)
-			diskLetter = agent.GetDriveLetterForLink(dataDir)
+			letter := agent.GetDriveLetterForLink(dataDir)
+			Expect(strings.ToUpper(letter)).NotTo(Equal("C"),
+				"agent unexpectedly placed ephemeral data on the root C: partition; ShrinkRootPartition may not have freed enough space")
+			diskLetter = letter
 
 			agent.AssertDataACLed()
 		})
@@ -62,7 +65,10 @@ var _ = Describe("EphemeralDisk", func() {
 			agent.StartAgent()
 
 			agent.EnsureLinkTargetedToDisk(dataDir, diskNumber)
-			diskLetter = agent.GetDriveLetterForLink(dataDir)
+			letter := agent.GetDriveLetterForLink(dataDir)
+			Expect(strings.ToUpper(letter)).NotTo(Equal("C"),
+				"agent unexpectedly placed ephemeral data on the root C: partition; ShrinkRootPartition may not have freed enough space")
+			diskLetter = letter
 
 			agent.RunPowershellCommand(`c:\bosh\service_wrapper.exe restart`)
 


### PR DESCRIPTION
Guard AfterEach against attempting to remove the C: system partition when the ephemeral partition was unexpectedly placed on the root drive, which caused an unrecoverable test environment failure.

Add an early assertion in the two root-disk tests so the failure is reported clearly in the test body rather than cryptically in AfterEach.

Expand the agent_test VM root EBS volume to 100 GB via a BOSH ops file so ShrinkRootPartition() frees enough contiguous space on disk 0 for a second ephemeral partition, addressing the root cause of the flake.