### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,6 +1,8 @@
 ---
 name: go
 on: [push, pull_request]
+permissions:
+  contents: read
 jobs:
   lint: # <- name
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/cloudfoundry/bosh-agent/security/code-scanning/14](https://github.com/cloudfoundry/bosh-agent/security/code-scanning/14)

Add an explicit top-level `permissions` block in `.github/workflows/go.yml` so all jobs inherit restricted `GITHUB_TOKEN` access. The best minimal fix (without changing functionality) is:

- Add at workflow root (after `on` is a clear location):
  - `permissions:`
  - `  contents: read`

This preserves current behavior for checkout/lint/test while preventing accidental write access if repo/org defaults are permissive or later changed. No imports, methods, or dependencies are needed—just YAML configuration in the existing workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
