### PR TITLE
ci: switch config-server resource to config-server-release repo

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -41,8 +41,8 @@ resources:
   - name: config-server
     type: git
     source:
-      uri: https://github.com/cloudfoundry/config-server.git
-      branch: develop
+      uri: https://github.com/cloudfoundry/config-server-release.git
+      branch: main
       username: bosh-admin-bot
       password: ((github_public_repo_token))
 


### PR DESCRIPTION


### What is this change about?

The cloudfoundry/config-server repo has been archived; its contents were merged into cloudfoundry/config-server-release. Update the pipeline resource to use HTTPS against the new repo (removing the SSH deploy key), target the main branch, and update SOURCE_DIR in config_server_service.rb to point to src/config-server within the release repo where the Go source now lives.

Copying what was done here: https://github.com/cloudfoundry/bosh/commit/53beb8aa7a9997c2abc5278f944dd69a347dc5e5

Changes already flown, running here: https://ci.bosh-ecosystem.cf-app.com/teams/main/pipelines/bosh-agent-main/jobs/bosh-integration-tests/builds/612

ai-assisted=yes
[TNZ-106038] Refactor bosh-agent CI pipeline to run integration tests on all supported stemcell lines (Jammy, Noble, Resolute)

