### PR TITLE
Reduce concurrent integration tests

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -623,6 +623,7 @@ jobs:
           DB: postgresql
           RAKE_TASK: "spec:integration"
           COVERAGE: false
+          PARALLEL_TEST_MULTIPLY_PROCESSES: "0.6"
 
   - name: promote
     serial: true


### PR DESCRIPTION
Mirroring this bosh pr: https://github.com/cloudfoundry/bosh/pull/2759 since they share the same wiring for integration tests

(already flown)