### PR TITLE
Fix Lint issues after new Go version

### DIFF
--- a/integration/utils/blobstore.go
+++ b/integration/utils/blobstore.go
@@ -65,7 +65,7 @@ func NewBlobstore(uri string) BlobClient {
 
 	httpClient := &http.Client{
 		Transport: &http.Transport{
-			Dial:                tunnelClient.Dial,
+			DialContext:         tunnelClient.DialContext,
 			TLSHandshakeTimeout: 10 * time.Second,
 		},
 	}

--- a/platform/firewall/nftables_firewall_other.go
+++ b/platform/firewall/nftables_firewall_other.go
@@ -8,7 +8,9 @@ import (
 	boshlog "github.com/cloudfoundry/bosh-utils/logger"
 )
 
+var errNftablesUnsupported = errors.New("nftables firewall is only supported on Linux")
+
 // NewNftablesFirewall returns an error on non-Linux platforms
 func NewNftablesFirewall(logger boshlog.Logger) (Manager, error) {
-	return nil, errors.New("nftables firewall is only supported on Linux")
+	return nil, errNftablesUnsupported
 }

--- a/platform/windows_platform_test.go
+++ b/platform/windows_platform_test.go
@@ -458,7 +458,7 @@ var _ = Describe("WindowsPlatform", func() {
 			setupHostKeys(os.Getenv("SYSTEMDRIVE"))
 
 			previous := SetSSHEnabled(func() error { return errors.New("test") })
-			defer SetSSHEnabled(previous)
+			defer SetSSHEnabled(previous) //nolint:staticcheck
 
 			_, err := platform.GetHostPublicKey()
 			Expect(err).To(HaveOccurred())


### PR DESCRIPTION
### What is this change about?

Addressing the errors that showed up in https://ci.bosh-ecosystem.cf-app.com/teams/main/pipelines/bosh-agent-main/jobs/test-unit/builds/889

### Please provide contextual information.

We recently bumped our go version, and coincidentally, the golangci-lint tool, which flagged some new things.

### What tests have you run against this PR?

Ran locally
```
❯ ./bin/lint
golangci-lint has version 2.13.1 built with go1.26.7 from (unknown, modified: ?, mod sum: "h1:RuM4OcluM4xFQcGuRE6R7jA33pqxK/W1EsBxpugdZjg=") on (unknown)

 lint-ing with GOOS=windows...
0 issues.

 lint-ing with GOOS=linux...
0 issues.

 shellcheck not found; install it (https://github.com/koalaman/shellcheck#installing)
```

### How should this change be described in bosh-agent release notes?

N/A

### Does this PR introduce a breaking change?

No

### Tag your pair, your PM, and/or team!

N/A

### AI Review Feedback

_All AI review comments (CodeRabbit, and Copilot when assigned) must be resolved before human reviewers will look at the PR. For each comment, either:_
- _Make the suggested change, or_
- _Reply to the comment explaining why it does not apply, then resolve the thread._
