### PR TITLE
Detect SR-IOV VFs via AZURE_UNMANAGED_SRIOV udev property

### DIFF
--- a/platform/net/mac_address_detector.go
+++ b/platform/net/mac_address_detector.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	gonet "net"
 	"path"
+	"slices"
 	"strings"
 
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
@@ -18,9 +19,10 @@ type MACAddressDetector interface {
 }
 
 const (
-	ifaliasPrefix            = "bosh-interface"
-	sriovVFIfalias           = "sriov-vf"
-	macAddressDetectorLogTag = "MacAddressDetector"
+	ifaliasPrefix              = "bosh-interface"
+	azureUnmanagedSRIOVUdevTag = "E:AZURE_UNMANAGED_SRIOV=1"
+	udevDataDir                = "/run/udev/data"
+	macAddressDetectorLogTag   = "MacAddressDetector"
 )
 
 type linuxMacAddressDetector struct {
@@ -75,16 +77,10 @@ func (d linuxMacAddressDetector) DetectMacAddresses() (map[string]string, error)
 			hasBoshPrefix = strings.HasPrefix(ifalias, ifaliasPrefix)
 		}
 
-		// SR-IOV VF interfaces share the same MAC address as synthetic interfaces and should be ignored
-		// They have an ifalias with the content "sriov-vf"
-		isSRIOVVF := false
-		if err == nil {
-			isSRIOVVF = strings.Contains(ifalias, sriovVFIfalias)
-			if isSRIOVVF {
-				interfaceName := path.Base(filePath)
-				d.logger.Debug(macAddressDetectorLogTag, "Ignoring SR-IOV VF interface: %s (ifalias: %s)", interfaceName, strings.TrimSpace(ifalias))
-				continue
-			}
+		if d.isAzureUnmanagedSRIOV(filePath) {
+			interfaceName := path.Base(filePath)
+			d.logger.Debug(macAddressDetectorLogTag, "Ignoring SR-IOV VF interface: %s (AZURE_UNMANAGED_SRIOV=1)", interfaceName)
+			continue
 		}
 
 		if isPhysicalDevice || hasBoshPrefix {
@@ -142,4 +138,20 @@ func adapterVisible(netAdapters []netAdapter, macAddress string, adapterName str
 		}
 	}
 	return false
+}
+
+// isAzureUnmanagedSRIOV returns true when the udev database tags the interface
+// with AZURE_UNMANAGED_SRIOV=1. The azure-vm-utils package applies this property
+// to SR-IOV VF devices transparently bonded under an hv_netvsc synthetic
+// interface, signaling that the IP layer should not configure them.
+func (d linuxMacAddressDetector) isAzureUnmanagedSRIOV(sysClassNetPath string) bool {
+	ifindex, err := d.fs.ReadFileString(path.Join(sysClassNetPath, "ifindex"))
+	if err != nil {
+		return false
+	}
+	contents, err := d.fs.ReadFileString(path.Join(udevDataDir, "n"+strings.TrimSpace(ifindex)))
+	if err != nil {
+		return false
+	}
+	return slices.Contains(strings.Split(contents, "\n"), azureUnmanagedSRIOVUdevTag)
 }

--- a/platform/net/mac_address_detector_test.go
+++ b/platform/net/mac_address_detector_test.go
@@ -140,10 +140,23 @@ var _ = Describe("MacAddressDetector", func() {
 					}))
 				})
 
+				It("includes the interface when the ifindex file is missing", func() {
+					stubInterfacesWithVirtual(map[string]string{
+						"aa:bb": "eth0",
+					}, nil, nil)
+
+					interfacesByMacAddress, err := macAddressDetector.DetectMacAddresses()
+					Expect(err).ToNot(HaveOccurred())
+					Expect(interfacesByMacAddress).To(HaveKeyWithValue("aa:bb", "eth0"))
+				})
+
 				It("includes the interface when the udev data file is missing", func() {
 					stubInterfacesWithVirtual(map[string]string{
 						"aa:bb": "eth0",
 					}, nil, nil)
+					// ifindex present but no /run/udev/data/n<ifindex> file
+					err := fs.WriteFileString("/sys/class/net/eth0/ifindex", "2\n")
+					Expect(err).NotTo(HaveOccurred())
 
 					interfacesByMacAddress, err := macAddressDetector.DetectMacAddresses()
 					Expect(err).ToNot(HaveOccurred())

--- a/platform/net/mac_address_detector_test.go
+++ b/platform/net/mac_address_detector_test.go
@@ -105,15 +105,25 @@ var _ = Describe("MacAddressDetector", func() {
 				})
 			})
 
-			Context("when there are SR-IOV VF interfaces", func() {
+			Context("when there are SR-IOV VF interfaces marked AZURE_UNMANAGED_SRIOV=1", func() {
+				writeUdevProperties := func(iface, ifindex, body string) {
+					err := fs.WriteFileString(fmt.Sprintf("/sys/class/net/%s/ifindex", iface), ifindex+"\n")
+					Expect(err).NotTo(HaveOccurred())
+					err = fs.WriteFileString(fmt.Sprintf("/run/udev/data/n%s", ifindex), body)
+					Expect(err).NotTo(HaveOccurred())
+				}
+
 				It("should ignore VF interfaces", func() {
 					stubInterfacesWithVirtual(map[string]string{
 						"aa:bb": "eth0",
 						"cc:dd": "eth2",
 					}, nil, nil)
 
-					sriovVF1Path := writeNetworkDevice("eth1", "aa:bb", true, "sriov-vf")
-					sriovVF2Path := writeNetworkDevice("eth3", "ee:ff", true, "sriov-vf")
+					sriovVF1Path := writeNetworkDevice("eth1", "aa:bb", true, "")
+					writeUdevProperties("eth1", "3", "I:1\nE:AZURE_UNMANAGED_SRIOV=1\nE:ID_NET_DRIVER=mlx5_core\n")
+
+					sriovVF2Path := writeNetworkDevice("eth3", "ee:ff", true, "")
+					writeUdevProperties("eth3", "5", "E:AZURE_UNMANAGED_SRIOV=1\n")
 
 					existingPaths, err := fs.Glob("/sys/class/net/*")
 					Expect(err).NotTo(HaveOccurred())
@@ -127,6 +137,37 @@ var _ = Describe("MacAddressDetector", func() {
 					Expect(interfacesByMacAddress).To(Equal(map[string]string{
 						"aa:bb": "eth0",
 						"cc:dd": "eth2",
+					}))
+				})
+
+				It("includes the interface when the udev data file is missing", func() {
+					stubInterfacesWithVirtual(map[string]string{
+						"aa:bb": "eth0",
+					}, nil, nil)
+
+					interfacesByMacAddress, err := macAddressDetector.DetectMacAddresses()
+					Expect(err).ToNot(HaveOccurred())
+					Expect(interfacesByMacAddress).To(HaveKeyWithValue("aa:bb", "eth0"))
+				})
+
+				It("does not match a substring or differently-valued property", func() {
+					stubInterfacesWithVirtual(map[string]string{
+						"aa:bb": "eth0",
+					}, nil, nil)
+
+					vfPath := writeNetworkDevice("eth1", "cc:dd", true, "")
+					// AZURE_UNMANAGED_SRIOV=0 and a similarly-named property must not trigger the skip
+					writeUdevProperties("eth1", "3", "E:AZURE_UNMANAGED_SRIOV=0\nE:SOME_AZURE_UNMANAGED_SRIOV=1\n")
+
+					existing, err := fs.Glob("/sys/class/net/*")
+					Expect(err).NotTo(HaveOccurred())
+					fs.SetGlob("/sys/class/net/*", append(existing, vfPath))
+
+					interfacesByMacAddress, err := macAddressDetector.DetectMacAddresses()
+					Expect(err).ToNot(HaveOccurred())
+					Expect(interfacesByMacAddress).To(Equal(map[string]string{
+						"aa:bb": "eth0",
+						"cc:dd": "eth1",
 					}))
 				})
 			})


### PR DESCRIPTION
Replace the sriov-vf ifalias check in the MAC address detector with detection of the `AZURE_UNMANAGED_SRIOV=1` udev property applied by [*azure-vm-utils*](https://github.com/Azure/azure-vm-utils) to SR-IOV VF devices bonded under hv_netvsc.

This makes MAC-based interface detection correct on stemcells that [ship](https://github.com/cloudfoundry/bosh-linux-stemcell-builder/blob/bc3670b441af248a3a9bdaa04fec506307d17939/stemcell_builder/stages/system_azure_init/apply.sh#L9) *azure-vm-utils* (e.g. Ubuntu Noble) without requiring a parallel stemcell-side [`ifalias` workaround](https://github.com/cloudfoundry/bosh-linux-stemcell-builder/pull/443/changes#diff-e039fa4be78e195ff9340f11ba02bb48fb0a64a9f5b3c180f51fafa679a1ce9cR19).

Stemcells that currently set `ATTR{ifalias}="sriov-vf"` (e.g. Ubuntu Jammy) already set `ENV{AZURE_UNMANAGED_SRIOV}="1"` alongside, so the new check is a strict superset of the previous behaviour.

The property is read from `/run/udev/data/n<ifindex>`, where udev persists per-device properties as lines of the form `"E:KEY=VALUE"`.

### Self-Validation

Built the agent, baked it into the latest noble stemcell and re-deployed with accelerated-networking enabled on Azure. Based on the logs it looks like the agent is going the right code path and ignores the VF interface (which uses `mlx5_core` driver):

```sh
zookeeper/df0f0087-4274-4862-aa82-04d601f3b1ea: ~# zgrep "Ignoring SR-IOV VF interface" /var/vcap/bosh/log/*
2026-06-26T15:32:47.924626+00:00 ab4fdf5c-2b60-431f-9995-5c53890866ae bosh-agent[1755]: [MacAddressDetectorl 2026/06/
6 15:32:47 DEBUG - Ignoring SR-IOV VF interface: eth1 (AZURE_UNMANAGED_SRIOV=1)
2026-06-26T15:32:52.694369+00:00 ab4fdf5c-2b60-431f-9995-5c53890866ae bosh-agent[3214]: [MacAddressDetector] 2026/06/
6 15:32:52 DEBUG - Ignoring SR-IOV VF interface: eth1 (AZURE_UNMANAGED_SRIOV=1)

zookeeper/df0f0087-4274-4862-aa82-04d601f3b1ea:~# ethtool -i eth1 | grep driver
driver: mlx5_core
```