### PR TITLE
ci: use agent image for unit tests task

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -336,6 +336,7 @@ jobs:
       - get: bosh-agent-registry-image
         trigger: true
       - task: test-unit
+        image: bosh-agent-registry-image
         file: bosh-agent-ci/ci/tasks/test-unit.yml
 
   - name: test-unit-windows


### PR DESCRIPTION
the job gets it, but never used it. Might've been overlooked

changes already flown: https://ci.bosh-ecosystem.cf-app.com/teams/main/pipelines/bosh-agent-main/jobs/test-unit/builds/865

ai-assisted=yes
[TNZ-106038] Refactor bosh-agent CI pipeline to run integration tests on all supported stemcell lines (Jammy, Noble, Resolute)