### PR TITLE
Set command to spawn with lower priority in GenericScript Run method

### DIFF
--- a/agent/script/generic_script.go
+++ b/agent/script/generic_script.go
@@ -84,6 +84,7 @@ func (s GenericScript) Run() error {
 	command := cmd.BuildCommand(s.path)
 	command.Stdout = stdoutFile
 	command.Stderr = stderrFile
+	command.SpawnWithLowerPriority = true
 
 	for key, val := range s.env {
 		command.Env[key] = val


### PR DESCRIPTION
Lifecycle scripts (drain, pre-start, post-start, post-deploy, etc.) are executed by the agent and inherit its scheduling priority. When a script is CPU-intensive (e.g. cloning large amounts of data from a database cluster), it can starve the agent's own event loop, causing the director to time out with an agent-unreachable error - even though the agent is technically alive and the script is making progress. The deployment then fails and the script has to run from scratch.

The stemcell already runs the agent at nice -15 (see [bosh-linux-stemcell-builder@00054bd](https://github.com/cloudfoundry/bosh-linux-stemcell-builder/commit/00054bd98693465dd75eda1f12a7326fc5191804)) to give it priority over BOSH-managed jobs (nice 0). However, lifecycle scripts spawned by the agent inherit that -15 priority, defeating the purpose.

This PR sets `SpawnWithLowerPriority = true` on the `Command` struct for all lifecycle scripts, so they run at a lower priority than the agent itself:

- **Linux:** child process nice = parent nice + 5 (capped at 19). With the agent at -15, scripts get nice -10 - still above normal jobs (0), but below the agent.
- **Windows:** child process priority class is set to `BelowNormal`.

The priority logic itself lives entirely in bosh-utils ([#142](https://github.com/cloudfoundry/bosh-utils/pull/142)), which adds the `SpawnWithLowerPriority` field to `boshsys.Command` with platform-specific priority logic inlined directly (no external dependency, as suggested by [@rkoster](https://github.com/rkoster)).

## References

- Fixes #337
- Depends on cloudfoundry/bosh-utils#142
