### PR TITLE
Add AI review feedback section to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+### What is this change about?
+
+_Describe the change and why it's needed._
+
+### Please provide contextual information.
+
+_Include any links to other PRs, stories, slack discussions, etc... that will help establish context._
+
+### What tests have you run against this PR?
+
+_Include a comprehensive list of all tests run successfully._
+
+### How should this change be described in bosh-agent release notes?
+
+_Something brief that conveys the change and is written with the Operator audience in mind.
+See [previous release notes](https://github.com/cloudfoundry/bosh-agent/releases) for examples._
+
+### Does this PR introduce a breaking change?
+
+_Does this introduce changes that would require operators to take care in order to upgrade without a failure?_
+
+### Tag your pair, your PM, and/or team!
+_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
+
+### AI Review Feedback
+
+_All AI review comments (CodeRabbit, and Copilot when assigned) must be resolved before human reviewers will look at the PR. For each comment, either:_
+- _Make the suggested change, or_
+- _Reply to the comment explaining why it does not apply, then resolve the thread._

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,6 +20,7 @@ See [previous release notes](https://github.com/cloudfoundry/bosh-agent/releases
 _Does this introduce changes that would require operators to take care in order to upgrade without a failure?_
 
 ### Tag your pair, your PM, and/or team!
+
 _It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
 
 ### AI Review Feedback


### PR DESCRIPTION
## Summary

- Adds a new **AI Review Feedback** section to the PR template
- Clarifies that all CodeRabbit and Copilot (when assigned) review comments must be resolved before human reviewers will look at the PR
- Each comment must either result in a code change, or a reply explaining why it does not apply with the thread resolved