### PR TITLE
File Settings should return error in case the file itself does not exist 

### DIFF
--- a/infrastructure/file_settings_source.go
+++ b/infrastructure/file_settings_source.go
@@ -36,7 +36,7 @@ func NewFileSettingsSource(
 
 func (s *FileSettingsSource) PublicSSHKeyForUsername(string) (string, error) {
 	if !s.fs.FileExists(s.settingsFilePath) {
-		return "", bosherr.Error("File for settings source does not exist")
+		return "", bosherr.Errorf("File for settings source does not exist: '%s'", s.settingsFilePath)
 	}
 	return "", nil
 }

--- a/infrastructure/file_settings_source.go
+++ b/infrastructure/file_settings_source.go
@@ -35,6 +35,9 @@ func NewFileSettingsSource(
 }
 
 func (s *FileSettingsSource) PublicSSHKeyForUsername(string) (string, error) {
+	if !s.fs.FileExists(s.settingsFilePath) {
+		return "", bosherr.Error("File for settings source does not exist")
+	}
 	return "", nil
 }
 

--- a/infrastructure/file_settings_source_test.go
+++ b/infrastructure/file_settings_source_test.go
@@ -26,10 +26,31 @@ var _ = Describe("FileSettingsSource", func() {
 	})
 
 	Describe("PublicSSHKeyForUsername", func() {
-		It("returns an empty string", func() {
-			publicKey, err := source.PublicSSHKeyForUsername("fake-username")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(publicKey).To(Equal(""))
+		Context("when the settings file exists", func() {
+			BeforeEach(func() {
+				settingsFileName := "/fake-settings-file-path"
+				source = infrastructure.NewFileSettingsSource(settingsFileName, fs, logger)
+				err := fs.WriteFileString(settingsFileName, "{}")
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("returns an empty string", func() {
+				publicKey, err := source.PublicSSHKeyForUsername("fake-username")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(publicKey).To(Equal(""))
+			})
+		})
+
+		Context("when the settings file does not exist", func() {
+			BeforeEach(func() {
+				source = infrastructure.NewFileSettingsSource("/missing-settings-file-path", fs, logger)
+			})
+
+			It("returns an error", func() {
+				_, err := source.PublicSSHKeyForUsername("fake-username")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("File for settings source does not exist"))
+			})
 		})
 	})
 

--- a/infrastructure/file_settings_source_test.go
+++ b/infrastructure/file_settings_source_test.go
@@ -46,10 +46,11 @@ var _ = Describe("FileSettingsSource", func() {
 				source = infrastructure.NewFileSettingsSource("/missing-settings-file-path", fs, logger)
 			})
 
-			It("returns an error", func() {
+			It("returns an error with the file path", func() {
 				_, err := source.PublicSSHKeyForUsername("fake-username")
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("File for settings source does not exist"))
+				Expect(err.Error()).To(ContainSubstring("/missing-settings-file-path"))
 			})
 		})
 	})

--- a/infrastructure/multi_settings_source.go
+++ b/infrastructure/multi_settings_source.go
@@ -42,6 +42,7 @@ func (s *MultiSettingsSource) PublicSSHKeyForUsername(username string) (string, 
 			s.selectedSSHKeySource = source
 			return publicSSHKey, nil
 		}
+		s.logger.Warn("multi-settings-source", "Failed to get public SSH key from source: %v", err)
 	}
 
 	return "", bosherr.WrapErrorf(err, "Getting public SSH key for '%s'", username)

--- a/infrastructure/multi_settings_source_test.go
+++ b/infrastructure/multi_settings_source_test.go
@@ -85,6 +85,11 @@ var _ = Describe("MultiSettingsSource", func() {
 					Expect(err).ToNot(HaveOccurred())
 					Expect(publicKey).To(Equal("fake-public-key-2"))
 				})
+
+				It("logs a warning for the first source", func() {
+					_, _ = source.PublicSSHKeyForUsername("fake-username") //nolint:errcheck
+					Expect(logBuffer.String()).To(ContainSubstring("fake-public-key-err-1"))
+				})
 			})
 
 			Context("when both sources fail to get ssh key", func() {
@@ -92,6 +97,11 @@ var _ = Describe("MultiSettingsSource", func() {
 					_, err := source.PublicSSHKeyForUsername("fake-username")
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring("fake-public-key-err-2"))
+				})
+
+				It("logs a warning for the first source", func() {
+					_, _ = source.PublicSSHKeyForUsername("fake-username") //nolint:errcheck
+					Expect(logBuffer.String()).To(ContainSubstring("fake-public-key-err-1"))
 				})
 			})
 		})


### PR DESCRIPTION
The agent loops over the settings sources defined in the stemcell. E.g. [here](https://github.com/cloudfoundry/bosh-linux-stemcell-builder/blob/cfe8aa1e91815eb5825e8602a20ec6c4af710b0b/stemcell_builder/stages/bosh_openstack_agent_settings/apply.sh#L21) for openstack when trying to retrieve the default ssh key [here](https://github.com/cloudfoundry/bosh-agent/blob/ae5bf9a77a516f3b9a40410f1242ca46d6399449/infrastructure/multi_settings_source.go#L39). In case of an error the agent tries the next source. The file setting source, however, does not return an SSH Key at all, but also does not error out, therefore blocking the agent from trying other sources for the SSH key retrieval. Therefore, the file setting source should return an error when an ssh key is trying to be fetched, so that the agent can fall back to other settings sources for the ssh key retrieval.