### PR TITLE
Re-attempt GrowFilesystem when partition already matches disk size

### DIFF
--- a/platform/linux_platform.go
+++ b/platform/linux_platform.go
@@ -1451,6 +1451,11 @@ func (p linux) AdjustPersistentDiskPartitioning(diskSetting boshsettings.DiskSet
 		if err != nil {
 			return bosherr.WrapError(err, fmt.Sprintf("Formatting partition with %s", diskSetting.FileSystemType))
 		}
+
+		// Grow is idempotent — re-attempt on every run to catch incomplete prior grows.
+		if err = p.diskManager.GetFormatter().GrowFilesystem(firstPartitionPath); err != nil {
+			return bosherr.WrapError(err, "Failed to grow filesystem")
+		}
 	}
 	return nil
 }

--- a/platform/linux_platform_test.go
+++ b/platform/linux_platform_test.go
@@ -3372,6 +3372,29 @@ sam:fakeanotheruser`)
 					Expect(err.Error()).To(Equal("Formatting partition with xfs: oh noes"))
 				})
 			})
+
+			Context("when the partition already exists and does not need resizing", func() {
+				It("attempts to grow the filesystem", func() {
+					err := platform.AdjustPersistentDiskPartitioning(diskSettings, mntPoint)
+					Expect(err).ToNot(HaveOccurred())
+
+					Expect(formatter.GrowFilesystemCalled).To(BeTrue())
+					Expect(formatter.GrowFilesystemPartitionPath).To(Equal("fake-real-device-path1"))
+				})
+
+				Context("when growing the filesystem fails", func() {
+					BeforeEach(func() {
+						formatter.GrowFilesystemError = errors.New("resize2fs refused")
+					})
+
+					It("returns an error", func() {
+						err := platform.AdjustPersistentDiskPartitioning(diskSettings, mntPoint)
+						Expect(err).To(HaveOccurred())
+						Expect(err.Error()).To(ContainSubstring("Failed to grow filesystem"))
+						Expect(err.Error()).To(ContainSubstring("resize2fs refused"))
+					})
+				})
+			})
 		})
 	})
 


### PR DESCRIPTION
### What is this change about?

When `AdjustPersistentDiskPartitioning` is called after a disk resize, it either resizes the partition and grows the filesystem (if the partition is smaller than the disk), or falls into an `else` branch that only partitions and formats (if the partition already spans the disk). The `else` branch never called `GrowFilesystem`.

This means: if a previous deploy resized the partition but `GrowFilesystem` failed, every subsequent deploy would see the partition already at full size, skip the grow silently, and succeed - leaving the filesystem permanently smaller than its partition with no visible error.

Fix: call `GrowFilesystem` unconditionally in the `else` branch after `Format`. `resize2fs` and `xfs_growfs` are idempotent and exit 0 when the filesystem already fills the partition, so this is safe on every deploy. If the grow fails, the error is returned and the deployment fails, forcing the operator to resolve it.

### Please provide contextual information.

Discovered during an investigation into a `resize2fs: Permission denied` failure. Three nodes had pre-existing filesystem corruption from a storage write-error event. The partition resize succeeded but `GrowFilesystem` failed. Subsequent deploys silently succeeded, leaving those nodes with 98G filesystems on 1T volumes.

### What tests have you run against this PR?

- Full `platform` unit test suite: 373 passed, 0 failed
- New specs covering: grow called in else branch, grow failure returns error

### How should this change be described in bosh-agent release notes?

When a persistent disk's partition already matches the disk size but the filesystem is smaller (due to a previously failed grow), the agent now re-attempts the filesystem grow on each deploy instead of silently skipping it.

### Does this PR introduce a breaking change?

No. `resize2fs`/`xfs_growfs` are idempotent on already-full filesystems. The only behaviour change is that a previously silent failure now surfaces as a deploy error.