### PR TITLE
Release the SCSI device when a persistent disk is detached

### DIFF
--- a/agent/action/concrete_factory.go
+++ b/agent/action/concrete_factory.go
@@ -84,7 +84,7 @@ func NewFactory(
 			"mount_disk":             NewMountDisk(settingsService, platform, dirProvider, logger),
 			"unmount_disk":           NewUnmountDisk(settingsService, platform),
 			"add_persistent_disk":    NewAddPersistentDiskAction(settingsService),
-			"remove_persistent_disk": NewRemovePersistentDiskAction(settingsService),
+			"remove_persistent_disk": NewRemovePersistentDiskAction(settingsService, platform),
 			"add_dynamic_disk":       NewAddDynamicDiskAction(settingsService, platform),
 			"remove_dynamic_disk":    NewRemoveDynamicDiskAction(platform),
 

--- a/agent/action/concrete_factory_test.go
+++ b/agent/action/concrete_factory_test.go
@@ -199,7 +199,7 @@ var _ = Describe("concreteFactory", func() {
 	It("remove_persistent_disk", func() {
 		action, err := factory.Create("remove_persistent_disk")
 		Expect(err).ToNot(HaveOccurred())
-		Expect(action).To(Equal(boshaction.NewRemovePersistentDiskAction(settingsService)))
+		Expect(action).To(Equal(boshaction.NewRemovePersistentDiskAction(settingsService, platform)))
 	})
 
 	It("unmount_disk", func() {

--- a/agent/action/remove_persistent_disk.go
+++ b/agent/action/remove_persistent_disk.go
@@ -5,16 +5,19 @@ import (
 
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 
+	boshplatform "github.com/cloudfoundry/bosh-agent/v2/platform"
 	boshsettings "github.com/cloudfoundry/bosh-agent/v2/settings"
 )
 
 type RemovePersistentDiskAction struct {
 	settingsService boshsettings.Service
+	platform        boshplatform.Platform
 }
 
-func NewRemovePersistentDiskAction(settingsService boshsettings.Service) RemovePersistentDiskAction {
+func NewRemovePersistentDiskAction(settingsService boshsettings.Service, platform boshplatform.Platform) RemovePersistentDiskAction {
 	return RemovePersistentDiskAction{
 		settingsService: settingsService,
+		platform:        platform,
 	}
 }
 
@@ -22,6 +25,24 @@ func (a RemovePersistentDiskAction) Run(diskCID string) (interface{}, error) {
 	err := a.settingsService.LoadSettings()
 	if err != nil {
 		return nil, bosherr.WrapError(err, "Refreshing the settings")
+	}
+
+	// The director sends this immediately before asking the CPI to detach the
+	// disk, so release the kernel's device while the disk is still attached.
+	// Leaving it behind strands a dead device on the disk's controller slot,
+	// which stops a disk later attached to that same slot from being enumerated.
+	//
+	// A disk with no recorded settings has no device to release, which is normal
+	// when a detach is retried or rolled back, so that is not an error.
+	allDiskSettings, err := a.settingsService.GetAllPersistentDiskSettings()
+	if err != nil {
+		return "", bosherr.WrapError(err, "Getting all persistent disk settings")
+	}
+
+	if diskSettings, found := allDiskSettings[diskCID]; found {
+		if err := a.platform.RemovePersistentDiskDevice(diskSettings); err != nil {
+			return "", bosherr.WrapError(err, "Removing persistent disk device")
+		}
 	}
 
 	if err := a.settingsService.RemovePersistentDiskSettings(diskCID); err != nil {

--- a/agent/action/remove_persistent_disk_test.go
+++ b/agent/action/remove_persistent_disk_test.go
@@ -5,6 +5,8 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 
+	platformfakes "github.com/cloudfoundry/bosh-agent/v2/platform/platformfakes"
+	boshsettings "github.com/cloudfoundry/bosh-agent/v2/settings"
 	fakesettings "github.com/cloudfoundry/bosh-agent/v2/settings/fakes"
 )
 
@@ -12,20 +14,84 @@ var _ = Describe("RemovePersistentDiskAction", func() {
 	var (
 		action          RemovePersistentDiskAction
 		settingsService *fakesettings.FakeSettingsService
+		platform        *platformfakes.FakePlatform
 	)
 
 	BeforeEach(func() {
 		settingsService = &fakesettings.FakeSettingsService{}
-		action = NewRemovePersistentDiskAction(settingsService)
+		platform = &platformfakes.FakePlatform{}
+		action = NewRemovePersistentDiskAction(settingsService, platform)
 	})
 
-	It("updates persistent disk settings", func() {
-		result, err := action.Run("diskCID")
+	Context("when the disk has recorded settings", func() {
+		BeforeEach(func() {
+			settingsService.PersistentDiskSettings = map[string]boshsettings.DiskSettings{
+				"diskCID": {ID: "diskCID", DeviceID: "6000c292-f726-52fa-eb33-8715920f9a92"},
+			}
+		})
 
-		Expect(err).ToNot(HaveOccurred())
-		Expect(result).To(Equal(map[string]string{}))
-		Expect(settingsService.RemovePersistentDiskSettingsCallCount).To(Equal(1))
-		Expect(settingsService.RemovePersistentDiskSettingsLastArg).To(Equal("diskCID"))
+		It("releases the device and updates persistent disk settings", func() {
+			result, err := action.Run("diskCID")
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(map[string]string{}))
+
+			Expect(platform.RemovePersistentDiskDeviceCallCount()).To(Equal(1))
+			Expect(platform.RemovePersistentDiskDeviceArgsForCall(0).DeviceID).
+				To(Equal("6000c292-f726-52fa-eb33-8715920f9a92"))
+
+			Expect(settingsService.RemovePersistentDiskSettingsCallCount).To(Equal(1))
+			Expect(settingsService.RemovePersistentDiskSettingsLastArg).To(Equal("diskCID"))
+		})
+
+		It("releases the device before dropping the settings", func() {
+			// The settings carry the device ID, so dropping them first would leave
+			// nothing to resolve the device with.
+			settingsService.RemovePersistentDiskSettingsError = errors.New("boom")
+
+			_, err := action.Run("diskCID")
+
+			Expect(err).To(HaveOccurred())
+			Expect(platform.RemovePersistentDiskDeviceCallCount()).To(Equal(1))
+		})
+
+		Context("when releasing the device fails", func() {
+			BeforeEach(func() {
+				platform.RemovePersistentDiskDeviceReturns(errors.New("could not release"))
+			})
+
+			It("returns the error and leaves the settings in place", func() {
+				_, err := action.Run("diskCID")
+
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Removing persistent disk device"))
+				Expect(settingsService.RemovePersistentDiskSettingsCallCount).To(Equal(0))
+			})
+		})
+	})
+
+	Context("when the disk has no recorded settings", func() {
+		// Reached when a detach is retried or rolled back; there is no device to
+		// release, and that must not fail the action.
+		It("skips the device removal and still updates settings", func() {
+			result, err := action.Run("diskCID")
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(map[string]string{}))
+			Expect(platform.RemovePersistentDiskDeviceCallCount()).To(Equal(0))
+			Expect(settingsService.RemovePersistentDiskSettingsCallCount).To(Equal(1))
+		})
+	})
+
+	Context("when reading settings fails", func() {
+		BeforeEach(func() {
+			settingsService.GetAllPersistentDiskSettingsError = errors.New("could not read")
+		})
+
+		It("should raise error", func() {
+			_, err := action.Run("diskCID")
+			Expect(err).To(HaveOccurred())
+		})
 	})
 
 	Context("when removing settings fails", func() {

--- a/platform/dummy_platform.go
+++ b/platform/dummy_platform.go
@@ -347,6 +347,10 @@ func (p dummyPlatform) MountPersistentDisk(diskSettings boshsettings.DiskSetting
 	return p.fs.WriteFile(p.mountsPath(), mountsJSON)
 }
 
+func (p dummyPlatform) RemovePersistentDiskDevice(diskSettings boshsettings.DiskSettings) error {
+	return nil
+}
+
 func (p dummyPlatform) UnmountPersistentDisk(diskSettings boshsettings.DiskSettings) (didUnmount bool, err error) {
 	mounts, err := p.existingMounts()
 	if err != nil {

--- a/platform/linux_platform.go
+++ b/platform/linux_platform.go
@@ -1524,6 +1524,65 @@ func (p linux) UnmountPersistentDisk(diskSettings boshsettings.DiskSettings) (bo
 	return p.diskManager.GetMounter().Unmount(realPath)
 }
 
+// RemovePersistentDiskDevice tells the kernel to release the disk's SCSI device
+// before the IaaS detaches the underlying virtual disk.
+//
+// Without this the kernel keeps a device object at the disk's controller slot
+// after the IaaS-side detach: I/O to it fails with DID_NO_CONNECT, but it still
+// occupies the address. When the IaaS later reuses that slot for another disk,
+// the kernel does not re-probe an address it believes is populated, so the new
+// disk is never enumerated and no /dev/disk/by-id entry appears for it. Mounting
+// then fails with "Timed out getting real device path". Note that a SCSI rescan
+// does not help — it only adds devices at unoccupied addresses.
+//
+// Deliberately resolves the device with a single non-blocking lookup rather than
+// through devicePathResolver: the resolver waits up to its disk timeout (50s for
+// SCSI) before reporting a missing device, and this is called on paths where the
+// device is legitimately already gone.
+//
+// Missing or unidentifiable devices are not an error — this is best effort and
+// must stay idempotent, since it is also reached when a detach is rolled back.
+func (p linux) RemovePersistentDiskDevice(diskSettings boshsettings.DiskSettings) error {
+	p.logger.Debug(logTag, "Removing persistent disk device %+v", diskSettings)
+
+	if diskSettings.DeviceID == "" {
+		p.logger.Debug(logTag, "No device ID in disk settings, nothing to remove")
+		return nil
+	}
+
+	// /dev/disk/by-id entries carry the disk UUID without dashes, matching how
+	// SCSIIDDevicePathResolver locates the device.
+	uuid := strings.ReplaceAll(diskSettings.DeviceID, "-", "")
+	matches, err := p.fs.Glob(path.Join("/", "dev", "disk", "by-id", "*"+uuid))
+	if err != nil {
+		return bosherr.WrapError(err, "Listing disks by id")
+	}
+
+	for _, match := range matches {
+		realPath, err := p.fs.ReadAndFollowLink(match)
+		if err != nil {
+			continue
+		}
+
+		// Partition links resolve to e.g. /dev/sdc1; the delete node lives under
+		// the parent block device.
+		deletePath := path.Join("/", "sys", "block", filepath.Base(realPath), "device", "delete")
+		if !p.fs.FileExists(deletePath) {
+			continue
+		}
+
+		p.logger.Debug(logTag, "Releasing device %s via %s", realPath, deletePath)
+		if err := p.fs.WriteFileString(deletePath, "1"); err != nil {
+			return bosherr.WrapErrorf(err, "Removing device %s", realPath)
+		}
+
+		return nil
+	}
+
+	p.logger.Debug(logTag, "No device found for disk ID %s, nothing to remove", diskSettings.DeviceID)
+	return nil
+}
+
 func (p linux) GetEphemeralDiskPath(diskSettings boshsettings.DiskSettings) (string, error) {
 	realPath, _, err := p.devicePathResolver.GetRealDevicePath(diskSettings)
 	if err != nil {

--- a/platform/linux_platform_test.go
+++ b/platform/linux_platform_test.go
@@ -3864,6 +3864,77 @@ sam:fakeanotheruser`)
 		})
 	})
 
+	Describe("RemovePersistentDiskDevice", func() {
+		const deviceID = "6000c292-f726-52fa-eb33-8715920f9a92"
+		const byIDPath = "/dev/disk/by-id/scsi-36000c292f72652faeb338715920f9a92"
+		const deletePath = "/sys/block/sdc/device/delete"
+
+		diskSettings := boshsettings.DiskSettings{ID: "disk-cid", DeviceID: deviceID}
+
+		Context("when the device is present", func() {
+			BeforeEach(func() {
+				fs.SetGlob("/dev/disk/by-id/*6000c292f72652faeb338715920f9a92", []string{byIDPath})
+				err := fs.WriteFileString("/dev/sdc", "")
+				Expect(err).NotTo(HaveOccurred())
+				err = fs.Symlink("/dev/sdc", byIDPath)
+				Expect(err).NotTo(HaveOccurred())
+				err = fs.WriteFileString(deletePath, "")
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("asks the kernel to release the device", func() {
+				err := platform.RemovePersistentDiskDevice(diskSettings)
+				Expect(err).NotTo(HaveOccurred())
+
+				contents, err := fs.ReadFileString(deletePath)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(contents).To(Equal("1"))
+			})
+		})
+
+		Context("when the disk settings carry no device ID", func() {
+			It("does nothing", func() {
+				err := platform.RemovePersistentDiskDevice(boshsettings.DiskSettings{ID: "disk-cid"})
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+
+		Context("when no device matches the disk", func() {
+			// Reached when a detach is retried or rolled back after the device is gone.
+			It("does not return an error", func() {
+				err := platform.RemovePersistentDiskDevice(diskSettings)
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+
+		Context("when the device has no delete node", func() {
+			BeforeEach(func() {
+				fs.SetGlob("/dev/disk/by-id/*6000c292f72652faeb338715920f9a92", []string{byIDPath})
+				err := fs.WriteFileString("/dev/sdc", "")
+				Expect(err).NotTo(HaveOccurred())
+				err = fs.Symlink("/dev/sdc", byIDPath)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("does not return an error", func() {
+				err := platform.RemovePersistentDiskDevice(diskSettings)
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+
+		Context("when listing devices fails", func() {
+			BeforeEach(func() {
+				fs.GlobErr = errors.New("fake-glob-err")
+			})
+
+			It("returns an error", func() {
+				err := platform.RemovePersistentDiskDevice(diskSettings)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Listing disks by id"))
+			})
+		})
+	})
+
 	Describe("GetEphemeralDiskPath", func() {
 		Context("when real device path was resolved without an error", func() {
 			It("returns real device path and true", func() {

--- a/platform/platform_interface.go
+++ b/platform/platform_interface.go
@@ -84,6 +84,7 @@ type Platform interface {
 	AdjustPersistentDiskPartitioning(diskSettings boshsettings.DiskSettings, mountPoint string) error
 	MountPersistentDisk(diskSettings boshsettings.DiskSettings, mountPoint string) error
 	UnmountPersistentDisk(diskSettings boshsettings.DiskSettings) (didUnmount bool, err error)
+	RemovePersistentDiskDevice(diskSettings boshsettings.DiskSettings) error
 	MigratePersistentDisk(fromMountPoint, toMountPoint string) (err error)
 	GetEphemeralDiskPath(diskSettings boshsettings.DiskSettings) (string, error)
 	IsMountPoint(path string) (partitionPath string, result bool, err error)

--- a/platform/platformfakes/fake_platform.go
+++ b/platform/platformfakes/fake_platform.go
@@ -430,6 +430,17 @@ type FakePlatform struct {
 	removeDevToolsReturnsOnCall map[int]struct {
 		result1 error
 	}
+	RemovePersistentDiskDeviceStub        func(settings.DiskSettings) error
+	removePersistentDiskDeviceMutex       sync.RWMutex
+	removePersistentDiskDeviceArgsForCall []struct {
+		arg1 settings.DiskSettings
+	}
+	removePersistentDiskDeviceReturns struct {
+		result1 error
+	}
+	removePersistentDiskDeviceReturnsOnCall map[int]struct {
+		result1 error
+	}
 	RemoveStaticLibrariesStub        func(string) error
 	removeStaticLibrariesMutex       sync.RWMutex
 	removeStaticLibrariesArgsForCall []struct {
@@ -2878,6 +2889,67 @@ func (fake *FakePlatform) RemoveDevToolsReturnsOnCall(i int, result1 error) {
 		})
 	}
 	fake.removeDevToolsReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakePlatform) RemovePersistentDiskDevice(arg1 settings.DiskSettings) error {
+	fake.removePersistentDiskDeviceMutex.Lock()
+	ret, specificReturn := fake.removePersistentDiskDeviceReturnsOnCall[len(fake.removePersistentDiskDeviceArgsForCall)]
+	fake.removePersistentDiskDeviceArgsForCall = append(fake.removePersistentDiskDeviceArgsForCall, struct {
+		arg1 settings.DiskSettings
+	}{arg1})
+	stub := fake.RemovePersistentDiskDeviceStub
+	fakeReturns := fake.removePersistentDiskDeviceReturns
+	fake.recordInvocation("RemovePersistentDiskDevice", []interface{}{arg1})
+	fake.removePersistentDiskDeviceMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakePlatform) RemovePersistentDiskDeviceCallCount() int {
+	fake.removePersistentDiskDeviceMutex.RLock()
+	defer fake.removePersistentDiskDeviceMutex.RUnlock()
+	return len(fake.removePersistentDiskDeviceArgsForCall)
+}
+
+func (fake *FakePlatform) RemovePersistentDiskDeviceCalls(stub func(settings.DiskSettings) error) {
+	fake.removePersistentDiskDeviceMutex.Lock()
+	defer fake.removePersistentDiskDeviceMutex.Unlock()
+	fake.RemovePersistentDiskDeviceStub = stub
+}
+
+func (fake *FakePlatform) RemovePersistentDiskDeviceArgsForCall(i int) settings.DiskSettings {
+	fake.removePersistentDiskDeviceMutex.RLock()
+	defer fake.removePersistentDiskDeviceMutex.RUnlock()
+	argsForCall := fake.removePersistentDiskDeviceArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakePlatform) RemovePersistentDiskDeviceReturns(result1 error) {
+	fake.removePersistentDiskDeviceMutex.Lock()
+	defer fake.removePersistentDiskDeviceMutex.Unlock()
+	fake.RemovePersistentDiskDeviceStub = nil
+	fake.removePersistentDiskDeviceReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakePlatform) RemovePersistentDiskDeviceReturnsOnCall(i int, result1 error) {
+	fake.removePersistentDiskDeviceMutex.Lock()
+	defer fake.removePersistentDiskDeviceMutex.Unlock()
+	fake.RemovePersistentDiskDeviceStub = nil
+	if fake.removePersistentDiskDeviceReturnsOnCall == nil {
+		fake.removePersistentDiskDeviceReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.removePersistentDiskDeviceReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
 }

--- a/platform/windows_platform.go
+++ b/platform/windows_platform.go
@@ -654,6 +654,12 @@ func (p WindowsPlatform) MountPersistentDisk(diskSettings boshsettings.DiskSetti
 	return
 }
 
+// RemovePersistentDiskDevice is a no-op on Windows; disks are released through
+// the storage stack rather than by writing to a sysfs delete node.
+func (p WindowsPlatform) RemovePersistentDiskDevice(diskSettings boshsettings.DiskSettings) error {
+	return nil
+}
+
 func (p WindowsPlatform) UnmountPersistentDisk(diskSettings boshsettings.DiskSettings) (didUnmount bool, err error) {
 	return
 }


### PR DESCRIPTION
This resolves a new issue surfaced in vSphere 9.1 where attaching orpahned disks or repeatedly resizing a disk fails.

remove_persistent_disk only dropped the disk's settings hints, leaving the kernel's device object in place. After the IaaS-side detach that object is dead — I/O returns DID_NO_CONNECT — but it still occupies the disk's controller slot. When the IaaS later reuses that slot for another disk, the kernel does not re-probe an address it believes is populated, so the incoming disk is never enumerated, no /dev/disk/by-id entry appears, and mounting fails with "Timed out getting real device path".

A SCSI rescan does not help: SCSIIDDevicePathResolver already performs one, and it only adds devices at unoccupied addresses.

This breaks routine deploys, not just recovery workflows. Resizing a persistent disk detaches the old disk from a running VM, so every resize strands a dead device. update_disk attaches the replacement before detaching the old disk, so the first resize survives — the old disk still holds its slot and the new one lands elsewhere. The second resize on the same VM is then handed the slot the first one stranded, and fails. `bosh attach-disk` onto an instance that already has a persistent disk fails the same way, on its first use, because AttachDisk detaches before attaching.

The director sends remove_persistent_disk from DetachDiskStep immediately before calling the CPI, so the action now releases the device there, while the disk is still attached. That is the documented order for removing a SCSI disk from a Linux guest: unmount, let the kernel release the device, then detach at the IaaS. DetachDiskStep backs every detach path, so this covers resize and attach-disk alike.

Device removal is best effort and idempotent. A disk with no recorded settings has no device to release, which is normal when a detach is retried or rolled back, so that is not an error. The device is resolved with a single non-blocking lookup rather than through devicePathResolver, whose SCSI timeout is 50s, because this runs on paths where the device is legitimately already gone.

Reproduced and verified on vCenter 9.1, where vm-operator assigns the lowest free controller unit and so reuses a stranded slot. Before: 1GiB -> 2GiB resize left a dead device, and the 2GiB -> 3GiB resize failed; attach-disk failed every attempt. After: the resize chain completes, the replacement disk mounts on the reused slot, and the guest is left with no dead devices.