### PR TITLE
Warn when persistent disk filesystem is smaller than its partition

### DIFF
--- a/platform/disk/fakes/fake_formatter.go
+++ b/platform/disk/fakes/fake_formatter.go
@@ -14,6 +14,11 @@ type FakeFormatter struct {
 	GrowFilesystemCalled        bool
 	GrowFilesystemPartitionPath string
 	GrowFilesystemError         error
+
+	FilesystemNeedsGrowCalled        bool
+	FilesystemNeedsGrowPartitionPath string
+	FilesystemNeedsGrowResult        bool
+	FilesystemNeedsGrowError         error
 }
 
 func NewFakeFormatter() *FakeFormatter {
@@ -33,6 +38,12 @@ func (p *FakeFormatter) GrowFilesystem(partitionPath string) error {
 	p.GrowFilesystemCalled = true
 	p.GrowFilesystemPartitionPath = partitionPath
 	return p.GrowFilesystemError
+}
+
+func (p *FakeFormatter) FilesystemNeedsGrow(partitionPath string) (bool, error) {
+	p.FilesystemNeedsGrowCalled = true
+	p.FilesystemNeedsGrowPartitionPath = partitionPath
+	return p.FilesystemNeedsGrowResult, p.FilesystemNeedsGrowError
 }
 
 func (p *FakeFormatter) GetPartitionFormatType(partitionPath string) (boshdisk.FileSystemType, error) {

--- a/platform/disk/formatter_interface.go
+++ b/platform/disk/formatter_interface.go
@@ -16,4 +16,5 @@ type Formatter interface {
 	Format(partitionPath string, fsType FileSystemType) (err error)
 	GetPartitionFormatType(string) (FileSystemType, error)
 	GrowFilesystem(partitionPath string) error
+	FilesystemNeedsGrow(partitionPath string) (bool, error)
 }

--- a/platform/disk/linux_formatter.go
+++ b/platform/disk/linux_formatter.go
@@ -2,6 +2,7 @@ package disk
 
 import (
 	"regexp"
+	"strconv"
 	"strings"
 
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
@@ -95,6 +96,83 @@ func (f linuxFormatter) GrowFilesystem(partitionPath string) error {
 		return nil
 	}
 	return nil
+}
+
+// FilesystemNeedsGrow reports whether the ext4 filesystem on partitionPath is
+// significantly smaller than the partition that contains it, indicating a
+// previous grow did not complete. "Significantly" uses the same 100MB delta as
+// SinglePartitionNeedsResize to avoid false positives from alignment rounding
+// between filesystem block groups and partition sector boundaries.
+//
+// Only ext4 is supported: querying the size of an XFS filesystem requires
+// xfs_info, which only works on a mounted filesystem. dumpe2fs reads directly
+// from the block device and works regardless of mount state. Unknown or
+// unsupported filesystem types return false.
+func (f linuxFormatter) FilesystemNeedsGrow(partitionPath string) (bool, error) {
+	fsType, err := f.GetPartitionFormatType(partitionPath)
+	if err != nil {
+		return false, bosherr.WrapError(err, "Checking filesystem format of partition")
+	}
+
+	if fsType != FileSystemExt4 {
+		return false, nil
+	}
+
+	partitionSize, err := f.blockDeviceSize(partitionPath)
+	if err != nil {
+		return false, err
+	}
+
+	fsSize, err := f.ext4FilesystemSize(partitionPath)
+	if err != nil {
+		return false, err
+	}
+
+	return significantlySmallerThan(fsSize, partitionSize, ConvertFromMbToBytes(deltaSize)), nil
+}
+
+func (f linuxFormatter) blockDeviceSize(partitionPath string) (uint64, error) {
+	stdout, _, _, err := f.runner.RunCommand("blockdev", "--getsize64", partitionPath)
+	if err != nil {
+		return 0, bosherr.WrapError(err, "Getting block device size")
+	}
+
+	size, err := strconv.ParseUint(strings.TrimSpace(stdout), 10, 64)
+	if err != nil {
+		return 0, bosherr.WrapError(err, "Parsing block device size")
+	}
+
+	return size, nil
+}
+
+func (f linuxFormatter) ext4FilesystemSize(partitionPath string) (uint64, error) {
+	stdout, _, _, err := f.runner.RunCommand("dumpe2fs", "-h", partitionPath)
+	if err != nil {
+		return 0, bosherr.WrapError(err, "Reading ext4 superblock")
+	}
+
+	blockCount, err := parseDumpe2fsField(stdout, "Block count:")
+	if err != nil {
+		return 0, err
+	}
+
+	blockSize, err := parseDumpe2fsField(stdout, "Block size:")
+	if err != nil {
+		return 0, err
+	}
+
+	return blockCount * blockSize, nil
+}
+
+func parseDumpe2fsField(stdout, field string) (uint64, error) {
+	for _, line := range strings.Split(stdout, "\n") {
+		if strings.HasPrefix(line, field) {
+			value := strings.TrimSpace(strings.TrimPrefix(line, field))
+			return strconv.ParseUint(value, 10, 64)
+		}
+	}
+
+	return 0, bosherr.Errorf("Field %q not found in dumpe2fs output", field)
 }
 
 func (f linuxFormatter) makeFileSystemExt4(partitionPath string) error {

--- a/platform/disk/linux_formatter_test.go
+++ b/platform/disk/linux_formatter_test.go
@@ -306,4 +306,102 @@ var _ = Describe("Linux Formatter", func() {
 			})
 		})
 	})
+
+	Describe("FilesystemNeedsGrow", func() {
+		var (
+			fakeRunner *fakesys.FakeCmdRunner
+			fakeFs     *fakesys.FakeFileSystem
+			formatter  Formatter
+		)
+
+		BeforeEach(func() {
+			fakeRunner = fakesys.NewFakeCmdRunner()
+			fakeFs = fakesys.NewFakeFileSystem()
+			formatter = NewLinuxFormatter(fakeRunner, fakeFs)
+		})
+
+		Context("when the filesystem is ext4", func() {
+			BeforeEach(func() {
+				fakeRunner.AddCmdResult("blkid -p /dev/sdb1", fakesys.FakeCmdResult{Stdout: `xxxxx TYPE="ext4" yyyy zzzz`})
+			})
+
+			Context("when the filesystem is significantly smaller than the partition", func() {
+				BeforeEach(func() {
+					// partition 1 TiB, filesystem 100 GiB (26213888 blocks * 4096)
+					fakeRunner.AddCmdResult("blockdev --getsize64 /dev/sdb1", fakesys.FakeCmdResult{Stdout: "1099511627776\n"})
+					fakeRunner.AddCmdResult("dumpe2fs -h /dev/sdb1", fakesys.FakeCmdResult{Stdout: "Block count:              26213888\nBlock size:               4096\n"})
+				})
+
+				It("returns true", func() {
+					needsGrow, err := formatter.FilesystemNeedsGrow("/dev/sdb1")
+					Expect(err).NotTo(HaveOccurred())
+					Expect(needsGrow).To(BeTrue())
+				})
+			})
+
+			Context("when the filesystem already fills the partition", func() {
+				BeforeEach(func() {
+					// partition 1 TiB, filesystem 1 TiB (268435456 blocks * 4096)
+					fakeRunner.AddCmdResult("blockdev --getsize64 /dev/sdb1", fakesys.FakeCmdResult{Stdout: "1099511627776\n"})
+					fakeRunner.AddCmdResult("dumpe2fs -h /dev/sdb1", fakesys.FakeCmdResult{Stdout: "Block count:              268435456\nBlock size:               4096\n"})
+				})
+
+				It("returns false", func() {
+					needsGrow, err := formatter.FilesystemNeedsGrow("/dev/sdb1")
+					Expect(err).NotTo(HaveOccurred())
+					Expect(needsGrow).To(BeFalse())
+				})
+			})
+
+			Context("when reading the block device size fails", func() {
+				BeforeEach(func() {
+					fakeRunner.AddCmdResult("blockdev --getsize64 /dev/sdb1", fakesys.FakeCmdResult{ExitStatus: 1, Error: errors.New("blockdev boom")})
+				})
+
+				It("returns an error", func() {
+					_, err := formatter.FilesystemNeedsGrow("/dev/sdb1")
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("Getting block device size"))
+				})
+			})
+
+			Context("when reading the ext4 superblock fails", func() {
+				BeforeEach(func() {
+					fakeRunner.AddCmdResult("blockdev --getsize64 /dev/sdb1", fakesys.FakeCmdResult{Stdout: "1099511627776\n"})
+					fakeRunner.AddCmdResult("dumpe2fs -h /dev/sdb1", fakesys.FakeCmdResult{ExitStatus: 1, Error: errors.New("dumpe2fs boom")})
+				})
+
+				It("returns an error", func() {
+					_, err := formatter.FilesystemNeedsGrow("/dev/sdb1")
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("Reading ext4 superblock"))
+				})
+			})
+
+			Context("when a required field is missing from the superblock", func() {
+				BeforeEach(func() {
+					fakeRunner.AddCmdResult("blockdev --getsize64 /dev/sdb1", fakesys.FakeCmdResult{Stdout: "1099511627776\n"})
+					fakeRunner.AddCmdResult("dumpe2fs -h /dev/sdb1", fakesys.FakeCmdResult{Stdout: "Block size:               4096\n"})
+				})
+
+				It("returns an error", func() {
+					_, err := formatter.FilesystemNeedsGrow("/dev/sdb1")
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("Block count:"))
+				})
+			})
+		})
+
+		Context("when the filesystem is not ext4", func() {
+			BeforeEach(func() {
+				fakeRunner.AddCmdResult("blkid -p /dev/sdb1", fakesys.FakeCmdResult{Stdout: `xxxxx TYPE="xfs" yyyy zzzz`})
+			})
+
+			It("returns false without inspecting sizes", func() {
+				needsGrow, err := formatter.FilesystemNeedsGrow("/dev/sdb1")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(needsGrow).To(BeFalse())
+			})
+		})
+	})
 })

--- a/platform/linux_platform.go
+++ b/platform/linux_platform.go
@@ -1451,6 +1451,17 @@ func (p linux) AdjustPersistentDiskPartitioning(diskSetting boshsettings.DiskSet
 		if err != nil {
 			return bosherr.WrapError(err, fmt.Sprintf("Formatting partition with %s", diskSetting.FileSystemType))
 		}
+
+		// A partition that already spans the disk can still hold a filesystem smaller
+		// than the partition if a previous grow did not complete. Detect and warn so
+		// the condition is visible; growing here is avoided since the filesystem is
+		// not mounted and the underlying cause often needs manual intervention.
+		needsGrow, err := p.diskManager.GetFormatter().FilesystemNeedsGrow(firstPartitionPath)
+		if err != nil {
+			p.logger.Warn(logTag, "Failed to determine whether filesystem on %s needs growing: %s", firstPartitionPath, err)
+		} else if needsGrow {
+			p.logger.Warn(logTag, "Filesystem on %s is smaller than its partition; a previous grow did not complete", firstPartitionPath)
+		}
 	}
 	return nil
 }

--- a/platform/linux_platform_test.go
+++ b/platform/linux_platform_test.go
@@ -3372,6 +3372,48 @@ sam:fakeanotheruser`)
 					Expect(err.Error()).To(Equal("Formatting partition with xfs: oh noes"))
 				})
 			})
+
+			Context("when the partition already exists and does not need resizing", func() {
+				It("checks whether the filesystem needs growing", func() {
+					err := platform.AdjustPersistentDiskPartitioning(diskSettings, mntPoint)
+					Expect(err).ToNot(HaveOccurred())
+
+					Expect(formatter.FilesystemNeedsGrowCalled).To(BeTrue())
+					Expect(formatter.FilesystemNeedsGrowPartitionPath).To(Equal("fake-real-device-path1"))
+				})
+
+				It("does not grow the filesystem or mount the partition", func() {
+					err := platform.AdjustPersistentDiskPartitioning(diskSettings, mntPoint)
+					Expect(err).ToNot(HaveOccurred())
+
+					Expect(formatter.GrowFilesystemCalled).To(BeFalse())
+					Expect(mounter.MountCallCount()).To(Equal(0))
+				})
+
+				Context("when the filesystem is smaller than its partition", func() {
+					BeforeEach(func() {
+						formatter.FilesystemNeedsGrowResult = true
+					})
+
+					It("does not fail the deployment", func() {
+						err := platform.AdjustPersistentDiskPartitioning(diskSettings, mntPoint)
+						Expect(err).ToNot(HaveOccurred())
+
+						Expect(formatter.GrowFilesystemCalled).To(BeFalse())
+					})
+				})
+
+				Context("when the needs-grow check fails", func() {
+					BeforeEach(func() {
+						formatter.FilesystemNeedsGrowError = errors.New("dumpe2fs boom")
+					})
+
+					It("does not fail the deployment", func() {
+						err := platform.AdjustPersistentDiskPartitioning(diskSettings, mntPoint)
+						Expect(err).ToNot(HaveOccurred())
+					})
+				})
+			})
 		})
 	})
 


### PR DESCRIPTION
### What is this change about?

When a persistent disk is resized, `AdjustPersistentDiskPartitioning` resizes the partition and grows the filesystem. If the partition resize succeeds but the filesystem grow does not complete, every subsequent deploy sees the partition already spanning the disk, takes the branch that only partitions and formats, and never revisits the filesystem - leaving it silently smaller than its partition with no indication anything is wrong.

This change adds a `FilesystemNeedsGrow` check (ext4) to the formatter. When the partition already matches the disk size, `AdjustPersistentDiskPartitioning` runs the check and logs a warning if the filesystem is smaller than its partition, surfacing the condition for operator follow-up.

Detection only - no automatic grow is attempted:
- The filesystem is not mounted at this point (`AdjustPersistentDiskPartitioning` runs before `MountPersistentDisk`), so `xfs_growfs`, which requires a mounted filesystem, is not applicable.
- The underlying cause often requires manual intervention (e.g. a filesystem flagged with errors that the kernel refuses to grow online).

`FilesystemNeedsGrow` compares the ext4 superblock size (`dumpe2fs -h`) against the block device size (`blockdev --getsize64`), using the same 100MB delta as `SinglePartitionNeedsResize` to avoid false positives from alignment rounding.

### Please provide contextual information.

Found while investigating a `resize2fs: Permission denied` failure. Three nodes had pre-existing filesystem corruption. The partition resize succeeded, `GrowFilesystem` failed, and subsequent deploys silently succeeded - leaving those nodes with 98G filesystems on 1T volumes and no visible error.

### What tests have you run against this PR?

- Full `platform` and `platform/disk` unit test suites: 375 + 177 passed, 0 failed
- New specs: `FilesystemNeedsGrow` for ext4 (smaller, already-full, command failures, missing superblock field, non-ext4); platform specs for the warn path (check invoked, no grow/mount, no deploy failure on mismatch or check error)

### How should this change be described in bosh-agent release notes?

The agent now logs a warning when a persistent disk's filesystem is smaller than its partition (indicating a previous grow did not complete), instead of silently leaving it unresized.

### Does this PR introduce a breaking change?

No. The change only adds a read-only check and a log warning. No behaviour change to partitioning, formatting, or mounting.