### PR TITLE
Honor explicit DHCP for aliased networks

### DIFF
--- a/platform/net/interface_configuration_creator.go
+++ b/platform/net/interface_configuration_creator.go
@@ -221,7 +221,8 @@ func (creator interfaceConfigurationCreator) createMultipleInterfaceConfiguratio
 func (creator interfaceConfigurationCreator) createInterfaceConfiguration(staticConfigs []StaticInterfaceConfiguration, dhcpConfigs []DHCPInterfaceConfiguration, ifaceName string, networkSettings boshsettings.Network) ([]StaticInterfaceConfiguration, []DHCPInterfaceConfiguration, error) {
 	creator.logger.Debug(creator.logTag, "Creating network configuration with settings: %s", networkSettings)
 
-	if (networkSettings.IsDHCP() || networkSettings.Mac == "") && networkSettings.Alias == "" {
+	usesExplicitDHCP := networkSettings.IsDHCP() && networkSettings.UseDHCP
+	if usesExplicitDHCP || ((networkSettings.IsDHCP() || networkSettings.Mac == "") && networkSettings.Alias == "") {
 		creator.logger.Debug(creator.logTag, "Using dhcp networking")
 		dhcpConfigs = append(dhcpConfigs, DHCPInterfaceConfiguration{
 			Name:                ifaceName,

--- a/platform/net/interface_configuration_creator_test.go
+++ b/platform/net/interface_configuration_creator_test.go
@@ -551,6 +551,39 @@ var _ = Describe("InterfaceConfigurationCreator", func() {
 				})
 			})
 
+			Context("when IPv4 and IPv6 DHCP networks share an alias", func() {
+				BeforeEach(func() {
+					ipv4Network := staticNetworkWithoutMAC
+					ipv4Network.Alias = "eth0"
+					ipv4Network.UseDHCP = true
+					networks["ipv4"] = ipv4Network
+					networks["ipv6"] = boshsettings.Network{
+						Type:    "manual",
+						IP:      "2001:db8::1",
+						Netmask: "ffff:ffff:ffff:ffff:0000:0000:0000:0000",
+						UseDHCP: true,
+						Alias:   "eth0",
+					}
+				})
+
+				It("creates DHCP configurations for both addresses", func() {
+					staticInterfaceConfigurations, dhcpInterfaceConfigurations, err := interfaceConfigurationCreator.CreateInterfaceConfigurations(networks, interfacesByMAC)
+					Expect(err).ToNot(HaveOccurred())
+
+					Expect(staticInterfaceConfigurations).To(BeEmpty())
+					Expect(dhcpInterfaceConfigurations).To(ConsistOf(
+						DHCPInterfaceConfiguration{
+							Name:    "eth0",
+							Address: "1.2.3.4",
+						},
+						DHCPInterfaceConfiguration{
+							Name:    "eth0",
+							Address: "2001:db8::1",
+						},
+					))
+				})
+			})
+
 			Context("when multiple networks with ipv6 for one interface exist", func() {
 				BeforeEach(func() {
 					networks["foo"] = staticNetworkipv6

--- a/platform/net/ubuntu_net_manager_ipv6_test.go
+++ b/platform/net/ubuntu_net_manager_ipv6_test.go
@@ -206,6 +206,57 @@ Gateway=2001:db8::1
 `)).To(BeTrue())
 		})
 
+		It("groups aliased IPv4 and IPv6 DHCP networks into one networkd configuration", func() {
+			ipv4Net := boshsettings.Network{
+				Type:    "manual",
+				IP:      "1.2.3.4",
+				Netmask: "255.255.255.0",
+				Gateway: "3.4.5.6",
+				UseDHCP: true,
+				Alias:   "eth0",
+			}
+			ipv6Net := boshsettings.Network{
+				Type:    "manual",
+				IP:      "2001:db8::103",
+				Netmask: "ffff:ffff:ffff:ffff:0000:0000:0000:0000",
+				Gateway: "2001:db8::1",
+				Default: []string{"dns"},
+				DNS:     []string{"2001:4860:4860::8888", "2001:4860:4860::8844"},
+				UseDHCP: true,
+				Alias:   "eth0",
+			}
+
+			stubInterfaces(map[string]boshsettings.Network{
+				"eth0": {Mac: "mac1"},
+			})
+
+			err := netManager.SetupNetworking(boshsettings.Networks{"ipv4": ipv4Net, "ipv6": ipv6Net}, nil, nil)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(kernelIPv6.Enabled).To(BeTrue())
+
+			matches, err := fs.Ls("/etc/systemd/network/")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(matches).To(ConsistOf(
+				"/etc/systemd/network/10_eth0.network",
+			))
+
+			networkConfig := fs.GetFileTestStat("/etc/systemd/network/10_eth0.network")
+			Expect(networkConfig).ToNot(BeNil())
+			Expect(networkConfig.StringContents()).To(ContainSubstring(`
+[Match]
+Name=eth0
+`))
+			Expect(networkConfig.StringContents()).To(ContainSubstring(`
+[Network]
+DHCP=yes
+IPv6AcceptRA=true
+DNS=2001:4860:4860::8888
+DNS=2001:4860:4860::8844
+`))
+			Expect(networkConfig.StringContents()).ToNot(ContainSubstring("[Address]"))
+		})
+
 		It("returns error if enabling IPv6 in kernel fails", func() {
 			static1Net := boshsettings.Network{
 				Type:    "manual",


### PR DESCRIPTION
### What is this change about?

Honor explicit DHCP for aliased networks so both address families are grouped into one DHCP-enabled networkd unit. Preserve existing static alias behavior when `use_dhcp` is false.

### Please provide contextual information.

An interface alias identifies which device a network belongs to when the CPI cannot provide a MAC address. It must not override the network's explicit use_dhcp setting.

Azure assigns control-plane static addresses through DHCP in the guest. For networks sharing a NIC, the CPI therefore supplies the same interface alias with use_dhcp set to true for both IPv4 and IPv6.

The agent previously treated every aliased network as static. Each address family was consequently written separately to the same networkd file, and the last write discarded the other family.

### What tests have you run against this PR?

- Unit tests
- Deployed  a stemcell with a patched agent and verified it starts up and works with dual stack networks. In the case of azure this requires https://github.com/cloudfoundry/bosh-azure-cpi-release/pull/746.

### How should this change be described in bosh-agent release notes?

_Something brief that conveys the change and is written with the Operator audience in mind.
See [previous release notes](https://github.com/cloudfoundry/bosh-agent/releases) for examples._

### Does this PR introduce a breaking change?

No

### Tag your pair, your PM, and/or team!

@a-hassanin

### AI Review Feedback

_All AI review comments (CodeRabbit, and Copilot when assigned) must be resolved before human reviewers will look at the PR. For each comment, either:_
- [ ] _Make the suggested change, or_
- [x] _Reply to the comment explaining why it does not apply, then resolve the thread._
