### PR TITLE
Revert "Reduce concurrent integration tests"

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -623,7 +623,6 @@ jobs:
           DB: postgresql
           RAKE_TASK: "spec:integration"
           COVERAGE: false
-          PARALLEL_TEST_MULTIPLY_PROCESSES: "0.6"
 
   - name: promote
     serial: true


### PR DESCRIPTION
Reverts cloudfoundry/bosh-agent#453

After https://github.com/cloudfoundry/bosh/pull/2792 I don't think it's necessary anymore - here is a successful run without the value set: https://ci.bosh-ecosystem.cf-app.com/teams/main/pipelines/bosh-agent-main/jobs/bosh-integration-tests/builds/608

(already flown)