### PR TITLE
Retry `resize2fs` on transient Permission denied during persistent disk grow

### DIFF
--- a/platform/disk/linux_disk_manager.go
+++ b/platform/disk/linux_disk_manager.go
@@ -82,7 +82,7 @@ func NewLinuxDiskManager(
 	return linuxDiskManager{
 		ephemeralPartitioner:  ephemeralPartitioner,
 		diskUtil:              diskUtil,
-		formatter:             NewLinuxFormatter(runner, fs),
+		formatter:             NewLinuxFormatter(runner, fs, clock.NewClock()),
 		fs:                    fs,
 		logger:                logger,
 		mounter:               mounter,

--- a/platform/disk/linux_disk_manager.go
+++ b/platform/disk/linux_disk_manager.go
@@ -82,7 +82,7 @@ func NewLinuxDiskManager(
 	return linuxDiskManager{
 		ephemeralPartitioner:  ephemeralPartitioner,
 		diskUtil:              diskUtil,
-		formatter:             NewLinuxFormatter(runner, fs, clock.NewClock()),
+		formatter:             NewLinuxFormatter(runner, fs),
 		fs:                    fs,
 		logger:                logger,
 		mounter:               mounter,

--- a/platform/disk/linux_formatter.go
+++ b/platform/disk/linux_formatter.go
@@ -3,20 +3,30 @@ package disk
 import (
 	"regexp"
 	"strings"
+	"time"
 
+	"code.cloudfoundry.org/clock"
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 	boshsys "github.com/cloudfoundry/bosh-utils/system"
 )
 
+const (
+	growFilesystemRetryDelay    = 5 * time.Second
+	growFilesystemMaxAttempts   = 10
+	growFilesystemPermDeniedMsg = "Permission denied to resize filesystem"
+)
+
 type linuxFormatter struct {
-	runner boshsys.CmdRunner
-	fs     boshsys.FileSystem
+	runner      boshsys.CmdRunner
+	fs          boshsys.FileSystem
+	timeService clock.Clock
 }
 
-func NewLinuxFormatter(runner boshsys.CmdRunner, fs boshsys.FileSystem) Formatter {
+func NewLinuxFormatter(runner boshsys.CmdRunner, fs boshsys.FileSystem, timeService clock.Clock) Formatter {
 	return linuxFormatter{
-		runner: runner,
-		fs:     fs,
+		runner:      runner,
+		fs:          fs,
+		timeService: timeService,
 	}
 }
 
@@ -74,11 +84,7 @@ func (f linuxFormatter) GrowFilesystem(partitionPath string) error {
 
 	switch existingFsType {
 	case FileSystemExt4:
-		_, _, _, err := f.runner.RunCommand(
-			"resize2fs",
-			"-f",
-			partitionPath,
-		)
+		err = f.growExt4WithRetry(partitionPath)
 		if err != nil {
 			return bosherr.WrapError(err, "Failed to grow Ext4 filesystem")
 		}
@@ -95,6 +101,25 @@ func (f linuxFormatter) GrowFilesystem(partitionPath string) error {
 		return nil
 	}
 	return nil
+}
+
+// growExt4WithRetry retries resize2fs when the block device reports "Permission
+// denied". This can happen transiently after an online volume extension while
+// the block device's new size is not yet consistently visible to the guest, and
+// resolves once the underlying storage layer settles.
+func (f linuxFormatter) growExt4WithRetry(partitionPath string) error {
+	var err error
+	for range growFilesystemMaxAttempts {
+		_, _, _, err = f.runner.RunCommand("resize2fs", "-f", partitionPath)
+		if err == nil {
+			return nil
+		}
+		if !strings.Contains(err.Error(), growFilesystemPermDeniedMsg) {
+			return err
+		}
+		f.timeService.Sleep(growFilesystemRetryDelay)
+	}
+	return err
 }
 
 func (f linuxFormatter) makeFileSystemExt4(partitionPath string) error {

--- a/platform/disk/linux_formatter.go
+++ b/platform/disk/linux_formatter.go
@@ -11,8 +11,8 @@ import (
 )
 
 const (
-	growFilesystemRetryDelay    = 5 * time.Second
-	growFilesystemMaxAttempts   = 10
+	growFilesystemRetryDelay  = 5 * time.Second
+	growFilesystemMaxRetries  = 10
 	growFilesystemPermDeniedMsg = "Permission denied to resize filesystem"
 )
 
@@ -109,7 +109,10 @@ func (f linuxFormatter) GrowFilesystem(partitionPath string) error {
 // resolves once the underlying storage layer settles.
 func (f linuxFormatter) growExt4WithRetry(partitionPath string) error {
 	var err error
-	for range growFilesystemMaxAttempts {
+	for retry := range growFilesystemMaxRetries + 1 {
+		if retry > 0 {
+			f.timeService.Sleep(growFilesystemRetryDelay)
+		}
 		_, _, _, err = f.runner.RunCommand("resize2fs", "-f", partitionPath)
 		if err == nil {
 			return nil
@@ -117,7 +120,6 @@ func (f linuxFormatter) growExt4WithRetry(partitionPath string) error {
 		if !strings.Contains(err.Error(), growFilesystemPermDeniedMsg) {
 			return err
 		}
-		f.timeService.Sleep(growFilesystemRetryDelay)
 	}
 	return err
 }

--- a/platform/disk/linux_formatter.go
+++ b/platform/disk/linux_formatter.go
@@ -11,8 +11,8 @@ import (
 )
 
 const (
-	growFilesystemRetryDelay  = 5 * time.Second
-	growFilesystemMaxRetries  = 10
+	growFilesystemRetryDelay    = 5 * time.Second
+	growFilesystemMaxRetries    = 10
 	growFilesystemPermDeniedMsg = "Permission denied to resize filesystem"
 )
 

--- a/platform/disk/linux_formatter.go
+++ b/platform/disk/linux_formatter.go
@@ -22,7 +22,11 @@ type linuxFormatter struct {
 	timeService clock.Clock
 }
 
-func NewLinuxFormatter(runner boshsys.CmdRunner, fs boshsys.FileSystem, timeService clock.Clock) Formatter {
+func NewLinuxFormatter(runner boshsys.CmdRunner, fs boshsys.FileSystem) Formatter {
+	return NewLinuxFormatterWithClock(runner, fs, clock.NewClock())
+}
+
+func NewLinuxFormatterWithClock(runner boshsys.CmdRunner, fs boshsys.FileSystem, timeService clock.Clock) Formatter {
 	return linuxFormatter{
 		runner:      runner,
 		fs:          fs,

--- a/platform/disk/linux_formatter_test.go
+++ b/platform/disk/linux_formatter_test.go
@@ -21,7 +21,7 @@ var _ = Describe("Linux Formatter", func() {
 				fakeFs := fakesys.NewFakeFileSystem()
 				fakeRunner.AddCmdResult("blkid -p /dev/xvda2", fakesys.FakeCmdResult{ExitStatus: 2, Error: errors.New("Exit code 2")})
 
-				formatter := NewLinuxFormatter(fakeRunner, fakeFs, &fakeboshaction.FakeClock{})
+				formatter := NewLinuxFormatter(fakeRunner, fakeFs)
 				err := formatter.Format("/dev/xvda2", FileSystemSwap)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -34,7 +34,7 @@ var _ = Describe("Linux Formatter", func() {
 				fakeFs := fakesys.NewFakeFileSystem()
 				fakeRunner.AddCmdResult("blkid -p /dev/xvda1", fakesys.FakeCmdResult{Stdout: `xxxxx TYPE="ext4" yyyy zzzz`})
 
-				formatter := NewLinuxFormatter(fakeRunner, fakeFs, &fakeboshaction.FakeClock{})
+				formatter := NewLinuxFormatter(fakeRunner, fakeFs)
 				err := formatter.Format("/dev/xvda1", FileSystemSwap)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -47,7 +47,7 @@ var _ = Describe("Linux Formatter", func() {
 				fakeFs := fakesys.NewFakeFileSystem()
 				fakeRunner.AddCmdResult("blkid -p /dev/xvda1", fakesys.FakeCmdResult{Stdout: `xxxxx TYPE="swap" yyyy zzzz`})
 
-				formatter := NewLinuxFormatter(fakeRunner, fakeFs, &fakeboshaction.FakeClock{})
+				formatter := NewLinuxFormatter(fakeRunner, fakeFs)
 				err := formatter.Format("/dev/xvda1", FileSystemSwap)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -64,7 +64,7 @@ var _ = Describe("Linux Formatter", func() {
 				Expect(err).NotTo(HaveOccurred())
 				fakeRunner.AddCmdResult("blkid -p /dev/xvda2", fakesys.FakeCmdResult{Stdout: `xxxxx TYPE="ext2" yyyy zzzz`})
 
-				formatter := NewLinuxFormatter(fakeRunner, fakeFs, &fakeboshaction.FakeClock{})
+				formatter := NewLinuxFormatter(fakeRunner, fakeFs)
 				err = formatter.Format("/dev/xvda2", FileSystemExt4)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -95,7 +95,7 @@ var _ = Describe("Linux Formatter", func() {
 					fakeRunner.AddCmdResult(mkeCmd, fakesys.FakeCmdResult{
 						ExitStatus: 0,
 					})
-					formatter := NewLinuxFormatter(fakeRunner, fakeFs, &fakeboshaction.FakeClock{})
+					formatter := NewLinuxFormatter(fakeRunner, fakeFs)
 					err := formatter.Format("/dev/xvda2", FileSystemExt4)
 					Expect(err).NotTo(HaveOccurred())
 
@@ -108,7 +108,7 @@ var _ = Describe("Linux Formatter", func() {
 					fakeRunner.AddCmdResult(mkeCmd, fakesys.FakeCmdResult{
 						Error: errors.New(`some other error`),
 					})
-					formatter := NewLinuxFormatter(fakeRunner, fakeFs, &fakeboshaction.FakeClock{})
+					formatter := NewLinuxFormatter(fakeRunner, fakeFs)
 					err := formatter.Format("/dev/xvda2", FileSystemExt4)
 					Expect(err).To(HaveOccurred())
 
@@ -122,7 +122,7 @@ var _ = Describe("Linux Formatter", func() {
 				fakeFs := fakesys.NewFakeFileSystem()
 				fakeRunner.AddCmdResult("blkid -p /dev/xvda2", fakesys.FakeCmdResult{Stdout: `xxxxx TYPE="ext2" yyyy zzzz`})
 
-				formatter := NewLinuxFormatter(fakeRunner, fakeFs, &fakeboshaction.FakeClock{})
+				formatter := NewLinuxFormatter(fakeRunner, fakeFs)
 				err := formatter.Format("/dev/xvda2", FileSystemExt4)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -135,7 +135,7 @@ var _ = Describe("Linux Formatter", func() {
 				fakeFs := fakesys.NewFakeFileSystem()
 				fakeRunner.AddCmdResult("blkid -p /dev/xvda1", fakesys.FakeCmdResult{Stdout: `xxxxx TYPE="ext4" yyyy zzzz`})
 
-				formatter := NewLinuxFormatter(fakeRunner, fakeFs, &fakeboshaction.FakeClock{})
+				formatter := NewLinuxFormatter(fakeRunner, fakeFs)
 				err := formatter.Format("/dev/xvda1", FileSystemExt4)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -148,7 +148,7 @@ var _ = Describe("Linux Formatter", func() {
 				fakeFs := fakesys.NewFakeFileSystem()
 				fakeRunner.AddCmdResult("blkid -p /dev/xvda2", fakesys.FakeCmdResult{Stdout: `xxxxx TYPE="xfs" yyyy zzzz`})
 
-				formatter := NewLinuxFormatter(fakeRunner, fakeFs, &fakeboshaction.FakeClock{})
+				formatter := NewLinuxFormatter(fakeRunner, fakeFs)
 				err := formatter.Format("/dev/xvda2", FileSystemExt4)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -161,7 +161,7 @@ var _ = Describe("Linux Formatter", func() {
 				fakeFs := fakesys.NewFakeFileSystem()
 				fakeRunner.AddCmdResult("blkid -p /dev/xvda2", fakesys.FakeCmdResult{Stdout: `xxxxx TYPE="somethingelse" yyyy zzzz`})
 
-				formatter := NewLinuxFormatter(fakeRunner, fakeFs, &fakeboshaction.FakeClock{})
+				formatter := NewLinuxFormatter(fakeRunner, fakeFs)
 				err := formatter.Format("/dev/xvda2", FileSystemExt4)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -176,7 +176,7 @@ var _ = Describe("Linux Formatter", func() {
 				fakeFs := fakesys.NewFakeFileSystem()
 				fakeRunner.AddCmdResult("blkid -p /dev/xvda2", fakesys.FakeCmdResult{ExitStatus: 2, Error: errors.New("Exit code 2")})
 
-				formatter := NewLinuxFormatter(fakeRunner, fakeFs, &fakeboshaction.FakeClock{})
+				formatter := NewLinuxFormatter(fakeRunner, fakeFs)
 				err := formatter.Format("/dev/xvda2", FileSystemXFS)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -189,7 +189,7 @@ var _ = Describe("Linux Formatter", func() {
 				fakeFs := fakesys.NewFakeFileSystem()
 				fakeRunner.AddCmdResult("blkid -p /dev/xvda1", fakesys.FakeCmdResult{Stdout: `xxxxx TYPE="ext4" yyyy zzzz`})
 
-				formatter := NewLinuxFormatter(fakeRunner, fakeFs, &fakeboshaction.FakeClock{})
+				formatter := NewLinuxFormatter(fakeRunner, fakeFs)
 				err := formatter.Format("/dev/xvda1", FileSystemXFS)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -202,7 +202,7 @@ var _ = Describe("Linux Formatter", func() {
 				fakeFs := fakesys.NewFakeFileSystem()
 				fakeRunner.AddCmdResult("blkid -p /dev/xvda1", fakesys.FakeCmdResult{Stdout: `xxxxx TYPE="xfs" yyyy zzzz`})
 
-				formatter := NewLinuxFormatter(fakeRunner, fakeFs, &fakeboshaction.FakeClock{})
+				formatter := NewLinuxFormatter(fakeRunner, fakeFs)
 				err := formatter.Format("/dev/xvda1", FileSystemXFS)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -216,7 +216,7 @@ var _ = Describe("Linux Formatter", func() {
 				fakeRunner.AddCmdResult("mkfs.xfs /dev/xvda2", fakesys.FakeCmdResult{Error: errors.New("Sadness")})
 				fakeRunner.AddCmdResult("blkid -p /dev/xvda2", fakesys.FakeCmdResult{Stderr: "", ExitStatus: 2})
 
-				formatter := NewLinuxFormatter(fakeRunner, fakeFs, &fakeboshaction.FakeClock{})
+				formatter := NewLinuxFormatter(fakeRunner, fakeFs)
 				err := formatter.Format("/dev/xvda2", FileSystemXFS)
 
 				Expect(err).To(HaveOccurred())
@@ -242,7 +242,7 @@ var _ = Describe("Linux Formatter", func() {
 		Context("when determining partition filesystem fails", func() {
 			BeforeEach(func() {
 				fakeRunner.AddCmdResult("blkid -p /dev/nvme2n1p1", fakesys.FakeCmdResult{ExitStatus: 1, Error: errors.New("No GPT found")})
-				formatter = NewLinuxFormatter(fakeRunner, fakeFs, fakeClock)
+				formatter = NewLinuxFormatterWithClock(fakeRunner, fakeFs, fakeClock)
 			})
 
 			It("returns an error", func() {
@@ -256,7 +256,7 @@ var _ = Describe("Linux Formatter", func() {
 		Context("when using Ext4", func() {
 			BeforeEach(func() {
 				fakeRunner.AddCmdResult("blkid -p /dev/nvme2n1p1", fakesys.FakeCmdResult{Stdout: `xxxxx TYPE="ext4" yyyy zzzz`})
-				formatter = NewLinuxFormatter(fakeRunner, fakeFs, fakeClock)
+				formatter = NewLinuxFormatterWithClock(fakeRunner, fakeFs, fakeClock)
 			})
 
 			It("grows the Ext4 filesystem", func() {
@@ -319,7 +319,7 @@ var _ = Describe("Linux Formatter", func() {
 		Context("when using XFS", func() {
 			BeforeEach(func() {
 				fakeRunner.AddCmdResult("blkid -p /dev/nvme2n1p1", fakesys.FakeCmdResult{Stdout: `xxxxx TYPE="xfs" yyyy zzzz`})
-				formatter = NewLinuxFormatter(fakeRunner, fakeFs, fakeClock)
+				formatter = NewLinuxFormatterWithClock(fakeRunner, fakeFs, fakeClock)
 			})
 
 			It("grows the XFS filesystem", func() {

--- a/platform/disk/linux_formatter_test.go
+++ b/platform/disk/linux_formatter_test.go
@@ -9,6 +9,7 @@ import (
 
 	fakesys "github.com/cloudfoundry/bosh-utils/system/fakes"
 
+	fakeboshaction "github.com/cloudfoundry/bosh-agent/v2/agent/action/fakes"
 	. "github.com/cloudfoundry/bosh-agent/v2/platform/disk"
 )
 
@@ -20,7 +21,7 @@ var _ = Describe("Linux Formatter", func() {
 				fakeFs := fakesys.NewFakeFileSystem()
 				fakeRunner.AddCmdResult("blkid -p /dev/xvda2", fakesys.FakeCmdResult{ExitStatus: 2, Error: errors.New("Exit code 2")})
 
-				formatter := NewLinuxFormatter(fakeRunner, fakeFs)
+				formatter := NewLinuxFormatter(fakeRunner, fakeFs, &fakeboshaction.FakeClock{})
 				err := formatter.Format("/dev/xvda2", FileSystemSwap)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -33,7 +34,7 @@ var _ = Describe("Linux Formatter", func() {
 				fakeFs := fakesys.NewFakeFileSystem()
 				fakeRunner.AddCmdResult("blkid -p /dev/xvda1", fakesys.FakeCmdResult{Stdout: `xxxxx TYPE="ext4" yyyy zzzz`})
 
-				formatter := NewLinuxFormatter(fakeRunner, fakeFs)
+				formatter := NewLinuxFormatter(fakeRunner, fakeFs, &fakeboshaction.FakeClock{})
 				err := formatter.Format("/dev/xvda1", FileSystemSwap)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -46,7 +47,7 @@ var _ = Describe("Linux Formatter", func() {
 				fakeFs := fakesys.NewFakeFileSystem()
 				fakeRunner.AddCmdResult("blkid -p /dev/xvda1", fakesys.FakeCmdResult{Stdout: `xxxxx TYPE="swap" yyyy zzzz`})
 
-				formatter := NewLinuxFormatter(fakeRunner, fakeFs)
+				formatter := NewLinuxFormatter(fakeRunner, fakeFs, &fakeboshaction.FakeClock{})
 				err := formatter.Format("/dev/xvda1", FileSystemSwap)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -63,7 +64,7 @@ var _ = Describe("Linux Formatter", func() {
 				Expect(err).NotTo(HaveOccurred())
 				fakeRunner.AddCmdResult("blkid -p /dev/xvda2", fakesys.FakeCmdResult{Stdout: `xxxxx TYPE="ext2" yyyy zzzz`})
 
-				formatter := NewLinuxFormatter(fakeRunner, fakeFs)
+				formatter := NewLinuxFormatter(fakeRunner, fakeFs, &fakeboshaction.FakeClock{})
 				err = formatter.Format("/dev/xvda2", FileSystemExt4)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -94,7 +95,7 @@ var _ = Describe("Linux Formatter", func() {
 					fakeRunner.AddCmdResult(mkeCmd, fakesys.FakeCmdResult{
 						ExitStatus: 0,
 					})
-					formatter := NewLinuxFormatter(fakeRunner, fakeFs)
+					formatter := NewLinuxFormatter(fakeRunner, fakeFs, &fakeboshaction.FakeClock{})
 					err := formatter.Format("/dev/xvda2", FileSystemExt4)
 					Expect(err).NotTo(HaveOccurred())
 
@@ -107,7 +108,7 @@ var _ = Describe("Linux Formatter", func() {
 					fakeRunner.AddCmdResult(mkeCmd, fakesys.FakeCmdResult{
 						Error: errors.New(`some other error`),
 					})
-					formatter := NewLinuxFormatter(fakeRunner, fakeFs)
+					formatter := NewLinuxFormatter(fakeRunner, fakeFs, &fakeboshaction.FakeClock{})
 					err := formatter.Format("/dev/xvda2", FileSystemExt4)
 					Expect(err).To(HaveOccurred())
 
@@ -121,7 +122,7 @@ var _ = Describe("Linux Formatter", func() {
 				fakeFs := fakesys.NewFakeFileSystem()
 				fakeRunner.AddCmdResult("blkid -p /dev/xvda2", fakesys.FakeCmdResult{Stdout: `xxxxx TYPE="ext2" yyyy zzzz`})
 
-				formatter := NewLinuxFormatter(fakeRunner, fakeFs)
+				formatter := NewLinuxFormatter(fakeRunner, fakeFs, &fakeboshaction.FakeClock{})
 				err := formatter.Format("/dev/xvda2", FileSystemExt4)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -134,7 +135,7 @@ var _ = Describe("Linux Formatter", func() {
 				fakeFs := fakesys.NewFakeFileSystem()
 				fakeRunner.AddCmdResult("blkid -p /dev/xvda1", fakesys.FakeCmdResult{Stdout: `xxxxx TYPE="ext4" yyyy zzzz`})
 
-				formatter := NewLinuxFormatter(fakeRunner, fakeFs)
+				formatter := NewLinuxFormatter(fakeRunner, fakeFs, &fakeboshaction.FakeClock{})
 				err := formatter.Format("/dev/xvda1", FileSystemExt4)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -147,7 +148,7 @@ var _ = Describe("Linux Formatter", func() {
 				fakeFs := fakesys.NewFakeFileSystem()
 				fakeRunner.AddCmdResult("blkid -p /dev/xvda2", fakesys.FakeCmdResult{Stdout: `xxxxx TYPE="xfs" yyyy zzzz`})
 
-				formatter := NewLinuxFormatter(fakeRunner, fakeFs)
+				formatter := NewLinuxFormatter(fakeRunner, fakeFs, &fakeboshaction.FakeClock{})
 				err := formatter.Format("/dev/xvda2", FileSystemExt4)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -160,7 +161,7 @@ var _ = Describe("Linux Formatter", func() {
 				fakeFs := fakesys.NewFakeFileSystem()
 				fakeRunner.AddCmdResult("blkid -p /dev/xvda2", fakesys.FakeCmdResult{Stdout: `xxxxx TYPE="somethingelse" yyyy zzzz`})
 
-				formatter := NewLinuxFormatter(fakeRunner, fakeFs)
+				formatter := NewLinuxFormatter(fakeRunner, fakeFs, &fakeboshaction.FakeClock{})
 				err := formatter.Format("/dev/xvda2", FileSystemExt4)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -175,7 +176,7 @@ var _ = Describe("Linux Formatter", func() {
 				fakeFs := fakesys.NewFakeFileSystem()
 				fakeRunner.AddCmdResult("blkid -p /dev/xvda2", fakesys.FakeCmdResult{ExitStatus: 2, Error: errors.New("Exit code 2")})
 
-				formatter := NewLinuxFormatter(fakeRunner, fakeFs)
+				formatter := NewLinuxFormatter(fakeRunner, fakeFs, &fakeboshaction.FakeClock{})
 				err := formatter.Format("/dev/xvda2", FileSystemXFS)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -188,7 +189,7 @@ var _ = Describe("Linux Formatter", func() {
 				fakeFs := fakesys.NewFakeFileSystem()
 				fakeRunner.AddCmdResult("blkid -p /dev/xvda1", fakesys.FakeCmdResult{Stdout: `xxxxx TYPE="ext4" yyyy zzzz`})
 
-				formatter := NewLinuxFormatter(fakeRunner, fakeFs)
+				formatter := NewLinuxFormatter(fakeRunner, fakeFs, &fakeboshaction.FakeClock{})
 				err := formatter.Format("/dev/xvda1", FileSystemXFS)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -201,7 +202,7 @@ var _ = Describe("Linux Formatter", func() {
 				fakeFs := fakesys.NewFakeFileSystem()
 				fakeRunner.AddCmdResult("blkid -p /dev/xvda1", fakesys.FakeCmdResult{Stdout: `xxxxx TYPE="xfs" yyyy zzzz`})
 
-				formatter := NewLinuxFormatter(fakeRunner, fakeFs)
+				formatter := NewLinuxFormatter(fakeRunner, fakeFs, &fakeboshaction.FakeClock{})
 				err := formatter.Format("/dev/xvda1", FileSystemXFS)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -215,7 +216,7 @@ var _ = Describe("Linux Formatter", func() {
 				fakeRunner.AddCmdResult("mkfs.xfs /dev/xvda2", fakesys.FakeCmdResult{Error: errors.New("Sadness")})
 				fakeRunner.AddCmdResult("blkid -p /dev/xvda2", fakesys.FakeCmdResult{Stderr: "", ExitStatus: 2})
 
-				formatter := NewLinuxFormatter(fakeRunner, fakeFs)
+				formatter := NewLinuxFormatter(fakeRunner, fakeFs, &fakeboshaction.FakeClock{})
 				err := formatter.Format("/dev/xvda2", FileSystemXFS)
 
 				Expect(err).To(HaveOccurred())
@@ -228,18 +229,20 @@ var _ = Describe("Linux Formatter", func() {
 		var (
 			fakeRunner *fakesys.FakeCmdRunner
 			fakeFs     *fakesys.FakeFileSystem
+			fakeClock  *fakeboshaction.FakeClock
 			formatter  Formatter
 		)
 
 		BeforeEach(func() {
 			fakeRunner = fakesys.NewFakeCmdRunner()
 			fakeFs = fakesys.NewFakeFileSystem()
+			fakeClock = &fakeboshaction.FakeClock{}
 		})
 
 		Context("when determining partition filesystem fails", func() {
 			BeforeEach(func() {
 				fakeRunner.AddCmdResult("blkid -p /dev/nvme2n1p1", fakesys.FakeCmdResult{ExitStatus: 1, Error: errors.New("No GPT found")})
-				formatter = NewLinuxFormatter(fakeRunner, fakeFs)
+				formatter = NewLinuxFormatter(fakeRunner, fakeFs, fakeClock)
 			})
 
 			It("returns an error", func() {
@@ -253,7 +256,7 @@ var _ = Describe("Linux Formatter", func() {
 		Context("when using Ext4", func() {
 			BeforeEach(func() {
 				fakeRunner.AddCmdResult("blkid -p /dev/nvme2n1p1", fakesys.FakeCmdResult{Stdout: `xxxxx TYPE="ext4" yyyy zzzz`})
-				formatter = NewLinuxFormatter(fakeRunner, fakeFs)
+				formatter = NewLinuxFormatter(fakeRunner, fakeFs, fakeClock)
 			})
 
 			It("grows the Ext4 filesystem", func() {
@@ -263,17 +266,52 @@ var _ = Describe("Linux Formatter", func() {
 				Expect(fakeRunner.RunCommands[1]).To(Equal([]string{"resize2fs", "-f", "/dev/nvme2n1p1"}))
 			})
 
-			Context("when resize2fs fails", func() {
+			Context("when resize2fs fails with a non-retryable error", func() {
 				BeforeEach(func() {
 					fakeRunner.AddCmdResult("resize2fs -f /dev/nvme2n1p1", fakesys.FakeCmdResult{ExitStatus: 1, Error: errors.New("resize2fs failure")})
 				})
 
-				It("returns an error", func() {
+				It("returns the error immediately without retrying", func() {
 					err := formatter.GrowFilesystem("/dev/nvme2n1p1")
 
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring("Failed to grow Ext4 filesystem"))
 					Expect(err.Error()).To(ContainSubstring("resize2fs failure"))
+					Expect(fakeClock.SleepCallCount()).To(Equal(0))
+				})
+			})
+
+			Context("when resize2fs fails with 'Permission denied to resize filesystem'", func() {
+				BeforeEach(func() {
+					permDeniedErr := errors.New("Permission denied to resize filesystem")
+					fakeRunner.AddCmdResult("resize2fs -f /dev/nvme2n1p1", fakesys.FakeCmdResult{ExitStatus: 1, Error: permDeniedErr})
+					fakeRunner.AddCmdResult("resize2fs -f /dev/nvme2n1p1", fakesys.FakeCmdResult{ExitStatus: 1, Error: permDeniedErr})
+					fakeRunner.AddCmdResult("resize2fs -f /dev/nvme2n1p1", fakesys.FakeCmdResult{ExitStatus: 0})
+				})
+
+				It("retries until success and sleeps between attempts", func() {
+					err := formatter.GrowFilesystem("/dev/nvme2n1p1")
+
+					Expect(err).NotTo(HaveOccurred())
+					Expect(fakeClock.SleepCallCount()).To(Equal(2))
+				})
+			})
+
+			Context("when resize2fs keeps failing with 'Permission denied' for all attempts", func() {
+				BeforeEach(func() {
+					permDeniedErr := errors.New("Permission denied to resize filesystem")
+					for i := 0; i < 10; i++ {
+						fakeRunner.AddCmdResult("resize2fs -f /dev/nvme2n1p1", fakesys.FakeCmdResult{ExitStatus: 1, Error: permDeniedErr})
+					}
+				})
+
+				It("returns an error after exhausting all attempts", func() {
+					err := formatter.GrowFilesystem("/dev/nvme2n1p1")
+
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("Failed to grow Ext4 filesystem"))
+					Expect(err.Error()).To(ContainSubstring("Permission denied to resize filesystem"))
+					Expect(fakeClock.SleepCallCount()).To(Equal(10))
 				})
 			})
 		})
@@ -281,7 +319,7 @@ var _ = Describe("Linux Formatter", func() {
 		Context("when using XFS", func() {
 			BeforeEach(func() {
 				fakeRunner.AddCmdResult("blkid -p /dev/nvme2n1p1", fakesys.FakeCmdResult{Stdout: `xxxxx TYPE="xfs" yyyy zzzz`})
-				formatter = NewLinuxFormatter(fakeRunner, fakeFs)
+				formatter = NewLinuxFormatter(fakeRunner, fakeFs, fakeClock)
 			})
 
 			It("grows the XFS filesystem", func() {

--- a/platform/disk/linux_formatter_test.go
+++ b/platform/disk/linux_formatter_test.go
@@ -300,7 +300,7 @@ var _ = Describe("Linux Formatter", func() {
 			Context("when resize2fs keeps failing with 'Permission denied' for all attempts", func() {
 				BeforeEach(func() {
 					permDeniedErr := errors.New("Permission denied to resize filesystem")
-					for i := 0; i < 10; i++ {
+					for i := 0; i < 11; i++ {
 						fakeRunner.AddCmdResult("resize2fs -f /dev/nvme2n1p1", fakesys.FakeCmdResult{ExitStatus: 1, Error: permDeniedErr})
 					}
 				})


### PR DESCRIPTION
### What is this change about?

When a persistent disk is extended online, the agent calls `resize2fs` to grow the ext4 filesystem after resizing the partition. We noticed this on OpenStack and it fails transiently with:

```
Error: Action Failed get_task: Task <xxxxxxxxx> result: Adjusting persistent disk partitioning: Failed to grow filesystem: Failed to grow Ext4 filesystem: Running command: 'resize2fs -f /dev/sdb1', stdout: 'Filesystem at /dev/sdb1 is mounted on /var/vcap/store; on-line resizing required
old_desc_blocks = 13, new_desc_blocks = 128
', stderr: 'resize2fs 1.46.5 (30-Dec-2021)
resize2fs: Permission denied to resize filesystem
': exit status 1
```

The `EXT4_IOC_RESIZE_FS` ioctl returns EPERM when the kernel cannot yet confirm the block device's new size - a race between the storage layer acknowledging the extension and the guest-visible device reflecting it. The error resolves on its own once the storage layer settles.

This change retries `resize2fs` up to 10 times with a 5s sleep between attempts, but **only** on `"Permission denied to resize filesystem"` - any other error still fails immediately. Maximum additional wait before giving up: 50 seconds.

### Please provide contextual information.

Observed repeatedly in production during a disk type change (`100G` → `1T`).

The fix follows the existing clock-injection pattern used by `NewPartedPartitioner` and `NewSfdiskPartitioner` in the same package, making the retry delay injectable for tests. The original `NewLinuxFormatter(runner, fs)` signature is preserved; a new `NewLinuxFormatterWithClock(runner, fs, clock)` is added for test injection.

### What tests have you run against this PR?

- Full `platform/disk` unit test suite: 173 passed, 0 failed
- Three new specs covering:
  - Non-retryable errors fail immediately (`SleepCallCount() == 0`)
  - Transient EPERM retries until success (sleep count matches failed attempts)
  - Exhausted retries returns the error after 10 sleeps

### How should this change be described in bosh-agent release notes?

Persistent disk grows that fail with a transient "Permission denied" from `resize2fs` are now retried automatically (up to 10 times, 5s apart), avoiding deploy failures during online disk extension on affected IaaS environments.

### Does this PR introduce a breaking change?

No. The `NewLinuxFormatter(runner, fs)` signature is unchanged. A new `NewLinuxFormatterWithClock(runner, fs, clock)` constructor is added alongside it for clock injection in tests.