### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,6 +1,8 @@
 ---
 name: go
 on: [push, pull_request]
+permissions:
+  contents: read
 jobs:
   lint: # <- name
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/cloudfoundry/bosh-agent/security/code-scanning/13](https://github.com/cloudfoundry/bosh-agent/security/code-scanning/13)

Add an explicit workflow-level `permissions` block in `.github/workflows/go.yml` so all jobs inherit least-privilege token access by default.

Best fix without changing functionality:
- In `.github/workflows/go.yml`, insert:
  - `permissions:`
  - `  contents: read`
- Place it at the top level (after `on:` is a clear location), before `jobs:`.  
This preserves current behavior for checkout/lint/test while making token scope explicit and stable across repo/org default changes.

No imports, methods, or external definitions are needed since this is a YAML workflow configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
