### PR TITLE
ci: migrate registry-image resources from Docker Hub to GHCR

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -93,17 +93,17 @@ resources:
   - name: bosh-agent-docker-image
     type: registry-image
     source:
-      repository: docker.io/bosh/agent
+      repository: ghcr.io/cloudfoundry/bosh-agent
       tag: latest
-      username: ((docker.username))
-      password: ((docker.password))
+      username: ((github_read_write_packages.username))
+      password: ((github_read_write_packages.password))
 
   - name: bosh-agent-registry-image
     type: registry-image
     source:
-      repository: docker.io/bosh/agent
-      username: ((docker.username))
-      password: ((docker.password))
+      repository: ghcr.io/cloudfoundry/bosh-agent
+      username: ((github_read_write_packages.username))
+      password: ((github_read_write_packages.password))
 
   - name: golang-release-image
     type: registry-image
@@ -113,10 +113,10 @@ resources:
   - name: integration-postgres-15-image
     type: registry-image
     source:
-      repository: docker.io/bosh/main-postgres-15
+      repository: ghcr.io/cloudfoundry/bosh/main-postgres-15
       tag: main
-      username: ((docker.username))
-      password: ((docker.password))
+      username: ((github_read_write_packages.username))
+      password: ((github_read_write_packages.password))
 
   - name: bosh
     type: git


### PR DESCRIPTION
## Summary

Switch all three `registry-image` resources from `docker.io` to `ghcr.io/cloudfoundry`, using the `github_read_write_packages` credential already in CredHub:

| Resource | Before | After |
|---|---|---|
| `bosh-agent-docker-image` | `docker.io/bosh/agent` | `ghcr.io/cloudfoundry/bosh-agent` |
| `bosh-agent-registry-image` | `docker.io/bosh/agent` | `ghcr.io/cloudfoundry/bosh-agent` |
| `integration-postgres-15-image` | `docker.io/bosh/main-postgres-15` | `ghcr.io/cloudfoundry/bosh/main-postgres-15` |

Resource types (`bosh-deployment-resource`, `metalink-repository-resource`, `semver-resource`) remain on Docker Hub — no GHCR equivalents exist for these Concourse worker plugins.

## Why

The `integration-postgres-15` GHCR image has `bundle config set --global path "${GEM_HOME}"` baked in. This ensures bundled gems land in `GEM_HOME`, which the CPI wrapper script (`cpi.erb`) exports into the CPI subprocess environment. Without it, `require 'bundler/setup'` and `require 'cloud'` silently crash the subprocess, producing the `Invalid CPI response - unexpected end of input` failures that plagued `bosh-integration-tests` since build 591.

**Verified:** `bosh-integration-tests` build 601 succeeded (1h9m, 0 failures across all suites) after switching to the GHCR image.

## Post-merge action required

`ghcr.io/cloudfoundry/bosh-agent` does not exist yet. After merging and reconfiguring the pipeline, manually trigger `build-docker-image` once to bootstrap the package on GHCR. All downstream jobs will then trigger normally via `bosh-agent-registry-image`.

Made with [Cursor](https://cursor.com)