### PR TITLE
test: stop auditd cleanly before tearing down /var/log

### DIFF
--- a/integration/scripts/detach_mount.sh
+++ b/integration/scripts/detach_mount.sh
@@ -3,9 +3,9 @@
 # detach_device.sh: the Go caller prepends "SM=<service manager>" (and concatenates the caller's
 # body) before this file, so detach_mount is defined once and reused.
 #
-# For the given directory it stops rsyslog first when detaching /var/log on systemd (see the long
-# note below), then for each mount under $d -- deepest first -- fuser-kills holders and unmounts
-# (lazily for /var/log), and finally removes the directory.
+# For the given directory it stops rsyslog and auditd first when detaching /var/log on systemd (see
+# the long note below), then for each mount under $d -- deepest first -- fuser-kills holders and
+# unmounts (lazily for /var/log), and finally removes the directory.
 #
 # On systemd-based stemcells (e.g. resolute), rsyslog is intentionally left running for the whole
 # test run so it can keep forwarding journald output into /var/log/bosh-agent.log, which
@@ -20,11 +20,22 @@
 # mount of /var/vcap/data/root_log, and for reasons we don't fully understand `fuser -k` doesn't
 # consistently terminate its holders in time for a plain umount. Because we later unmount
 # /var/vcap/data, a lingering /var/log reference will eventually fail loudly there, so this is safe.
+#
+# auditd is stopped cleanly for the same reason, and it MUST be a clean stop rather than relying on
+# the fuser -km below: auditd's log dir /var/log/audit lives under /var/log, so fuser -km /var/log
+# SIGKILLs it. A SIGKILLed auditd triggers systemd's Restart=always, which -- since the rm -rf below
+# just removed /var/log/audit -- crash-loops ("Could not open dir /var/log/audit") until it trips
+# StartLimitBurst (5/10s). That storm races the agent's bootstrap: when bosh-start-logging-and-auditing
+# later starts auditd, systemd may refuse ("Start request repeated too quickly"), the agent exits 1
+# and crash-loops, and the spec fails intermittently. An explicit `systemctl stop` does not trigger
+# Restart=, so no storm occurs. We do NOT restart auditd; the agent's bootstrap recreates
+# /var/log/audit and starts it.
 : "${SM:?}"
 detach_mount() {
   d="$1"
   if [ "$d" = /var/log ] && [ "$SM" = systemd ]; then
-    sudo systemctl stop syslog.socket rsyslog.service || true
+    sudo systemctl stop syslog.socket rsyslog.service auditd.service \
+      || echo "detach_mount: warning: failed to stop rsyslog/auditd before tearing down /var/log" >&2
   fi
   mps=$(sudo mount | grep "on $d" | cut -d' ' -f3 | awk '{ print length"\t"$0 }' | sort -rn | cut -f2- || true)
   for mp in $mps; do

--- a/integration/test_environment.go
+++ b/integration/test_environment.go
@@ -597,11 +597,10 @@ func (t *TestEnvironment) StartAgent() error {
 	var err error
 	if t.serviceManager == SERVICE_MANAGER_SYSTEMD {
 		// Clear any accumulated systemd start-limit / failed state before (re)starting. CleanupDataDir's
-		// `fuser -km /var/log` SIGKILLs auditd (its log lives under /var/log/audit); systemd then restarts
-		// it in a tight loop until it trips its StartLimitBurst (5 starts / 10s) and refuses to start it at
-		// all. A StopAgent -> CleanupDataDir -> StartAgent sequence can land inside that window, so the
-		// agent's bootstrap fails to start auditd and crash-loops. reset-failed clears the counters so
-		// auditd (and the agent) can start cleanly; it is a harmless no-op when nothing has failed.
+		// detach_mount now stops auditd cleanly before its `fuser -km /var/log` so systemd's Restart=always
+		// storm (which trips StartLimitBurst and makes the agent's bootstrap fail to start auditd and
+		// crash-loop) never happens. reset-failed is a timing-independent safety net: it clears the counters
+		// so auditd, rsyslog, and the agent can start cleanly, and is a harmless no-op when nothing failed.
 		_, err = t.RunCommand("sudo systemctl reset-failed auditd.service rsyslog.service bosh-agent.service 2>/dev/null || true")
 		if err != nil {
 			return err


### PR DESCRIPTION
This caused a flake, reproduced the flake using --until-it-fails, ran it a bunch of times with this fix and did not see the flake.

### What is this change about?

CleanupDataDir's `fuser -km /var/log` SIGKILLed auditd (its log dir /var/log/audit lives under /var/log), triggering systemd's Restart=always. Since the rm -rf had just removed /var/log/audit, auditd crash-looped and tripped StartLimitBurst; the agent's bootstrap then couldn't start auditd and crash-looped itself, failing StopAgent->CleanupDataDir->StartAgent specs intermittently on systemd stemcells (noble/resolute).

Stop auditd (alongside rsyslog) with an explicit `systemctl stop` in detach_mount so no restart storm occurs; the agent's bootstrap recreates /var/log/audit and restarts it. reset-failed in StartAgent stays as a timing-independent safety net.

### What tests have you run against this PR?

Ran the integration test which was failing a number of times

### Does this PR introduce a breaking change?

No